### PR TITLE
Switch to KnowledgeStrategy for domain-aware compression

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -200,7 +200,13 @@ const framework = await AgentFramework.create({
     name: 'researcher',
     model: 'claude-opus-4-20250514',
     systemPrompt: SYSTEM_PROMPT,
-    strategy: new PassthroughStrategy(),
+    strategy: new KnowledgeStrategy({
+      headWindowTokens: 4000,
+      recentWindowTokens: 30000,
+      compressionModel: 'claude-opus-4-6',
+      autoTickOnNewMessage: true,
+      maxMessageTokens: 10000,
+    }),
   }],
   modules: [tuiModule, subagentModule, lessonsModule, retrievalModule],
   mcplServers: [{
@@ -267,7 +273,7 @@ bun --watch src/index.ts
 | Subagent TUI visibility (Tab toggle) | Done |
 | Bun + Chronicle compatibility | Validated (56 tests) |
 | End-to-end knowledge extraction session | Not yet tested |
-| KnowledgeStrategy (context compression) | Not started |
+| KnowledgeStrategy (context compression) | Done |
 | Tests | Not started |
 
 ## TUI Evolution

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
     "test": "bun test"
   },
   "dependencies": {
-    "@connectome/agent-framework": "github:Anarchid/agent-framework#zombie-detection",
-    "@connectome/context-manager": "github:Anarchid/context-manager#fix-tool-crash",
+    "@connectome/agent-framework": "github:Tengro/agent-framework#feature/knowledge-strategy",
+    "@connectome/context-manager": "github:Tengro/context-manager#feature/knowledge-strategy",
     "chronicle": "file:../chronicle",
-    "membrane": "github:Anarchid/membrane#main",
+    "membrane": "github:Tengro/membrane#main",
     "@opentui/core": "^0.1.82"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@
  */
 
 import { Membrane, AnthropicAdapter, NativeFormatter } from 'membrane';
-import { AgentFramework, AutobiographicalStrategy, FilesModule } from '@connectome/agent-framework';
+import { AgentFramework, KnowledgeStrategy, FilesModule } from '@connectome/agent-framework';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { existsSync } from 'node:fs';
@@ -106,12 +106,15 @@ async function createFramework(membrane: Membrane, storePath: string): Promise<A
         name: 'researcher',
         model: config.model,
         systemPrompt: SYSTEM_PROMPT,
-        strategy: new AutobiographicalStrategy({
+        strategy: new KnowledgeStrategy({
           headWindowTokens: 4000,
           recentWindowTokens: 30000,
           compressionModel: config.model,
           autoTickOnNewMessage: true,
           maxMessageTokens: 10000,
+          // Phase detection defaults: mcpl:/zulip: → research,
+          // subagent: → subagent, lessons:create/update → lesson
+          // Asymmetric L1 budget: synthesis floor 40%, research cap 30%
         }),
       },
     ],


### PR DESCRIPTION
## Summary

Replaces `AutobiographicalStrategy` with `KnowledgeStrategy` for domain-aware context compression.

### What changes

- **`src/index.ts`**: Import and instantiate `KnowledgeStrategy` instead of `AutobiographicalStrategy`
- **`package.json`**: Point at `feature/knowledge-strategy` branches for context-manager and agent-framework
- **`ARCHITECTURE.md`**: Update config example and status table

### What KnowledgeStrategy does

Built on the hierarchical L1/L2/L3 compression pyramid, but domain-aware:

1. **Semantic chunking** — chunks at phase transitions instead of fixed token counts
2. **Phase-aware prompts** — aggressive for research, preserve-logic for synthesis, light for lessons
3. **Asymmetric budget** — synthesis floor 40%, research cap 30% of L1 budget
4. **[LEAD] tracking** — unresolved questions preserved across compression levels

Phase detection uses FKM's existing tool names automatically:
| Tool pattern | Phase |
|-------------|-------|
| `mcpl:*` / `zulip:*` | research |
| `subagent:*` | subagent |
| `lessons:create/update` | lesson |
| Pure dialogue | synthesis |

### Dependencies

- [context-manager PR #7](https://github.com/anima-research/context-manager/pull/7) — KnowledgeStrategy implementation
- [agent-framework PR #13](https://github.com/antra-tess/agent-framework/pull/13) — re-export

## Test plan

- [x] Type-checks pass across all three packages
- [ ] End-to-end session: verify research phases compress aggressively
- [ ] Verify synthesis reasoning chains are preserved longer
- [ ] Check [LEAD] markers survive compression

🤖 Generated with [Claude Code](https://claude.com/claude-code)