### PR TITLE
Genericize into connectome-host with recipe system and wake policies

### DIFF
--- a/recipes/mcpl-editor-test.json
+++ b/recipes/mcpl-editor-test.json
@@ -5,7 +5,7 @@
 
   "agent": {
     "name": "tester",
-    "model": "claude-sonnet-4-6-20250514",
+    "model": "claude-sonnet-4-6",
     "maxTokens": 8192,
     "systemPrompt": "You are a testing assistant connected to a collaborative markdown editor via MCPL.\n\nYour setup:\n- You are running as a Sonnet 4.6 instance inside the connectome-host (formerly forking-knowledge-miner)\n- You are connected to a live mcpl-editor instance at mcpl-editor-production.up.railway.app\n- The editor is a web-based CodeMirror 6 markdown editor backed by Chronicle (a branchable record store)\n- Humans can edit the document in the browser at the same URL, and you can see their changes and edit the document yourself\n- There is also a chat channel where the human and you can communicate\n\nYour role:\n- You are helping us test both the connectome-host harness AND the MCPL editor\n- When things work well, say so briefly\n- When something seems strange, broken, or unexpected — tell us immediately and describe exactly what happened\n- If you have ideas for improving the harness, the editor, the MCPL protocol, or the overall architecture, share them\n- Be honest about what you can and cannot do or observe\n\nAvailable tools (from the editor MCPL server):\n- get_document: Read the current document content (or a historical version by checkpoint)\n- edit_document: Edit the document using operations (replace_all, replace_range, insert_after)\n- get_outline: Get the document's heading structure with line numbers\n\nThe editor also has a chat channel. Messages from the human appear in your conversation. You can respond and the human will see your response in the editor's chat panel.\n\nWhen the human asks you to edit the document, use the edit_document tool. When they ask what's in the document, use get_document. Be proactive about reading the document when you first connect.\n\nRemember: you are a tester. Test things. Try edge cases. Report what works and what doesn't.",
 
@@ -13,7 +13,7 @@
       "type": "autobiographical",
       "headWindowTokens": 4000,
       "recentWindowTokens": 20000,
-      "compressionModel": "claude-sonnet-4-6-20250514",
+      "compressionModel": "claude-sonnet-4-6",
       "maxMessageTokens": 8000
     }
   },

--- a/recipes/zulip-miner.json
+++ b/recipes/zulip-miner.json
@@ -29,7 +29,21 @@
     "subagents": true,
     "lessons": true,
     "retrieval": true,
-    "wake": true,
+    "wake": {
+      "policies": [
+        {
+          "name": "zulip-messages",
+          "match": { "scope": ["channel:incoming"] },
+          "behavior": "always"
+        },
+        {
+          "name": "zulip-events",
+          "match": { "scope": ["push:event"], "source": "zulip" },
+          "behavior": { "debounce": 3000 }
+        }
+      ],
+      "default": "always"
+    },
     "files": { "namespace": "products" }
   },
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,11 +15,11 @@
 
 import { Membrane, AnthropicAdapter, NativeFormatter } from 'membrane';
 import { AgentFramework, AutobiographicalStrategy, PassthroughStrategy, FilesModule, type Module } from '@connectome/agent-framework';
-import { resolve } from 'node:path';
+import { resolve, join } from 'node:path';
 import { SubagentModule } from './modules/subagent-module.js';
 import { LessonsModule } from './modules/lessons-module.js';
 import { RetrievalModule } from './modules/retrieval-module.js';
-import { WakeModule } from './modules/wake-module.js';
+import { WakeModule, seedWakeConfig, type WakeConfig } from './modules/wake-module.js';
 import { LocalFilesModule } from './modules/local-files-module.js';
 import { TuiModule } from './modules/tui-module.js';
 import { loadMcplServers, DEFAULT_CONFIG_PATH } from './mcpl-config.js';
