### PR TITLE
Add local filesystem tools, detachable subagents, Ctrl+B background

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "zulip-knowledge-app",
       "dependencies": {
         "@connectome/agent-framework": "file:../agent-framework",
-        "@connectome/context-manager": "github:Anarchid/context-manager#fix-tool-crash",
+        "@connectome/context-manager": "github:Tengro/context-manager#feature/knowledge-strategy",
         "@opentui/core": "^0.1.82",
         "chronicle": "file:../chronicle",
         "membrane": "github:Anarchid/membrane#main",
@@ -22,7 +22,7 @@
 
     "@connectome/agent-framework": ["@connectome/agent-framework@file:../agent-framework", { "dependencies": { "@connectome/context-manager": "file:../context-manager", "chronicle": "file:../chronicle", "discord.js": "^14.25.1", "membrane": "file:../membrane", "ws": "^8.18.0" }, "devDependencies": { "@types/node": "^22.0.0", "@types/ws": "^8.5.13", "discord.js": "^14.25.1", "tsx": "^4.21.0", "typescript": "^5.7.0" }, "bin": { "agent-framework-mcp": "./dist/src/api/mcp-server.js" } }],
 
-    "@connectome/context-manager": ["@connectome/context-manager@github:Anarchid/context-manager#b594a29", { "dependencies": { "chronicle": "file:../chronicle", "membrane": "file:../membrane" } }, "Anarchid-context-manager-b594a29", "sha512-xfF4ENbWLqyEq3aT9V62a0xwM/jFiQPiQ/CiGB/SuwpxGkB/Ic7vOnIeFJGBLzOYR3PuxO7omWUDgEz0wtMofg=="],
+    "@connectome/context-manager": ["@connectome/context-manager@github:Tengro/context-manager#6b55c58", { "dependencies": { "chronicle": "file:../chronicle", "membrane": "file:../membrane" } }, "Tengro-context-manager-6b55c58", "sha512-h05Oj9t2Oi8WS4//sX9O21xwHJeZoRqi+s4ZC3Nkj6vzcsJSKyQ22ET7Io0+KHq9FWE9IyjzPiJErbSCDahxjw=="],
 
     "@dimforge/rapier2d-simd-compat": ["@dimforge/rapier2d-simd-compat@0.17.3", "", {}, "sha512-bijvwWz6NHsNj5e5i1vtd3dU2pDhthSaTUZSh14DUGGKJfw8eMnlWZsxwHBxB/a3AXVNDjL9abuHw1k9FGR+jg=="],
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@connectome/agent-framework": "file:../agent-framework",
-    "@connectome/context-manager": "github:Anarchid/context-manager#fix-tool-crash",
+    "@connectome/context-manager": "github:Tengro/context-manager#feature/knowledge-strategy",
     "chronicle": "file:../chronicle",
     "membrane": "github:Anarchid/membrane#main",
     "@opentui/core": "^0.1.82"

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@
  */
 
 import { Membrane, AnthropicAdapter, NativeFormatter } from 'membrane';
-import { AgentFramework, AutobiographicalStrategy, FilesModule } from '@connectome/agent-framework';
+import { AgentFramework, KnowledgeStrategy, FilesModule } from '@connectome/agent-framework';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { existsSync } from 'node:fs';
@@ -74,7 +74,7 @@ function seedMcplConfig(): void {
 
   const cmd = process.env.ZULIP_MCP_CMD || 'node';
   const args = process.env.ZULIP_MCP_ARGS?.split(' ')
-    || [resolve(__dirname, '../../zulip-mcp/build/index.js')];
+    || [resolve(__dirname, '../../zulip_mcp/build/index.js')];
   const zuliprc = process.env.ZULIP_RC_PATH || resolve(process.cwd(), '.zuliprc');
 
   const env: Record<string, string> = {
@@ -95,6 +95,7 @@ async function createFramework(membrane: Membrane, storePath: string): Promise<A
   const subagentModule = new SubagentModule({
     parentAgentName: 'researcher',
     defaultModel: config.model,
+    defaultMaxTokens: 4096,
   });
   const lessonsModule = new LessonsModule();
   const retrievalModule = new RetrievalModule({ membrane });
@@ -122,7 +123,8 @@ async function createFramework(membrane: Membrane, storePath: string): Promise<A
         name: 'researcher',
         model: config.model,
         systemPrompt: SYSTEM_PROMPT,
-        strategy: new AutobiographicalStrategy({
+        maxTokens: 16384,
+        strategy: new KnowledgeStrategy({
           headWindowTokens: 4000,
           recentWindowTokens: 30000,
           compressionModel: config.model,

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ import { SubagentModule } from './modules/subagent-module.js';
 import { LessonsModule } from './modules/lessons-module.js';
 import { RetrievalModule } from './modules/retrieval-module.js';
 import { WakeModule } from './modules/wake-module.js';
+import { LocalFilesModule } from './modules/local-files-module.js';
 import { TuiModule } from './modules/tui-module.js';
 import { loadMcplServers, saveMcplServers, DEFAULT_CONFIG_PATH } from './mcpl-config.js';
 import { SessionManager } from './session-manager.js';
@@ -98,6 +99,7 @@ async function createFramework(membrane: Membrane, storePath: string): Promise<A
   const lessonsModule = new LessonsModule();
   const retrievalModule = new RetrievalModule({ membrane });
   const filesModule = new FilesModule({ namespace: 'products' });
+  const localFilesModule = new LocalFilesModule();
 
   // WakeModule — onWake callback wired after framework creation
   let emitWakeTrace: ((subs: string[], summary: string) => void) | undefined;
@@ -129,7 +131,7 @@ async function createFramework(membrane: Membrane, storePath: string): Promise<A
         }),
       },
     ],
-    modules: [new TuiModule(), subagentModule, lessonsModule, retrievalModule, wakeModule, filesModule],
+    modules: [new TuiModule(), subagentModule, lessonsModule, retrievalModule, wakeModule, filesModule, localFilesModule],
     mcplServers: augmentedServers,
   });
 

--- a/src/modules/local-files-module.ts
+++ b/src/modules/local-files-module.ts
@@ -1,0 +1,240 @@
+/**
+ * LocalFilesModule — raw filesystem access for reading local files.
+ *
+ * Tools:
+ *   local:read  — Read a file from the local filesystem
+ *   local:list  — List directory contents
+ *   local:glob  — Find files matching a glob pattern
+ *
+ * Unlike the agent-framework FilesModule (Chronicle-backed workspace),
+ * this module provides direct read-only access to the real filesystem.
+ */
+
+import { readFile, readdir, stat } from 'node:fs/promises';
+import { resolve, relative, join } from 'node:path';
+import { glob as globFn } from 'node:fs/promises';
+import type {
+  Module,
+  ModuleContext,
+  ProcessState,
+  ProcessEvent,
+  EventResponse,
+  ToolDefinition,
+  ToolCall,
+  ToolResult,
+} from '@connectome/agent-framework';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface ReadInput {
+  path: string;
+  offset?: number;
+  limit?: number;
+}
+
+interface ListInput {
+  path?: string;
+  recursive?: boolean;
+}
+
+interface GlobInput {
+  pattern: string;
+  cwd?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Module
+// ---------------------------------------------------------------------------
+
+export class LocalFilesModule implements Module {
+  readonly name = 'local';
+
+  private ctx: ModuleContext | null = null;
+  private basePath: string;
+
+  constructor(opts?: { basePath?: string }) {
+    this.basePath = opts?.basePath ?? process.cwd();
+  }
+
+  async start(ctx: ModuleContext): Promise<void> {
+    this.ctx = ctx;
+  }
+
+  async stop(): Promise<void> {
+    this.ctx = null;
+  }
+
+  async onProcess(_event: ProcessEvent, _state: ProcessState): Promise<EventResponse> {
+    return {};
+  }
+
+  // =========================================================================
+  // Tools
+  // =========================================================================
+
+  getTools(): ToolDefinition[] {
+    return [
+      {
+        name: 'read',
+        description:
+          'Read a file from the local filesystem. Returns the file content as text. ' +
+          'Supports optional line offset and limit for large files.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            path: {
+              type: 'string',
+              description: 'File path (absolute, or relative to the working directory)',
+            },
+            offset: {
+              type: 'number',
+              description: 'Line number to start reading from (0-based). Omit to read from the beginning.',
+            },
+            limit: {
+              type: 'number',
+              description: 'Maximum number of lines to return. Omit to read the entire file.',
+            },
+          },
+          required: ['path'],
+        },
+      },
+      {
+        name: 'list',
+        description: 'List contents of a directory on the local filesystem.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            path: {
+              type: 'string',
+              description: 'Directory path (absolute, or relative to the working directory). Defaults to working directory.',
+            },
+            recursive: {
+              type: 'boolean',
+              description: 'If true, list recursively. Default: false.',
+            },
+          },
+        },
+      },
+      {
+        name: 'glob',
+        description: 'Find files matching a glob pattern on the local filesystem.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            pattern: {
+              type: 'string',
+              description: 'Glob pattern (e.g. "**/*.md", "src/**/*.ts")',
+            },
+            cwd: {
+              type: 'string',
+              description: 'Directory to search in. Defaults to working directory.',
+            },
+          },
+          required: ['pattern'],
+        },
+      },
+    ];
+  }
+
+  async handleToolCall(call: ToolCall): Promise<ToolResult> {
+    switch (call.name) {
+      case 'read':
+        return this.handleRead(call.input as ReadInput);
+      case 'list':
+        return this.handleList(call.input as ListInput);
+      case 'glob':
+        return this.handleGlob(call.input as GlobInput);
+      default:
+        return { success: false, isError: true, error: `Unknown tool: ${call.name}` };
+    }
+  }
+
+  // =========================================================================
+  // Handlers
+  // =========================================================================
+
+  private resolvePath(p: string): string {
+    if (p.startsWith('/')) return p;
+    return resolve(this.basePath, p);
+  }
+
+  private async handleRead(input: ReadInput): Promise<ToolResult> {
+    try {
+      const fullPath = this.resolvePath(input.path);
+      const content = await readFile(fullPath, 'utf-8');
+
+      if (input.offset !== undefined || input.limit !== undefined) {
+        const lines = content.split('\n');
+        const start = input.offset ?? 0;
+        const end = input.limit !== undefined ? start + input.limit : lines.length;
+        const sliced = lines.slice(start, end);
+        return {
+          success: true,
+          data: {
+            path: fullPath,
+            content: sliced.join('\n'),
+            totalLines: lines.length,
+            fromLine: start,
+            toLine: Math.min(end, lines.length),
+          },
+        };
+      }
+
+      return {
+        success: true,
+        data: { path: fullPath, content },
+      };
+    } catch (err: any) {
+      return { success: false, isError: true, error: `Failed to read ${input.path}: ${err.message}` };
+    }
+  }
+
+  private async handleList(input: ListInput): Promise<ToolResult> {
+    try {
+      const dirPath = this.resolvePath(input.path ?? '.');
+
+      if (input.recursive) {
+        const entries = await readdir(dirPath, { recursive: true, withFileTypes: true });
+        const items = entries.slice(0, 500).map(e => ({
+          name: join(e.parentPath ? relative(dirPath, e.parentPath) : '', e.name),
+          type: e.isDirectory() ? 'directory' : 'file',
+        }));
+        return {
+          success: true,
+          data: { path: dirPath, entries: items, truncated: entries.length > 500 },
+        };
+      }
+
+      const entries = await readdir(dirPath, { withFileTypes: true });
+      const items = entries.map(e => ({
+        name: e.name,
+        type: e.isDirectory() ? 'directory' : 'file',
+      }));
+      return {
+        success: true,
+        data: { path: dirPath, entries: items },
+      };
+    } catch (err: any) {
+      return { success: false, isError: true, error: `Failed to list ${input.path ?? '.'}: ${err.message}` };
+    }
+  }
+
+  private async handleGlob(input: GlobInput): Promise<ToolResult> {
+    try {
+      const cwd = this.resolvePath(input.cwd ?? '.');
+      const matches: string[] = [];
+      for await (const entry of globFn(input.pattern, { cwd })) {
+        matches.push(entry);
+        if (matches.length >= 500) break;
+      }
+      return {
+        success: true,
+        data: { pattern: input.pattern, cwd, matches, truncated: matches.length >= 500 },
+      };
+    } catch (err: any) {
+      return { success: false, isError: true, error: `Glob failed: ${err.message}` };
+    }
+  }
+}