@@ -146,11 +146,18 @@ async function createFramework(membrane: Membrane, storePath: string, recipe: Re
 
   // Wake
   let wakeModule: WakeModule | null = null;
-  let emitWakeTrace: ((subs: string[], summary: string) => void) | undefined;
+  let emitWakeTrace: ((policyNames: string[], summary: string) => void) | undefined;
   if (modules.wake !== false) {
+    // Resolve wake config path and seed from recipe if needed
+    const wakeConfigPath = join(config.dataDir, 'wake.json');
+    if (typeof modules.wake === 'object' && 'policies' in modules.wake) {
+      // Recipe provides wake config — seed file if it doesn't exist
+      seedWakeConfig(wakeConfigPath, modules.wake as WakeConfig);
+    }
     wakeModule = new WakeModule({
+      configPath: wakeConfigPath,
       agentName,
-      onWake: (subs, summary) => emitWakeTrace?.(subs, summary),
+      onWake: (policyNames, summary) => emitWakeTrace?.(policyNames, summary),
     });
     moduleInstances.push(wakeModule);
   }
@@ -213,12 +220,12 @@ async function createFramework(membrane: Membrane, storePath: string, recipe: Re
 
   // Wire post-creation hooks
   if (wakeModule) {
-    emitWakeTrace = (subs, summary) => {
+    emitWakeTrace = (policyNames, summary) => {
       framework.pushEvent({
         type: 'external-message',
         source: 'wake:triggered',
         content: summary,
-        metadata: { subscriptions: subs, eventSummary: summary },
+        metadata: { policies: policyNames, eventSummary: summary },
         triggerInference: false,
       } as any);
     };

--- a/src/modules/wake-module.test.ts
+++ b/src/modules/wake-module.test.ts
@@ -1,0 +1,492 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { existsSync, mkdirSync, writeFileSync, rmSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { WakeModule, seedWakeConfig, type WakeConfig } from './wake-module.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const TMP_DIR = join(import.meta.dir, '../../.test-tmp');
+
+function tmpPath(name: string): string {
+  return join(TMP_DIR, name);
+}
+
+function writeConfig(name: string, config: WakeConfig): string {
+  const path = tmpPath(name);
+  mkdirSync(TMP_DIR, { recursive: true });
+  writeFileSync(path, JSON.stringify(config, null, 2));
+  return path;
+}
+
+function makeModule(configPath: string, agentName = 'agent') {
+  const wakes: Array<{ policies: string[]; summary: string }> = [];
+  const module = new WakeModule({
+    configPath,
+    agentName,
+    onWake: (policies, summary) => wakes.push({ policies, summary }),
+  });
+  return { module, wakes };
+}
+
+// ---------------------------------------------------------------------------
+// Setup / Teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  mkdirSync(TMP_DIR, { recursive: true });
+});
+
+afterEach(() => {
+  if (existsSync(TMP_DIR)) {
+    rmSync(TMP_DIR, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Policy matching
+// ---------------------------------------------------------------------------
+
+describe('policy matching', () => {
+  test('no policies + default always → triggers', () => {
+    const path = writeConfig('empty.json', { policies: [], default: 'always' });
+    const { module } = makeModule(path);
+    expect(module.shouldTrigger('hello', { eventType: 'push:event' })).toBe(true);
+  });
+
+  test('no policies + default suppress → does not trigger', () => {
+    const path = writeConfig('suppress.json', { policies: [], default: 'suppress' });
+    const { module } = makeModule(path);
+    expect(module.shouldTrigger('hello', { eventType: 'push:event' })).toBe(false);
+  });
+
+  test('scope match — matching event type', () => {
+    const path = writeConfig('scope.json', {
+      policies: [
+        { name: 'channels', match: { scope: ['channel:incoming'] }, behavior: 'always' },
+      ],
+      default: 'suppress',
+    });
+    const { module } = makeModule(path);
+    expect(module.shouldTrigger('msg', { eventType: 'channel:incoming' })).toBe(true);
+    expect(module.shouldTrigger('msg', { eventType: 'push:event' })).toBe(false);
+  });
+
+  test('source match — exact serverId', () => {
+    const path = writeConfig('source.json', {
+      policies: [
+        { name: 'zulip', match: { source: 'zulip' }, behavior: 'always' },
+      ],
+      default: 'suppress',
+    });
+    const { module } = makeModule(path);
+    expect(module.shouldTrigger('msg', { eventType: 'push:event', serverId: 'zulip' })).toBe(true);
+    expect(module.shouldTrigger('msg', { eventType: 'push:event', serverId: 'discord' })).toBe(false);
+  });
+
+  test('source match — glob pattern', () => {
+    const path = writeConfig('source-glob.json', {
+      policies: [
+        { name: 'any-zulip', match: { source: 'zulip-*' }, behavior: 'always' },
+      ],
+      default: 'suppress',
+    });
+    const { module } = makeModule(path);
+    expect(module.shouldTrigger('msg', { eventType: 'push:event', serverId: 'zulip-prod' })).toBe(true);
+    expect(module.shouldTrigger('msg', { eventType: 'push:event', serverId: 'zulip-staging' })).toBe(true);
+    expect(module.shouldTrigger('msg', { eventType: 'push:event', serverId: 'discord' })).toBe(false);
+  });
+
+  test('channel match — exact channelId', () => {
+    const path = writeConfig('channel.json', {
+      policies: [
+        { name: 'alerts', match: { channel: 'alerts' }, behavior: 'always' },
+      ],
+      default: 'suppress',
+    });
+    const { module } = makeModule(path);
+    expect(module.shouldTrigger('msg', { eventType: 'channel:incoming', channelId: 'alerts' })).toBe(true);
+    expect(module.shouldTrigger('msg', { eventType: 'channel:incoming', channelId: 'general' })).toBe(false);
+  });
+
+  test('channel match — glob pattern', () => {
+    const path = writeConfig('channel-glob.json', {
+      policies: [
+        { name: 'dev-channels', match: { channel: 'dev-*' }, behavior: 'always' },
+      ],
+      default: 'suppress',
+    });
+    const { module } = makeModule(path);
+    expect(module.shouldTrigger('msg', { eventType: 'channel:incoming', channelId: 'dev-backend' })).toBe(true);
+    expect(module.shouldTrigger('msg', { eventType: 'channel:incoming', channelId: 'prod-alerts' })).toBe(false);
+  });
+
+  test('content filter — text match (case insensitive)', () => {
+    const path = writeConfig('filter-text.json', {
+      policies: [
+        { name: 'errors', match: { filter: { type: 'text', pattern: 'ERROR' } }, behavior: 'always' },
+      ],
+      default: 'suppress',
+    });
+    const { module } = makeModule(path);
+    expect(module.shouldTrigger('Something error happened', { eventType: 'push:event' })).toBe(true);
+    expect(module.shouldTrigger('All good', { eventType: 'push:event' })).toBe(false);
+  });
+
+  test('content filter — regex match', () => {
+    const path = writeConfig('filter-regex.json', {
+      policies: [
+        { name: 'deploys', match: { filter: { type: 'regex', pattern: 'deploy|rollback' } }, behavior: 'always' },
+      ],
+      default: 'suppress',
+    });
+    const { module } = makeModule(path);
+    expect(module.shouldTrigger('Starting deploy v2.3', { eventType: 'push:event' })).toBe(true);
+    expect(module.shouldTrigger('Rolling back', { eventType: 'push:event' })).toBe(false);
+    expect(module.shouldTrigger('rollback initiated', { eventType: 'push:event' })).toBe(true);
+  });
+
+  test('combined match — scope + source + filter', () => {
+    const path = writeConfig('combined.json', {
+      policies: [
+        {
+          name: 'zulip-errors',
+          match: {
+            scope: ['channel:incoming'],
+            source: 'zulip',
+            filter: { type: 'text', pattern: 'error' },
+          },
+          behavior: 'always',
+        },
+      ],
+      default: 'suppress',
+    });
+    const { module } = makeModule(path);
+    // All conditions met
+    expect(module.shouldTrigger('An error occurred', {
+      eventType: 'channel:incoming', serverId: 'zulip',
+    })).toBe(true);
+    // Wrong scope
+    expect(module.shouldTrigger('An error occurred', {
+      eventType: 'push:event', serverId: 'zulip',
+    })).toBe(false);
+    // Wrong source
+    expect(module.shouldTrigger('An error occurred', {
+      eventType: 'channel:incoming', serverId: 'discord',
+    })).toBe(false);
+    // No error keyword
+    expect(module.shouldTrigger('All good', {
+      eventType: 'channel:incoming', serverId: 'zulip',
+    })).toBe(false);
+  });
+
+  test('first match wins — order matters', () => {
+    const path = writeConfig('order.json', {
+      policies: [
+        { name: 'suppress-noise', match: { filter: { type: 'text', pattern: 'heartbeat' } }, behavior: 'suppress' },
+        { name: 'catch-all', match: {}, behavior: 'always' },
+      ],
+      default: 'suppress',
+    });
+    const { module } = makeModule(path);
+    expect(module.shouldTrigger('heartbeat ping', { eventType: 'push:event' })).toBe(false);
+    expect(module.shouldTrigger('real message', { eventType: 'push:event' })).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suppress behavior
+// ---------------------------------------------------------------------------
+
+describe('suppress behavior', () => {
+  test('matching suppress policy returns false', () => {
+    const path = writeConfig('suppress-policy.json', {
+      policies: [
+        { name: 'suppress-all', match: {}, behavior: 'suppress' },
+      ],
+      default: 'always',
+    });
+    const { module } = makeModule(path);
+    expect(module.shouldTrigger('anything', { eventType: 'push:event' })).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Debounce behavior
+// ---------------------------------------------------------------------------
+
+describe('debounce behavior', () => {
+  test('debounce returns false immediately', () => {
+    const path = writeConfig('debounce.json', {
+      policies: [
+        { name: 'editor', match: { scope: ['push:event'] }, behavior: { debounce: 100 } },
+      ],
+      default: 'suppress',
+    });
+    const { module } = makeModule(path);
+    expect(module.shouldTrigger('edit 1', { eventType: 'push:event' })).toBe(false);
+  });
+
+  test('debounce batches events and fires after delay', async () => {
+    const path = writeConfig('debounce-fire.json', {
+      policies: [
+        { name: 'editor', match: { scope: ['push:event'] }, behavior: { debounce: 50 } },
+      ],
+      default: 'suppress',
+    });
+    const { module, wakes } = makeModule(path);
+
+    // Mock ctx so deliverEvents can work
+    const messages: Array<{ role: string; content: unknown }> = [];
+    const events: unknown[] = [];
+    (module as any).ctx = {
+      addMessage: (role: string, content: unknown) => messages.push({ role, content }),
+      pushEvent: (event: unknown) => events.push(event),
+    };
+
+    module.shouldTrigger('edit 1', { eventType: 'push:event' });
+    module.shouldTrigger('edit 2', { eventType: 'push:event' });
+    module.shouldTrigger('edit 3', { eventType: 'push:event' });
+
+    // Should not have delivered yet
+    expect(messages.length).toBe(0);
+
+    // Wait for debounce to fire
+    await new Promise(r => setTimeout(r, 80));
+
+    expect(messages.length).toBe(1);
+    const text = (messages[0].content as Array<{ text: string }>)[0].text;
+    expect(text).toContain('3 events matched');
+    expect(text).toContain('[editor]');
+    expect(events.length).toBe(1);
+    expect(wakes.length).toBe(1);
+    expect(wakes[0].policies).toEqual(['editor']);
+  });
+
+  test('debounce resets timer on new events', async () => {
+    const path = writeConfig('debounce-reset.json', {
+      policies: [
+        { name: 'editor', match: {}, behavior: { debounce: 60 } },
+      ],
+      default: 'suppress',
+    });
+    const { module } = makeModule(path);
+
+    const messages: unknown[] = [];
+    (module as any).ctx = {
+      addMessage: (_r: string, c: unknown) => messages.push(c),
+      pushEvent: () => {},
+    };
+
+    module.shouldTrigger('edit 1', { eventType: 'push:event' });
+    await new Promise(r => setTimeout(r, 30));
+    // Timer hasn't fired yet, send another
+    module.shouldTrigger('edit 2', { eventType: 'push:event' });
+    await new Promise(r => setTimeout(r, 30));
+    // Still within debounce window of second event
+    expect(messages.length).toBe(0);
+
+    await new Promise(r => setTimeout(r, 50));
+    // Now it should have fired (30 + 30 + 50 = 110ms, debounce was reset at 30ms)
+    expect(messages.length).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Inference buffering
+// ---------------------------------------------------------------------------
+
+describe('inference buffering', () => {
+  test('always events during inference are buffered', () => {
+    const path = writeConfig('infer-buf.json', {
+      policies: [
+        { name: 'chat', match: {}, behavior: 'always' },
+      ],
+      default: 'suppress',
+    });
+    const { module } = makeModule(path);
+
+    // Simulate inference started
+    (module as any).inferring = true;
+
+    expect(module.shouldTrigger('msg during inference', { eventType: 'channel:incoming' })).toBe(false);
+    expect((module as any).inferenceBuffer.length).toBe(1);
+    expect((module as any).inferenceBuffer[0].policyName).toBe('chat');
+  });
+
+  test('buffer is capped at MAX_INFERENCE_BUFFER', () => {
+    const path = writeConfig('infer-cap.json', {
+      policies: [
+        { name: 'chat', match: {}, behavior: 'always' },
+      ],
+      default: 'suppress',
+    });
+    const { module } = makeModule(path);
+    (module as any).inferring = true;
+
+    for (let i = 0; i < 150; i++) {
+      module.shouldTrigger(`msg ${i}`, { eventType: 'channel:incoming' });
+    }
+
+    // Should be capped at 100
+    expect((module as any).inferenceBuffer.length).toBe(100);
+    // Oldest should have been dropped — first event should be msg 50
+    expect((module as any).inferenceBuffer[0].content).toContain('msg 50');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Config hot-reload
+// ---------------------------------------------------------------------------
+
+describe('config hot-reload', () => {
+  test('reloads config when file changes', async () => {
+    const path = writeConfig('reload.json', {
+      policies: [{ name: 'all', match: {}, behavior: 'always' }],
+      default: 'suppress',
+    });
+    const { module } = makeModule(path);
+
+    expect(module.shouldTrigger('msg', { eventType: 'push:event' })).toBe(true);
+
+    // Force throttle to expire
+    (module as any).lastReloadCheck = 0;
+
+    // Wait a bit to ensure mtime differs (filesystem resolution)
+    await new Promise(r => setTimeout(r, 50));
+
+    // Rewrite config — now suppress everything
+    writeFileSync(path, JSON.stringify({ policies: [], default: 'suppress' }));
+
+    expect(module.shouldTrigger('msg', { eventType: 'push:event' })).toBe(false);
+  });
+
+  test('throttles filesystem checks', () => {
+    const path = writeConfig('throttle.json', {
+      policies: [],
+      default: 'always',
+    });
+    const { module } = makeModule(path);
+
+    // First call sets lastReloadCheck
+    module.shouldTrigger('msg', { eventType: 'push:event' });
+    const firstCheck = (module as any).lastReloadCheck;
+
+    // Immediate second call should be throttled
+    module.shouldTrigger('msg', { eventType: 'push:event' });
+    expect((module as any).lastReloadCheck).toBe(firstCheck);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// onWake callback
+// ---------------------------------------------------------------------------
+
+describe('onWake callback', () => {
+  test('fires onWake for always triggers', () => {
+    const path = writeConfig('onwake.json', {
+      policies: [{ name: 'chat', match: {}, behavior: 'always' }],
+      default: 'suppress',
+    });
+    const { module, wakes } = makeModule(path);
+
+    module.shouldTrigger('hello world', { eventType: 'channel:incoming' });
+
+    expect(wakes.length).toBe(1);
+    expect(wakes[0].policies).toEqual(['chat']);
+    expect(wakes[0].summary).toBe('hello world');
+  });
+
+  test('does not fire onWake for suppress', () => {
+    const path = writeConfig('no-wake.json', {
+      policies: [{ name: 'quiet', match: {}, behavior: 'suppress' }],
+      default: 'always',
+    });
+    const { module, wakes } = makeModule(path);
+
+    module.shouldTrigger('hello', { eventType: 'push:event' });
+
+    expect(wakes.length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// seedWakeConfig
+// ---------------------------------------------------------------------------
+
+describe('seedWakeConfig', () => {
+  test('writes config when file does not exist', () => {
+    const path = tmpPath('seed-new.json');
+    const config: WakeConfig = {
+      policies: [{ name: 'test', match: {}, behavior: 'always' }],
+      default: 'suppress',
+    };
+    seedWakeConfig(path, config);
+
+    expect(existsSync(path)).toBe(true);
+    const written = JSON.parse(readFileSync(path, 'utf-8'));
+    expect(written.policies[0].name).toBe('test');
+    expect(written.default).toBe('suppress');
+  });
+
+  test('does not overwrite existing file', () => {
+    const path = writeConfig('seed-existing.json', {
+      policies: [{ name: 'original', match: {}, behavior: 'always' }],
+      default: 'always',
+    });
+
+    seedWakeConfig(path, {
+      policies: [{ name: 'new', match: {}, behavior: 'suppress' }],
+      default: 'suppress',
+    });
+
+    const written = JSON.parse(readFileSync(path, 'utf-8'));
+    expect(written.policies[0].name).toBe('original'); // unchanged
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Config validation edge cases
+// ---------------------------------------------------------------------------
+
+describe('config validation', () => {
+  test('missing file → default config (all events pass)', () => {
+    const path = tmpPath('nonexistent.json');
+    const { module } = makeModule(path);
+    expect(module.shouldTrigger('anything', { eventType: 'push:event' })).toBe(true);
+  });
+
+  test('malformed JSON → default config', () => {
+    const path = tmpPath('bad.json');
+    mkdirSync(TMP_DIR, { recursive: true });
+    writeFileSync(path, 'not valid json{{{');
+    const { module } = makeModule(path);
+    expect(module.shouldTrigger('anything', { eventType: 'push:event' })).toBe(true);
+  });
+
+  test('invalid regex in filter → policy skipped at match time', () => {
+    // The validator catches invalid regex, so we need to bypass validation
+    // by writing a config where regex is syntactically valid but semantically weird
+    const path = writeConfig('bad-regex.json', {
+      policies: [
+        { name: 'bad', match: { filter: { type: 'regex', pattern: '(?:valid)' } }, behavior: 'always' },
+      ],
+      default: 'suppress',
+    });
+    const { module } = makeModule(path);
+    // This should work fine — the regex is actually valid
+    expect(module.shouldTrigger('valid text', { eventType: 'push:event' })).toBe(true);
+  });
+
+  test('empty match object matches everything', () => {
+    const path = writeConfig('empty-match.json', {
+      policies: [
+        { name: 'catch-all', match: {}, behavior: 'always' },
+      ],
+      default: 'suppress',
+    });
+    const { module } = makeModule(path);
+    expect(module.shouldTrigger('anything', { eventType: 'push:event', serverId: 'any', channelId: 'any' })).toBe(true);
+  });
+});

--- a/src/modules/wake-module.ts
+++ b/src/modules/wake-module.ts
@@ -1,16 +1,18 @@
 /**
- * WakeModule — selective MCPL event triggering via subscriptions.
+ * WakeModule — file-driven MCPL event triggering with per-policy debounce.
  *
- * Tools:
- *   wake:subscribe   — Create a subscription with text/regex filter
- *   wake:unsubscribe — Remove a subscription by name
- *   wake:list        — List all active subscriptions
+ * Reads policies from a `wake.json` config file. The recipe seeds this file
+ * on first run; after that the agent owns it and can edit it with file tools.
+ *
+ * Policies are evaluated in order — first match wins. Each policy specifies
+ * a behavior: "always" (trigger immediately), "suppress" (drop), or
+ * { "debounce": ms } (batch events per-policy, deliver when timer fires).
  *
  * Exposes `shouldTrigger` for wiring into McplServerConfig.shouldTriggerInference.
- * When no subscriptions exist, all events pass through (preserving default behavior).
- * When subscriptions exist, only matching events trigger inference.
  */
 
+import { existsSync, readFileSync, statSync, writeFileSync, mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
 import type {
   Module,
   ModuleContext,
@@ -25,33 +27,86 @@ import type {
 import type { AgentFramework } from '@connectome/agent-framework';
 
 // ---------------------------------------------------------------------------
-// Types
+// Types — Wake Config (persisted as wake.json)
 // ---------------------------------------------------------------------------
 
-export interface Subscription {
-  name: string;
-  filter: { type: 'text' | 'regex'; pattern: string };
-  subscriptionType: 'once' | 'permanent';
-  scope: string[];
-  createdAt: number;
-  matchCount: number;
+export interface WakeConfig {
+  policies: WakePolicy[];
+  /** What happens when no policy matches. Default: 'always' */
+  default: 'always' | 'suppress';
 }
 
-interface SubscribeInput {
+export interface WakePolicy {
   name: string;
-  filter: { type: 'text' | 'regex'; pattern: string };
-  type?: 'once' | 'permanent';
+  match: WakePolicyMatch;
+  behavior: 'always' | 'suppress' | { debounce: number };
+}
+
+export interface WakePolicyMatch {
+  /** Event types to match: 'channel:incoming', 'push:event', etc. Empty/omitted = all. */
   scope?: string[];
+  /** ServerId to match (exact or glob with *). */
+  source?: string;
+  /** ChannelId to match (exact or glob with *). */
+  channel?: string;
+  /** Content text filter. */
+  filter?: { type: 'text' | 'regex'; pattern: string };
 }
 
-interface UnsubscribeInput {
-  name: string;
-}
+/** Default config when no recipe wake config and no existing file. */
+export const DEFAULT_WAKE_CONFIG: WakeConfig = {
+  policies: [],
+  default: 'always',
+};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Max content length stored in pending events. */
+const MAX_CONTENT_SNIPPET = 200;
+/** Max content length shown in onWake callbacks. */
+const MAX_WAKE_SNIPPET = 80;
+/** Max events buffered during inference before oldest are dropped. */
+const MAX_INFERENCE_BUFFER = 100;
+/** Minimum interval between filesystem checks for config changes (ms). */
+const RELOAD_THROTTLE_MS = 1000;
+
+// ---------------------------------------------------------------------------
+// Internal types
+// ---------------------------------------------------------------------------
 
 interface PendingEvent {
-  subscription: string;
+  policyName: string;
   content: string;
   eventType: string;
+  timestamp: number;
+}
+
+interface DebounceState {
+  timer: ReturnType<typeof setTimeout>;
+  events: PendingEvent[];
+}
+
+/** A compiled policy with pre-built matchers for fast evaluation. */
+interface CompiledPolicy {
+  policy: WakePolicy;
+  filterRegex?: RegExp;
+  sourceRegex?: RegExp;
+  channelRegex?: RegExp;
+}
+
+// ---------------------------------------------------------------------------
+// Glob matching (simple * wildcards)
+// ---------------------------------------------------------------------------
+
+function compileGlob(pattern: string): RegExp {
+  if (!pattern.includes('*')) {
+    return new RegExp('^' + pattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&') + '$');
+  }
+  return new RegExp(
+    '^' + pattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*') + '$',
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -62,22 +117,32 @@ export class WakeModule implements Module {
   readonly name = 'wake';
 
   private ctx: ModuleContext | null = null;
-  private framework: AgentFramework | null = null;
-  private subscriptions = new Map<string, Subscription>();
-  private onceToRemove = new Set<string>();
-  private pendingEvents: PendingEvent[] = [];
-  private inferring = false;
-  private agentName: string;
-  private onWake?: (subs: string[], summary: string) => void;
+  private configPath: string;
+  private config: WakeConfig;
+  private compiledPolicies: CompiledPolicy[] = [];
+  private configMtime: number = 0;
+  private lastReloadCheck: number = 0;
 
-  constructor(opts?: { agentName?: string; onWake?: (subs: string[], summary: string) => void }) {
-    this.agentName = opts?.agentName ?? 'agent';
-    this.onWake = opts?.onWake;
+  private inferring = false;
+  private inferenceBuffer: PendingEvent[] = [];
+  private debounceTimers = new Map<string, DebounceState>();
+
+  private agentName: string;
+  private onWake?: (policyNames: string[], summary: string) => void;
+
+  constructor(opts: {
+    configPath: string;
+    agentName?: string;
+    onWake?: (policyNames: string[], summary: string) => void;
+  }) {
+    this.configPath = opts.configPath;
+    this.agentName = opts.agentName ?? 'agent';
+    this.onWake = opts.onWake;
+    this.config = this.loadConfig();
+    this.compiledPolicies = this.compilePolicies(this.config);
   }
 
   setFramework(framework: AgentFramework): void {
-    this.framework = framework;
-
     framework.onTrace((event: TraceEvent) => {
       const agent = 'agentName' in event ? (event as { agentName: string }).agentName : null;
       if (agent !== this.agentName) return;
@@ -86,42 +151,74 @@ export class WakeModule implements Module {
         this.inferring = true;
       } else if (event.type === 'inference:completed' || event.type === 'inference:failed') {
         this.inferring = false;
-        this.flushPendingEvents();
-        this.cleanupOnce();
+        // Defer flush to avoid pushEvent re-entrancy inside trace callback
+        queueMicrotask(() => this.flushInferenceBuffer());
       }
     });
   }
 
   async start(ctx: ModuleContext): Promise<void> {
     this.ctx = ctx;
-    this.restoreFromStore();
   }
 
   async stop(): Promise<void> {
     this.ctx = null;
-  }
-
-  // =========================================================================
-  // Persistence
-  // =========================================================================
-
-  private persistState(): void {
-    if (!this.ctx) return;
-    const subs: Record<string, Subscription> = {};
-    for (const [key, sub] of this.subscriptions) {
-      subs[key] = sub;
+    // Clear all debounce timers
+    for (const state of this.debounceTimers.values()) {
+      clearTimeout(state.timer);
     }
-    this.ctx.setState({ subscriptions: subs });
+    this.debounceTimers.clear();
   }
 
-  private restoreFromStore(): void {
-    if (!this.ctx) return;
-    const persisted = this.ctx.getState<{ subscriptions?: Record<string, Subscription> }>();
-    if (!persisted?.subscriptions) return;
+  // =========================================================================
+  // Config loading (file-based, reloaded when mtime changes)
+  // =========================================================================
 
-    this.subscriptions.clear();
-    for (const [key, sub] of Object.entries(persisted.subscriptions)) {
-      this.subscriptions.set(key, sub);
+  private loadConfig(): WakeConfig {
+    if (!existsSync(this.configPath)) {
+      return { ...DEFAULT_WAKE_CONFIG };
+    }
+    try {
+      const raw = readFileSync(this.configPath, 'utf-8');
+      const stat = statSync(this.configPath);
+      this.configMtime = stat.mtimeMs;
+      return validateWakeConfig(JSON.parse(raw));
+    } catch (err) {
+      console.error(`[wake] Failed to load ${this.configPath}:`, err);
+      return { ...DEFAULT_WAKE_CONFIG };
+    }
+  }
+
+  private compilePolicies(config: WakeConfig): CompiledPolicy[] {
+    return config.policies.map(policy => {
+      const compiled: CompiledPolicy = { policy };
+      if (policy.match.filter?.type === 'regex') {
+        try { compiled.filterRegex = new RegExp(policy.match.filter.pattern, 'i'); } catch { /* skip */ }
+      }
+      if (policy.match.source) {
+        compiled.sourceRegex = compileGlob(policy.match.source);
+      }
+      if (policy.match.channel) {
+        compiled.channelRegex = compileGlob(policy.match.channel);
+      }
+      return compiled;
+    });
+  }
+
+  private reloadIfChanged(): void {
+    const now = Date.now();
+    if (now - this.lastReloadCheck < RELOAD_THROTTLE_MS) return;
+    this.lastReloadCheck = now;
+
+    try {
+      if (!existsSync(this.configPath)) return;
+      const stat = statSync(this.configPath);
+      if (stat.mtimeMs !== this.configMtime) {
+        this.config = this.loadConfig();
+        this.compiledPolicies = this.compilePolicies(this.config);
+      }
+    } catch {
+      // ignore stat errors
     }
   }
 
@@ -130,229 +227,328 @@ export class WakeModule implements Module {
   // =========================================================================
 
   shouldTrigger = (content: string, metadata: Record<string, unknown>): boolean => {
-    if (this.subscriptions.size === 0) return true;
+    this.reloadIfChanged();
 
     const eventType = (metadata.eventType as string) ?? 'unknown';
-    const matches = this.matchSubscriptions(content, eventType);
+    const serverId = (metadata.serverId as string) ?? '';
+    const channelId = (metadata.channelId as string) ?? '';
 
-    if (matches.length === 0) return false;
+    const policy = this.matchPolicy(content, eventType, serverId, channelId);
 
-    // If currently inferring, stash for later delivery
-    if (this.inferring) {
-      for (const sub of matches) {
-        this.pendingEvents.push({
-          subscription: sub.name,
-          content: content.length > 200 ? content.slice(0, 200) + '...' : content,
-          eventType,
-        });
-      }
+    if (!policy) {
+      // No policy matched — use default
+      return this.config.default === 'always';
+    }
+
+    if (policy.behavior === 'suppress') {
       return false;
     }
 
-    // Fire onWake callback for TUI display
-    if (this.onWake) {
-      const snippet = content.length > 80 ? content.slice(0, 80) + '...' : content;
-      this.onWake(matches.map(m => m.name), snippet);
+    if (policy.behavior === 'always') {
+      return this.handleAlways(policy, content, eventType);
     }
 
-    return true;
+    // Debounce behavior
+    this.handleDebounce(policy, content, eventType);
+    return false; // Never trigger immediately for debounce — the timer will deliver
   };
 
   // =========================================================================
-  // Subscription matching
+  // Policy matching — first match wins
   // =========================================================================
 
-  private matchSubscriptions(content: string, eventType: string): Subscription[] {
-    const matched: Subscription[] = [];
-
-    for (const sub of this.subscriptions.values()) {
-      // Scope check
-      if (sub.scope.length > 0 && !sub.scope.includes(eventType)) continue;
-
-      // Filter check
-      let isMatch = false;
-      if (sub.filter.type === 'text') {
-        isMatch = content.toLowerCase().includes(sub.filter.pattern.toLowerCase());
-      } else {
-        try {
-          isMatch = new RegExp(sub.filter.pattern, 'i').test(content);
-        } catch {
-          // Invalid regex — skip
-        }
+  private matchPolicy(
+    content: string,
+    eventType: string,
+    serverId: string,
+    channelId: string,
+  ): WakePolicy | null {
+    for (const compiled of this.compiledPolicies) {
+      if (this.compiledMatches(compiled, content, eventType, serverId, channelId)) {
+        return compiled.policy;
       }
+    }
+    return null;
+  }
 
-      if (isMatch) {
-        sub.matchCount++;
-        matched.push(sub);
-        if (sub.subscriptionType === 'once') {
-          this.onceToRemove.add(sub.name);
+  private compiledMatches(
+    compiled: CompiledPolicy,
+    content: string,
+    eventType: string,
+    serverId: string,
+    channelId: string,
+  ): boolean {
+    const match = compiled.policy.match;
+
+    // Scope check
+    if (match.scope && match.scope.length > 0 && !match.scope.includes(eventType)) {
+      return false;
+    }
+
+    // Source check (serverId) — uses pre-compiled regex
+    if (compiled.sourceRegex && !compiled.sourceRegex.test(serverId)) {
+      return false;
+    }
+
+    // Channel check — uses pre-compiled regex
+    if (compiled.channelRegex && !compiled.channelRegex.test(channelId)) {
+      return false;
+    }
+
+    // Content filter check
+    if (match.filter) {
+      if (match.filter.type === 'text') {
+        if (!content.toLowerCase().includes(match.filter.pattern.toLowerCase())) {
+          return false;
         }
+      } else if (compiled.filterRegex) {
+        if (!compiled.filterRegex.test(content)) {
+          return false;
+        }
+      } else {
+        return false; // Regex failed to compile — no match
       }
     }
 
-    if (matched.length > 0) this.persistState();
-    return matched;
+    return true;
   }
 
   // =========================================================================
-  // Event bundling
+  // Behavior handlers
   // =========================================================================
 
-  private flushPendingEvents(): void {
-    if (this.pendingEvents.length === 0 || !this.ctx) return;
+  private snippetContent(content: string): string {
+    return content.length > MAX_CONTENT_SNIPPET ? content.slice(0, MAX_CONTENT_SNIPPET) + '...' : content;
+  }
 
-    const events = this.pendingEvents.splice(0);
-    const lines = events.map(e =>
-      `- [${e.subscription}] (${e.eventType}): ${e.content}`
-    ).join('\n');
+  private bufferEvent(policyName: string, content: string, eventType: string): void {
+    if (this.inferenceBuffer.length >= MAX_INFERENCE_BUFFER) {
+      // Drop oldest to prevent unbounded growth
+      this.inferenceBuffer.shift();
+    }
+    this.inferenceBuffer.push({
+      policyName,
+      content: this.snippetContent(content),
+      eventType,
+      timestamp: Date.now(),
+    });
+  }
 
-    const text = `[Wake: ${events.length} event${events.length > 1 ? 's' : ''} matched during inference]\n\n${lines}`;
+  private handleAlways(policy: WakePolicy, content: string, eventType: string): boolean {
+    // If currently inferring, buffer it (same as old behavior)
+    if (this.inferring) {
+      this.bufferEvent(policy.name, content, eventType);
+      return false;
+    }
+
+    if (this.onWake) {
+      const snippet = content.length > MAX_WAKE_SNIPPET ? content.slice(0, MAX_WAKE_SNIPPET) + '...' : content;
+      this.onWake([policy.name], snippet);
+    }
+    return true;
+  }
+
+  private handleDebounce(policy: WakePolicy, content: string, eventType: string): void {
+    const debounceMs = (policy.behavior as { debounce: number }).debounce;
+
+    const event: PendingEvent = {
+      policyName: policy.name,
+      content: this.snippetContent(content),
+      eventType,
+      timestamp: Date.now(),
+    };
+
+    const existing = this.debounceTimers.get(policy.name);
+    if (existing) {
+      // Reset timer, add event to batch
+      clearTimeout(existing.timer);
+      existing.events.push(event);
+      existing.timer = setTimeout(() => this.fireDebounce(policy.name), debounceMs);
+    } else {
+      // Start new debounce window
+      const timer = setTimeout(() => this.fireDebounce(policy.name), debounceMs);
+      this.debounceTimers.set(policy.name, { timer, events: [event] });
+    }
+  }
+
+  private fireDebounce(policyName: string): void {
+    const state = this.debounceTimers.get(policyName);
+    if (!state || state.events.length === 0) {
+      this.debounceTimers.delete(policyName);
+      return;
+    }
+
+    const events = state.events;
+    this.debounceTimers.delete(policyName);
+
+    // If currently inferring, move to inference buffer instead
+    if (this.inferring) {
+      this.inferenceBuffer.push(...events);
+      return;
+    }
+
+    this.deliverEvents(events);
+  }
+
+  // =========================================================================
+  // Event delivery
+  // =========================================================================
+
+  private deliverEvents(events: PendingEvent[]): void {
+    if (events.length === 0 || !this.ctx) return;
+
+    const policyNames = [...new Set(events.map(e => e.policyName))];
+    const lines = events
+      .map(e => `- [${e.policyName}] (${e.eventType}): ${e.content}`)
+      .join('\n');
+
+    const text = `[Wake: ${events.length} event${events.length > 1 ? 's' : ''} matched]\n\n${lines}`;
 
     this.ctx.addMessage('user', [{ type: 'text', text }]);
     this.ctx.pushEvent({
       type: 'inference-request',
       agentName: this.agentName,
-      reason: 'wake:pending-events',
+      reason: 'wake:events',
       source: 'wake',
     });
 
-    // Fire onWake for the bundled batch
     if (this.onWake) {
-      const subNames = [...new Set(events.map(e => e.subscription))];
-      this.onWake(subNames, `${events.length} events bundled`);
+      this.onWake(policyNames, `${events.length} event${events.length > 1 ? 's' : ''} delivered`);
     }
   }
 
-  private cleanupOnce(): void {
-    if (this.onceToRemove.size === 0) return;
-    for (const name of this.onceToRemove) {
-      this.subscriptions.delete(name);
-    }
-    this.onceToRemove.clear();
-    this.persistState();
+  private flushInferenceBuffer(): void {
+    if (this.inferenceBuffer.length === 0) return;
+    const events = this.inferenceBuffer.splice(0);
+    this.deliverEvents(events);
   }
 
   // =========================================================================
-  // onProcess — check subscriptions for non-MCPL events
+  // onProcess — handle non-MCPL external events
   // =========================================================================
 
   async onProcess(event: ProcessEvent, _state: ProcessState): Promise<EventResponse> {
     if (event.type !== 'external-message') return {};
     const source = (event as { source?: string }).source;
-    if (source === 'cli' || source === 'tui' || source === 'wake:triggered') return {};
+    if (source === 'cli' || source === 'tui' || source === 'wake:events' || source === 'wake:triggered') return {};
+
+    this.reloadIfChanged();
 
     const content = typeof event.content === 'string' ? event.content : JSON.stringify(event.content);
-    const eventType = (event as { source?: string }).source ?? 'external-message';
+    const eventType = source ?? 'external-message';
 
-    if (this.subscriptions.size === 0) return {};
+    const policy = this.matchPolicy(content, eventType, '', '');
 
-    const matches = this.matchSubscriptions(content, eventType);
-    if (matches.length === 0) return {};
-
-    if (this.onWake) {
-      const snippet = content.length > 80 ? content.slice(0, 80) + '...' : content;
-      this.onWake(matches.map(m => m.name), snippet);
+    if (!policy) {
+      // For non-MCPL events, we don't suppress — they're already in the queue.
+      // The shouldTrigger callback only applies to MCPL ingress.
+      return {};
     }
 
-    return { requestInference: true };
+    if (this.onWake) {
+      const snippet = content.length > MAX_WAKE_SNIPPET ? content.slice(0, MAX_WAKE_SNIPPET) + '...' : content;
+      this.onWake([policy.name], snippet);
+    }
+
+    return {};
   }
 
   // =========================================================================
-  // Tools
+  // Tools — none. Agent edits wake.json directly with file tools.
   // =========================================================================
 
   getTools(): ToolDefinition[] {
-    return [
-      {
-        name: 'subscribe',
-        description: 'Create a wake subscription. When matching events arrive, inference is triggered. With no subscriptions, all events pass through.',
-        inputSchema: {
-          type: 'object',
-          properties: {
-            name: { type: 'string', description: 'Unique name for this subscription' },
-            filter: {
-              type: 'object',
-              description: 'Match filter. The pattern is matched against the MESSAGE CONTENT text (not channel names or metadata). Use text for substring match, regex for pattern match.',
-              properties: {
-                type: { type: 'string', enum: ['text', 'regex'], description: 'Filter type' },
-                pattern: { type: 'string', description: 'Pattern matched against message content text. For text type: case-insensitive substring match. For regex type: regex tested against content.' },
-              },
-              required: ['type', 'pattern'],
-            },
-            type: { type: 'string', enum: ['once', 'permanent'], description: 'once = auto-remove after first match (default: permanent)' },
-            scope: {
-              type: 'array',
-              items: { type: 'string' },
-              description: 'Event types to filter by. Values: "channel:incoming", "push:event", or custom sources. Empty array or omitted = match all event types (recommended default).',
-            },
-          },
-          required: ['name', 'filter'],
-        },
-      },
-      {
-        name: 'unsubscribe',
-        description: 'Remove a wake subscription by name.',
-        inputSchema: {
-          type: 'object',
-          properties: {
-            name: { type: 'string', description: 'Subscription name to remove' },
-          },
-          required: ['name'],
-        },
-      },
-      {
-        name: 'list',
-        description: 'List all active wake subscriptions with match counts.',
-        inputSchema: {
-          type: 'object',
-          properties: {},
-        },
-      },
-    ];
+    return [];
   }
 
-  async handleToolCall(call: ToolCall): Promise<ToolResult> {
-    switch (call.name) {
-      case 'subscribe': {
-        const input = call.input as SubscribeInput;
-        if (this.subscriptions.has(input.name)) {
-          return { success: false, isError: true, error: `Subscription '${input.name}' already exists` };
-        }
-        if (input.filter.type === 'regex') {
-          try { new RegExp(input.filter.pattern); } catch (e) {
-            return { success: false, isError: true, error: `Invalid regex: ${e}` };
-          }
-        }
-        const sub: Subscription = {
-          name: input.name,
-          filter: input.filter,
-          subscriptionType: input.type ?? 'permanent',
-          scope: input.scope ?? [],
-          createdAt: Date.now(),
-          matchCount: 0,
-        };
-        this.subscriptions.set(input.name, sub);
-        this.persistState();
-        return { success: true, data: { subscription: sub, total: this.subscriptions.size } };
-      }
+  async handleToolCall(_call: ToolCall): Promise<ToolResult> {
+    return { success: false, isError: true, error: 'WakeModule has no tools' };
+  }
+}
 
-      case 'unsubscribe': {
-        const { name } = call.input as UnsubscribeInput;
-        if (!this.subscriptions.has(name)) {
-          return { success: false, isError: true, error: `No subscription named '${name}'` };
-        }
-        this.subscriptions.delete(name);
-        this.persistState();
-        return { success: true, data: { removed: name, remaining: this.subscriptions.size } };
-      }
+// ---------------------------------------------------------------------------
+// Config validation
+// ---------------------------------------------------------------------------
 
-      case 'list': {
-        const subs = [...this.subscriptions.values()];
-        return { success: true, data: { subscriptions: subs, total: subs.length } };
-      }
+function validateWakeConfig(raw: unknown): WakeConfig {
+  if (!raw || typeof raw !== 'object') {
+    throw new Error('wake.json must be a JSON object');
+  }
 
-      default:
-        return { success: false, isError: true, error: `Unknown tool: ${call.name}` };
+  const obj = raw as Record<string, unknown>;
+
+  const defaultBehavior = obj.default ?? 'always';
+  if (defaultBehavior !== 'always' && defaultBehavior !== 'suppress') {
+    throw new Error(`wake.json "default" must be "always" or "suppress", got: ${defaultBehavior}`);
+  }
+
+  const policies: WakePolicy[] = [];
+  const rawPolicies = obj.policies;
+  if (Array.isArray(rawPolicies)) {
+    for (const p of rawPolicies) {
+      policies.push(validatePolicy(p));
     }
   }
+
+  return { policies, default: defaultBehavior };
+}
+
+function validatePolicy(raw: unknown): WakePolicy {
+  if (!raw || typeof raw !== 'object') {
+    throw new Error('Each wake policy must be an object');
+  }
+
+  const obj = raw as Record<string, unknown>;
+
+  if (typeof obj.name !== 'string' || !obj.name) {
+    throw new Error('Wake policy must have a "name" string');
+  }
+
+  // Validate behavior
+  let behavior: WakePolicy['behavior'];
+  if (obj.behavior === 'always' || obj.behavior === 'suppress') {
+    behavior = obj.behavior;
+  } else if (obj.behavior && typeof obj.behavior === 'object') {
+    const b = obj.behavior as Record<string, unknown>;
+    if (typeof b.debounce === 'number' && b.debounce > 0) {
+      behavior = { debounce: b.debounce };
+    } else {
+      throw new Error(`Policy "${obj.name}": debounce must be a positive number`);
+    }
+  } else {
+    behavior = 'always'; // default behavior
+  }
+
+  // Validate match (lenient — missing fields mean "match all")
+  const match: WakePolicyMatch = {};
+  if (obj.match && typeof obj.match === 'object') {
+    const m = obj.match as Record<string, unknown>;
+    if (Array.isArray(m.scope)) match.scope = m.scope.filter(s => typeof s === 'string');
+    if (typeof m.source === 'string') match.source = m.source;
+    if (typeof m.channel === 'string') match.channel = m.channel;
+    if (m.filter && typeof m.filter === 'object') {
+      const f = m.filter as Record<string, unknown>;
+      if ((f.type === 'text' || f.type === 'regex') && typeof f.pattern === 'string') {
+        match.filter = { type: f.type, pattern: f.pattern };
+        // Validate regex
+        if (f.type === 'regex') {
+          try { new RegExp(f.pattern as string); } catch (e) {
+            throw new Error(`Policy "${obj.name}": invalid regex pattern: ${e}`);
+          }
+        }
+      }
+    }
+  }
+
+  return { name: obj.name, match, behavior };
+}
+
+// ---------------------------------------------------------------------------
+// Seed helper — writes wake.json if it doesn't exist
+// ---------------------------------------------------------------------------
+
+export function seedWakeConfig(configPath: string, config: WakeConfig): void {
+  if (existsSync(configPath)) return; // Agent's edits take precedence
+  mkdirSync(dirname(configPath), { recursive: true });
+  writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n');
 }

--- a/src/recipe.ts
+++ b/src/recipe.ts
@@ -13,6 +13,7 @@
 
 import { readFileSync, writeFileSync, existsSync, mkdirSync, unlinkSync } from 'node:fs';
 import { resolve } from 'node:path';
+import type { WakeConfig } from './modules/wake-module.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -55,7 +56,7 @@ export interface RecipeModules {
   subagents?: boolean | { defaultModel?: string };
   lessons?: boolean;
   retrieval?: boolean | { model?: string; maxInjected?: number };
-  wake?: boolean;
+  wake?: boolean | WakeConfig;
   files?: boolean | { namespace?: string };
 }
 


### PR DESCRIPTION
## Summary

- **Recipe system**: JSON config files that define system prompt, MCP servers, modules, agent strategy, and session naming — loadable from local files or HTTP URLs
- **Rename to connectome-host**: Package renamed, README rewritten for generic identity. Zulip-specific code extracted into `recipes/zulip-miner.json`
- **File-based wake policies**: WakeModule rewritten from tool-driven subscriptions to a `wake.json` config with per-policy debounce. Recipes seed the config on first run; the agent can edit it at runtime with file tools
- **WebSocket transport**: Recipes can specify `url` + `token` for WebSocket MCPL servers alongside stdio
- **Branch state on AppContext**: Undo/redo/checkpoint state moved from module-level singletons to AppContext for consistent reset on session switch and MCPL branch operations

### Wake policy system

Policies are evaluated first-match-wins with three behaviors:
- `"always"` — trigger inference immediately
- `"suppress"` — drop the event
- `{ "debounce": ms }` — batch events per-policy, deliver when timer fires

Match criteria: `scope` (event type), `source` (serverId glob), `channel` (channelId glob), `filter` (text/regex on content).

### Companion PR

- agent-framework: `feature/mcpl-v05-state-branches` — enriches `shouldTriggerInference` metadata with `serverId`, `channelId`, `author` so wake policies can match on channel structure

## Test plan

- [x] 27 unit tests for WakeModule (policy matching, debounce, inference buffering, hot-reload, seeding)
- [ ] `bun src/index.ts` — starts with default recipe, generic assistant
- [ ] `bun src/index.ts recipes/zulip-miner.json` — starts with Zulip recipe, same behavior as before
- [ ] `bun src/index.ts --no-recipe` — resets to default
- [ ] `/recipe` command shows current recipe info
- [ ] `wake.json` seeded from recipe on first run, not overwritten on subsequent runs
- [ ] Edit `wake.json` at runtime → policies reload within 1s

🤖 Generated with [Claude Code](https://claude.com/claude-code)