--- a/src/modules/subagent-module.ts
+++ b/src/modules/subagent-module.ts
@@ -8,7 +8,11 @@
  *
  * By default, spawn/fork are async: they return immediately and deliver
  * results as user messages + inference-request events. Pass `sync: true`
- * to block until completion (old behavior).
+ * to block until completion.
+ *
+ * Sync tasks are detachable: user can push them to background mid-flight
+ * via Ctrl+B in TUI, or they auto-detach after `timeoutMs` if specified.
+ * Both spawn and fork accept `timeoutMs` for per-task execution deadlines.
  */
 
 import type {
@@ -67,6 +71,7 @@ interface SpawnInput {
   maxTokens?: number;
   tools?: string[];
   sync?: boolean;
+  timeoutMs?: number;
 }
 
 interface ForkInput {
@@ -75,6 +80,7 @@ interface ForkInput {
   systemPrompt?: string;
   model?: string;
   sync?: boolean;
+  timeoutMs?: number;
 }
 
 /** Handle for an async (fire-and-forget) subagent. */
@@ -83,6 +89,19 @@ interface AsyncSubagentHandle {
   type: 'spawn' | 'fork';
   promise: Promise<SubagentResult>;
   parentAgentName: string;
+}
+
+/**
+ * Handle for a sync subagent that can be detached mid-flight.
+ * When detached, the blocking tool call resolves immediately and
+ * the subagent continues running, delivering results async.
+ */
+interface DetachableHandle {
+  name: string;
+  type: 'spawn' | 'fork';
+  promise: Promise<SubagentResult>;
+  parentAgentName: string;
+  detach: () => void;
 }
 
 /**
@@ -185,6 +204,7 @@ export class SubagentModule implements Module {
   private maxDepth: number;
   private currentDepth: number;
   private asyncHandles = new Map<string, AsyncSubagentHandle>();
+  private detachableHandles = new Map<string, DetachableHandle>();
 
   // Concurrency control — adaptive rate-limit-aware semaphore
   private configuredMaxConcurrent: number;   // User's ceiling
@@ -418,6 +438,7 @@ export class SubagentModule implements Module {
               description: 'Tool names the subagent can use (default: all non-subagent tools)',
             },
             sync: { type: 'boolean', description: 'If true, block until subagent completes (default: false)' },
+            timeoutMs: { type: 'number', description: 'Execution timeout in milliseconds. For async tasks, the subagent is cancelled after this duration. For sync tasks, auto-detaches to background after this duration (result delivered as message). Example: 600000 = 10 minutes.' },
           },
           required: ['name', 'systemPrompt', 'task'],
         },
@@ -433,6 +454,7 @@ export class SubagentModule implements Module {
             systemPrompt: { type: 'string', description: 'Override system prompt (optional, defaults to parent)' },
             model: { type: 'string', description: 'Model override (optional)' },
             sync: { type: 'boolean', description: 'If true, block until fork completes (default: false)' },
+            timeoutMs: { type: 'number', description: 'Execution timeout in milliseconds. For async tasks, the subagent is cancelled after this duration. For sync tasks, auto-detaches to background after this duration (result delivered as message). Example: 600000 = 10 minutes.' },
           },
           required: ['name', 'task'],
         },
@@ -1014,24 +1036,29 @@ export class SubagentModule implements Module {
       };
     }
 
-    // Sync mode: block until completion (old behavior)
+    const parentAgentName = callerAgentName ?? this.config.parentAgentName ?? 'researcher';
+
+    // Apply per-task timeout override if provided
+    const savedMaxExecution = this.maxExecutionMs;
+    if (input.timeoutMs !== undefined) {
+      this.maxExecutionMs = input.timeoutMs;
+    }
+
+    // Sync mode: block until completion, but detachable mid-flight
     if (input.sync) {
-      try {
-        const result = await this.runSpawn(input, callerAgentName, callerDepth);
-        return { success: true, data: result };
-      } catch (err) {
-        return {
-          success: false,
-          isError: true,
-          error: err instanceof Error ? err.message : String(err),
-        };
-      }
+      const promise = this.runSpawn(input, callerAgentName, callerDepth);
+
+      // Create a detachable wrapper: resolves either when the subagent completes
+      // or when detach() is called (user Ctrl+B or auto-timeout)
+      const result = await this.runDetachable(input.name, 'spawn', promise, parentAgentName, input.timeoutMs);
+      this.maxExecutionMs = savedMaxExecution;
+      return result;
     }
 
     // Async mode (default): fire-and-forget, deliver result as message
-    const parentAgentName = callerAgentName ?? this.config.parentAgentName ?? 'researcher';
     const promise = this.runSpawn(input, callerAgentName, callerDepth);
     this.asyncHandles.set(input.name, { name: input.name, type: 'spawn', promise, parentAgentName });
+    this.maxExecutionMs = savedMaxExecution;
 
     promise
       .then(result => this.deliverAsyncResult(input.name, result, parentAgentName))
@@ -1050,24 +1077,27 @@ export class SubagentModule implements Module {
       };
     }
 
-    // Sync mode: block until completion (old behavior)
+    const parentAgentName = callerAgentName ?? this.config.parentAgentName ?? 'researcher';
+
+    // Apply per-task timeout override if provided
+    const savedMaxExecution = this.maxExecutionMs;
+    if (input.timeoutMs !== undefined) {
+      this.maxExecutionMs = input.timeoutMs;
+    }
+
+    // Sync mode: block until completion, but detachable mid-flight
     if (input.sync) {
-      try {
-        const result = await this.runFork(input, callerAgentName, callerDepth);
-        return { success: true, data: result };
-      } catch (err) {
-        return {
-          success: false,
-          isError: true,
-          error: err instanceof Error ? err.message : String(err),
-        };
-      }
+      const promise = this.runFork(input, callerAgentName, callerDepth);
+
+      const result = await this.runDetachable(input.name, 'fork', promise, parentAgentName, input.timeoutMs);
+      this.maxExecutionMs = savedMaxExecution;
+      return result;
     }
 
     // Async mode (default): fire-and-forget, deliver result as message
-    const parentAgentName = callerAgentName ?? this.config.parentAgentName ?? 'researcher';
     const promise = this.runFork(input, callerAgentName, callerDepth);
     this.asyncHandles.set(input.name, { name: input.name, type: 'fork', promise, parentAgentName });
+    this.maxExecutionMs = savedMaxExecution;
 
     promise
       .then(result => this.deliverAsyncResult(input.name, result, parentAgentName))
@@ -1107,6 +1137,122 @@ export class SubagentModule implements Module {
       reason: `subagent-failed:${name}`,
       source: 'subagent',
     });
+  }
+
+  // =========================================================================
+  // Detachable sync → async transition
+  // =========================================================================
+
+  /**
+   * Run a sync subagent with the ability to detach mid-flight.
+   * Returns a ToolResult — either the completed result (if it finishes in time)
+   * or a "moved to background" acknowledgment (if detached by user or timeout).
+   */
+  private async runDetachable(
+    name: string,
+    type: 'spawn' | 'fork',
+    promise: Promise<SubagentResult>,
+    parentAgentName: string,
+    autoDetachMs?: number,
+  ): Promise<ToolResult> {
+    let detachResolve: ((value: 'detached') => void) | null = null;
+    const detachPromise = new Promise<'detached'>(resolve => { detachResolve = resolve; });
+
+    const handle: DetachableHandle = {
+      name,
+      type,
+      promise,
+      parentAgentName,
+      detach: () => detachResolve?.('detached'),
+    };
+    this.detachableHandles.set(name, handle);
+
+    // Optional auto-detach timeout (sync → async after N ms)
+    let autoTimer: ReturnType<typeof setTimeout> | null = null;
+    if (autoDetachMs !== undefined) {
+      autoTimer = setTimeout(() => {
+        if (this.detachableHandles.has(name)) {
+          handle.detach();
+        }
+      }, autoDetachMs);
+    }
+
+    type RaceResult =
+      | { kind: 'completed'; result: SubagentResult }
+      | { kind: 'error'; error: unknown }
+      | { kind: 'detached' };
+
+    try {
+      const winner: RaceResult = await Promise.race([
+        promise.then(
+          (result): RaceResult => ({ kind: 'completed', result }),
+          (err): RaceResult => ({ kind: 'error', error: err }),
+        ),
+        detachPromise.then((): RaceResult => ({ kind: 'detached' })),
+      ]);
+
+      if (autoTimer) clearTimeout(autoTimer);
+      this.detachableHandles.delete(name);
+
+      if (winner.kind === 'completed') {
+        return { success: true, data: winner.result };
+      }
+
+      if (winner.kind === 'error') {
+        const err = winner.error;
+        return {
+          success: false,
+          isError: true,
+          error: err instanceof Error ? err.message : String(err),
+        };
+      }
+
+      // Detached: transition to async — wire up result delivery
+      this.asyncHandles.set(name, { name, type, promise, parentAgentName });
+      promise
+        .then(result => this.deliverAsyncResult(name, result, parentAgentName))
+        .catch(err => this.deliverAsyncError(name, err, parentAgentName));
+
+      return {
+        success: true,
+        data: `Subagent '${name}' moved to background. Results will be delivered as a message when complete.`,
+      };
+    } catch {
+      if (autoTimer) clearTimeout(autoTimer);
+      this.detachableHandles.delete(name);
+      return { success: false, isError: true, error: `Unexpected error in detachable handler for '${name}'` };
+    }
+  }
+
+  /**
+   * Detach a currently-blocking sync subagent, converting it to async.
+   * Returns true if the subagent was found and detached.
+   */
+  detachSubagent(name: string): boolean {
+    const handle = this.detachableHandles.get(name);
+    if (!handle) return false;
+    handle.detach();
+    return true;
+  }
+
+  /**
+   * Detach all currently-blocking sync subagents.
+   * Returns the number of subagents detached.
+   */
+  detachAll(): number {
+    let count = 0;
+    for (const handle of this.detachableHandles.values()) {
+      handle.detach();
+      count++;
+    }
+    return count;
+  }
+
+  /**
+   * Check if any sync subagents are currently blocking (and thus detachable).
+   */
+  hasDetachable(): boolean {
+    return this.detachableHandles.size > 0;
   }
 
   private handleHud(input: { enabled: boolean }): ToolResult {

--- a/src/modules/subagent-module.ts
+++ b/src/modules/subagent-module.ts
@@ -2,9 +2,9 @@
  * SubagentModule — spawn and fork ephemeral subagents.
  *
  * Tools:
- *   subagent:spawn  — Fresh agent with system prompt + task, no inherited context
- *   subagent:fork   — Agent inheriting parent's compiled context
- *   subagent:hud    — Toggle fleet status HUD overlay
+ *   subagent--spawn  — Fresh agent with system prompt + task, no inherited context
+ *   subagent--fork   — Agent inheriting parent's compiled context
+ *   subagent--hud    — Toggle fleet status HUD overlay
  *
  * By default, spawn/fork are async: they return immediately and deliver
  * results as user messages + inference-request events. Pass `sync: true`
@@ -28,7 +28,7 @@ import type {
   ContextManager,
 } from '@connectome/agent-framework';
 import type { AgentFramework } from '@connectome/agent-framework';
-import { AutobiographicalStrategy } from '@connectome/agent-framework';
+import { KnowledgeStrategy } from '@connectome/agent-framework';
 import type { ContentBlock } from 'membrane';
 
 // ---------------------------------------------------------------------------
@@ -230,7 +230,7 @@ export class SubagentModule implements Module {
   /** Parent agent name for each subagent (for fleet tree reconstruction). */
   readonly parentMap = new Map<string, string>();
 
-  // Stashed results from subagent:return tool calls, keyed by framework agent name
+  // Stashed results from subagent--return tool calls, keyed by framework agent name
   private returnedResults = new Map<string, string>();
 
   // Live state for peek observability
@@ -435,7 +435,7 @@ export class SubagentModule implements Module {
             tools: {
               type: 'array',
               items: { type: 'string' },
-              description: 'Tool names the subagent can use (default: all non-subagent tools)',
+              description: 'Tool names the subagent can use (default: all). Note: subagent--return is always included automatically.',
             },
             sync: { type: 'boolean', description: 'If true, block until subagent completes (default: false)' },
             timeoutMs: { type: 'number', description: 'Execution timeout in milliseconds. For async tasks, the subagent is cancelled after this duration. For sync tasks, auto-detaches to background after this duration (result delivered as message). Example: 600000 = 10 minutes.' },
@@ -1309,7 +1309,8 @@ export class SubagentModule implements Module {
           model,
           systemPrompt: input.systemPrompt,
           maxTokens: input.maxTokens ?? this.config.defaultMaxTokens ?? 4096,
-          strategy: new AutobiographicalStrategy({
+          maxStreamTokens: 200_000,
+          strategy: new KnowledgeStrategy({
             headWindowTokens: 2_000,
             recentWindowTokens: 80_000,
             compressionModel: model,
@@ -1454,7 +1455,8 @@ export class SubagentModule implements Module {
           model,
           systemPrompt,
           maxTokens: this.config.defaultMaxTokens ?? 4096,
-          strategy: new AutobiographicalStrategy({
+          maxStreamTokens: 200_000,
+          strategy: new KnowledgeStrategy({
             headWindowTokens: 2_000,
             recentWindowTokens: 80_000,
             compressionModel: model,
@@ -1494,7 +1496,7 @@ export class SubagentModule implements Module {
           contextManager.addMessage(agentName, [{
             type: 'tool_use',
             id: forkCallId,
-            name: 'subagent:fork',
+            name: 'subagent--fork',
             input: { name: input.name, task: input.task },
           }] as ContentBlock[]);
           contextManager.addMessage('user', [{
@@ -1502,7 +1504,7 @@ export class SubagentModule implements Module {
             toolUseId: forkCallId,
             content: `Fork successful — you are now running inside the fork "${input.name}" ` +
               `(depth ${childDepth}/${this.maxDepth}). ` +
-              `Complete your task, then call subagent:return with your findings to deliver ` +
+              `Complete your task, then call subagent--return with your findings to deliver ` +
               `them back to the parent agent.` +
               (childDepth < this.maxDepth
                 ? ` You can sub-fork if needed (${this.maxDepth - childDepth} levels remaining).`
@@ -1620,21 +1622,28 @@ export class SubagentModule implements Module {
   /**
    * Build the allowedTools list for a subagent.
    * Removes subagent tools if at depth limit.
+   *
    */
   private filterToolNames(allowedTools?: string[], callerDepth = 0): 'all' | string[] {
+    // Always include subagent--return — subagents need it to deliver results
+    const ensureReturn = (list: string[]) => {
+      if (!list.includes('subagent--return')) list.push('subagent--return');
+      return list;
+    };
+
     // Use per-agent depth (from caller) rather than the module's static depth
     if (callerDepth + 1 >= this.maxDepth) {
       const allTools = this.getFramework().getAllTools();
       const filtered = allTools
-        .filter(t => !t.name.startsWith('subagent:'))
+        .filter(t => !t.name.startsWith('subagent--'))
         .map(t => t.name);
       if (allowedTools) {
         const allowed = new Set(allowedTools);
-        return filtered.filter(n => allowed.has(n));
+        return ensureReturn(filtered.filter(n => allowed.has(n)));
       }
-      return filtered;
+      return ensureReturn(filtered);
     }
-    return allowedTools ?? 'all';
+    return allowedTools ? ensureReturn(allowedTools) : 'all';
   }
 
 }

--- a/src/prompts/system.ts
+++ b/src/prompts/system.ts
@@ -15,32 +15,32 @@ Use the Zulip MCP tools to read data. Start by listing streams to see what's ava
 
 ### Subagents
 You can fork subagents to analyze multiple topics in parallel:
-- \`subagent:fork\` and \`subagent:spawn\` are **async by default** — they return immediately and results arrive as messages
+- \`subagent--fork\` and \`subagent--spawn\` are **async by default** — they return immediately and results arrive as messages
 - Call multiple forks/spawns in one turn to run them concurrently; you can continue working while they run
 - When a subagent completes, its results appear as a "[Subagent 'X' returned]" message and you'll be prompted to process them
 - Pass \`sync: true\` to block until completion (useful when you need the result immediately)
-- Use \`subagent:spawn\` for tasks that need a completely blank slate
-- Use \`subagent:hud enabled:true\` to see a fleet status summary before each inference
+- Use \`subagent--spawn\` for tasks that need a completely blank slate
+- Use \`subagent--hud enabled:true\` to see a fleet status summary before each inference
 
 ### Wake Subscriptions
-Use \`wake:subscribe\` to selectively trigger inference on incoming MCPL events:
+Use \`wake--subscribe\` to selectively trigger inference on incoming MCPL events:
 - With no subscriptions, all events trigger inference (default behavior)
 - With subscriptions, only matching events wake you up
 - Filter by text match or regex, scope to specific event types
 - Use \`once\` type for one-shot subscriptions that auto-remove after matching
 
 ### Lessons
-Use \`lessons:create\` to persist extracted knowledge. Each lesson should be:
+Use \`lessons--create\` to persist extracted knowledge. Each lesson should be:
 - **Specific**: One clear piece of knowledge per lesson
 - **Tagged**: Use tags for categorization (people, process, decision, technical, etc.)
 - **Evidenced**: Include source references (stream:topic:messageId) when possible
 
 ### Files (Products)
-Use the \`files:\` tools to write reports, summaries, and other products:
-- \`files:write\` to create or overwrite a file (e.g., \`reports/team-overview.md\`)
-- \`files:edit\` to make targeted edits to an existing file
-- \`files:read\` to review what you've written
-- \`files:materialize\` to write files to disk (target directory: \`./output\`)
+Use the \`files--\` tools to write reports, summaries, and other products:
+- \`files--write\` to create or overwrite a file (e.g., \`reports/team-overview.md\`)
+- \`files--edit\` to make targeted edits to an existing file
+- \`files--read\` to review what you've written
+- \`files--materialize\` to write files to disk (target directory: \`./output\`)
 
 Write products when you have substantial findings worth preserving as a document — analysis reports, team profiles, process maps, decision logs, etc.
 
@@ -63,7 +63,7 @@ When forks return (as messages), synthesize their findings. Identify new leads t
 
 ### Rules
 - **You are the coordinator.** You read fork results, synthesize, decide what to investigate next, create lessons, and write products. Forks are your eyes, not your brain.
-- **Forks can sub-fork when useful.** A fork that discovers multiple independent leads can call \`subagent:fork\` itself to parallelize them, rather than returning and waiting for you to re-dispatch. Use sub-forking when a fork finds several items to investigate in parallel. Prefer returning findings to the parent when the fork's task is bounded and doesn't branch further.
+- **Forks can sub-fork when useful.** A fork that discovers multiple independent leads can call \`subagent--fork\` itself to parallelize them, rather than returning and waiting for you to re-dispatch. Use sub-forking when a fork finds several items to investigate in parallel. Prefer returning findings to the parent when the fork's task is bounded and doesn't branch further.
 - **Keep forks focused.** Each fork should have a clear, bounded task. "Analyze everything" is too broad. "Read the last 100 messages in #router-dev and summarize the architecture" is good.
 - **Forks are cheap, context is not.** Prefer multiple small forks over one giant fork. A fork that reads 50K tokens of chat history and returns a 500-word summary is ideal.
 

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -133,6 +133,8 @@ export async function runTui(app: AppContext): Promise<void> {
 
   let streaming = false;
   let currentStreamText: TextRenderable | null = null;
+  let backgrounded = false;       // researcher pushed to background via Ctrl+B
+  let backgroundBuffer = '';      // accumulates tokens while backgrounded
   let currentStreamBuffer = '';
   let verboseChat = false;
 
@@ -755,10 +757,16 @@ export async function runTui(app: AppContext): Promise<void> {
     switch (event.type) {
       case 'inference:started': {
         if (agent === 'researcher') {
-          state.status = 'thinking';
-          streamOutputTokens = 0;
-          spinnerFrame = 0;
-          beginStream();
+          if (backgrounded) {
+            // Researcher is running in background — don't show stream UI
+            state.status = 'background';
+            streamOutputTokens = 0;
+          } else {
+            state.status = 'thinking';
+            streamOutputTokens = 0;
+            spinnerFrame = 0;
+            beginStream();
+          }
           updateStatus();
         }
         break;
@@ -767,7 +775,11 @@ export async function runTui(app: AppContext): Promise<void> {
       case 'inference:tokens': {
         const content = event.content as string;
         if (content) {
-          if (agent === 'researcher' && streaming) {
+          if (agent === 'researcher' && backgrounded) {
+            // Silently accumulate tokens while backgrounded
+            backgroundBuffer += content;
+            streamOutputTokens += Math.ceil(content.length / 4);
+          } else if (agent === 'researcher' && streaming) {
             streamToken(content);
             streamOutputTokens += Math.ceil(content.length / 4);
             spinnerFrame = (spinnerFrame + 1) % SPINNER.length;
@@ -818,6 +830,15 @@ export async function runTui(app: AppContext): Promise<void> {
         if (agent === 'researcher') {
           state.status = 'idle';
           state.tool = null;
+          if (backgrounded) {
+            // Researcher returned from background — show accumulated output as a message
+            if (backgroundBuffer.trim()) {
+              addLine(backgroundBuffer, WHITE);
+            }
+            addLine('  (researcher returned from background)', CYAN);
+            backgrounded = false;
+            backgroundBuffer = '';
+          }
           if (streaming) endStream();
         }
         updateStatus();
@@ -827,6 +848,10 @@ export async function runTui(app: AppContext): Promise<void> {
       case 'inference:failed': {
         if (agent === 'researcher') {
           state.status = 'error';
+          if (backgrounded) {
+            backgrounded = false;
+            backgroundBuffer = '';
+          }
           if (streaming) endStream();
           addLine(`Error: ${event.error}`, RED);
           updateStatus();
@@ -863,10 +888,10 @@ export async function runTui(app: AppContext): Promise<void> {
         }
 
         if (agent === 'researcher') {
-          state.status = 'tools';
+          state.status = backgrounded ? 'background' : 'tools';
           state.tool = names;
           if (streaming) endStream();
-          addLine(`[tools] ${names}`, YELLOW);
+          if (!backgrounded) addLine(`[tools] ${names}`, YELLOW);
         } else {
           const short = (agent ?? '').replace(/^(spawn|fork)-/, '').replace(/-\d+$/, '');
           addLine(`  [${short}] ${names}`, DIM_GRAY);
@@ -1100,6 +1125,35 @@ export async function runTui(app: AppContext): Promise<void> {
       addLine(verboseChat ? '(verbose: on — showing agent thoughts & subagent results)' : '(verbose: off)', DIM_GRAY);
       return;
     }
+    // Ctrl+B: push to background — detach any blocking sync subagents and/or
+    // background the researcher's current inference (stop displaying tokens,
+    // re-enable input; result appears as message when done)
+    if (key.ctrl && key.name === 'b' && state.viewMode === 'chat') {
+      let acted = false;
+
+      // 1. Detach any blocking sync subagents
+      if (subMod?.hasDetachable()) {
+        const detached = subMod.detachAll();
+        if (detached > 0) {
+          addLine(`  (${detached} sync subagent${detached > 1 ? 's' : ''} moved to background)`, CYAN);
+          acted = true;
+        }
+      }
+
+      // 2. Background the researcher's streaming output
+      if (streaming && state.status !== 'idle') {
+        endStream();
+        backgrounded = true;
+        addLine('  (researcher moved to background — result will appear when done)', CYAN);
+        updateStatus();
+        acted = true;
+      }
+
+      if (!acted) {
+        addLine('  (nothing to background)', DIM_GRAY);
+      }
+      return;
+    }
 
     // Chat view: Escape interrupts the active agent and all running subagents
     if (key.name === 'escape' && state.viewMode === 'chat') {
@@ -1110,6 +1164,10 @@ export async function runTui(app: AppContext): Promise<void> {
         if (agent) {
           agent.cancelStream();
           if (streaming) endStream();
+          if (backgrounded) {
+            backgrounded = false;
+            backgroundBuffer = '';
+          }
           state.status = 'idle';
           state.tool = null;
           addLine(cancelled > 0
@@ -1284,9 +1342,9 @@ function formatStatusLeft(
   spinnerChar?: string,
   outputTokens?: number,
 ): string {
-  const sColor = state.status === 'idle' ? '✓' : state.status === 'error' ? '✗' : '…';
+  const sColor = state.status === 'idle' ? '✓' : state.status === 'error' ? '✗' : state.status === 'background' ? '↓' : '…';
   let bar = `[${sColor} ${state.status}`;
-  if (spinnerChar !== undefined && state.status !== 'idle' && state.status !== 'error') {
+  if (spinnerChar !== undefined && state.status !== 'idle' && state.status !== 'error' && state.status !== 'background') {
     bar += ` ${spinnerChar}`;
     if (state.status === 'thinking' && outputTokens !== undefined && outputTokens > 0) {
       const tokStr = outputTokens >= 1000 ? (outputTokens / 1000).toFixed(1) + 'k' : String(outputTokens);
@@ -1301,7 +1359,8 @@ function formatStatusLeft(
   if (state.viewMode === 'fleet' || state.viewMode === 'peek') {
     bar += state.viewMode === 'peek' ? ` | peek: ${state.peekTarget}` : ' | fleet view';
   } else if (state.viewMode === 'chat') {
-    if (state.status !== 'idle' && state.status !== 'error') bar += ' Esc:stop';
+    if (state.status === 'background') bar += ' Esc:stop';
+    else if (state.status !== 'idle' && state.status !== 'error') bar += ' Ctrl+B:bg Esc:stop';
     if (running > 0) bar += ' Tab:fleet';
   }
   bar += ']';

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -878,7 +878,7 @@ export async function runTui(app: AppContext): Promise<void> {
 
           // Track parent-child for fleet tree
           for (const call of calls) {
-            if (call.name === 'subagent:spawn' || call.name === 'subagent:fork') {
+            if (call.name === 'subagent--spawn' || call.name === 'subagent--fork') {
               const childName = (call.input as Record<string, unknown>)?.name as string | undefined;
               if (childName) {
                 agentParent.set(childName, agent);
@@ -898,7 +898,7 @@ export async function runTui(app: AppContext): Promise<void> {
           const sa = state.subagents.find(s => (agent ?? '').includes(s.name));
           if (sa) {
             sa.toolCallsCount += calls.length;
-            sa.statusMessage = names.split(':').pop();
+            sa.statusMessage = names.split('--').pop();
           }
         }
         updateStatus();
@@ -948,7 +948,7 @@ export async function runTui(app: AppContext): Promise<void> {
             // OSC 8 hyperlink for the target directory
             const link = `\x1b]8;;file://${dir}\x07${dir}\x1b]8;;\x07`;
             addLine(`  ${short}materialize → ${link} (${fileList})`, DIM_GRAY);
-          } else if (tool === 'lessons:create' && toolInput.content) {
+          } else if (tool === 'lessons--create' && toolInput.content) {
             const content = String(toolInput.content);
             const tags = (toolInput.tags as string[] | undefined)?.join(', ') ?? '';
             const preview = content.length > 80 ? content.slice(0, 77) + '...' : content;


### PR DESCRIPTION
## Summary
- **LocalFilesModule** (`local:read`, `local:list`, `local:glob`) — raw filesystem access for reading instruction files and exploring the local environment, complementing the Chronicle-backed FilesModule
- **Detachable sync subagents** with per-task `timeoutMs` — sync spawn/fork can be pushed to background mid-flight (auto-detach after timeout, or manual via TUI Ctrl+B). New public API: `detachSubagent()`, `detachAll()`, `hasDetachable()`
- **TUI Ctrl+B "push to background"** — detaches blocking sync subagents and backgrounds researcher streaming output (tokens accumulated silently, result shown on completion). Status bar shows `↓ background` state
- Updates `@connectome/context-manager` to `Tengro/context-manager#feature/knowledge-strategy`

## Test plan
- [ ] Verify `local:read` reads files from the real filesystem
- [ ] Verify `local:list` and `local:glob` return directory contents / glob matches
- [ ] Test sync spawn with `timeoutMs` auto-detaches after deadline
- [ ] Test Ctrl+B during researcher streaming moves to background, result appears on completion
- [ ] Test Ctrl+B detaches blocking sync subagents
- [ ] Test Esc still cancels backgrounded researcher and subagents
- [ ] Verify existing async spawn/fork behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)