### PR TITLE
Switch deps to @animalabs/* npm packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
     "test": "bun test"
   },
   "dependencies": {
-    "@connectome/agent-framework": "file:../agent-framework",
-    "@connectome/context-manager": "file:../context-manager",
-    "chronicle": "file:../chronicle",
-    "membrane": "file:../membrane",
+    "@animalabs/agent-framework": "^0.1.0",
+    "@animalabs/context-manager": "^0.1.0",
+    "@animalabs/chronicle": "^0.1.0",
+    "@animalabs/membrane": "^0.5.40",
     "@opentui/core": "^0.1.82"
   },
   "devDependencies": {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -20,8 +20,8 @@
  *   /help          — List commands
  */
 
-import type { AgentFramework } from '@connectome/agent-framework';
-import type { ContextManager } from '@connectome/context-manager';
+import type { AgentFramework } from '@animalabs/agent-framework';
+import type { ContextManager } from '@animalabs/context-manager';
 import type { Recipe } from './recipe.js';
 import { readMcplServersFile, saveMcplServers, DEFAULT_CONFIG_PATH } from './mcpl-config.js';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,8 +13,8 @@
  *   DATA_DIR            - Data directory for sessions (default: ./data)
  */
 
-import { Membrane, AnthropicAdapter, NativeFormatter } from 'membrane';
-import { AgentFramework, AutobiographicalStrategy, PassthroughStrategy, WorkspaceModule, type Module, type MountConfig } from '@connectome/agent-framework';
+import { Membrane, AnthropicAdapter, NativeFormatter } from '@animalabs/membrane';
+import { AgentFramework, AutobiographicalStrategy, PassthroughStrategy, WorkspaceModule, type Module, type MountConfig } from '@animalabs/agent-framework';
 import { resolve, join } from 'node:path';
 import { SubagentModule } from './modules/subagent-module.js';
 import { LessonsModule } from './modules/lessons-module.js';
@@ -144,11 +144,11 @@ async function createFramework(membrane: Membrane, storePath: string, recipe: Re
 
   // Gate config (replaces WakeModule — gate is now a core AF feature)
   // Path is per-session: {storePath}/config/gate.json
-  let gateOptions: import('@connectome/agent-framework').GateOptions | undefined;
+  let gateOptions: import('@animalabs/agent-framework').GateOptions | undefined;
   if (modules.wake !== false) {
     gateOptions = { configPath: join(storePath, 'config', 'gate.json') };
     if (typeof modules.wake === 'object' && 'policies' in modules.wake) {
-      gateOptions.config = modules.wake as import('@connectome/agent-framework').GateConfig;
+      gateOptions.config = modules.wake as import('@animalabs/agent-framework').GateConfig;
     }
   }
 

--- a/src/modules/lessons-module.ts
+++ b/src/modules/lessons-module.ts
@@ -19,8 +19,8 @@ import type {
   ToolDefinition,
   ToolCall,
   ToolResult,
-} from '@connectome/agent-framework';
-import type { ContextInjection } from '@connectome/context-manager';
+} from '@animalabs/agent-framework';
+import type { ContextInjection } from '@animalabs/context-manager';
 import { randomUUID } from 'node:crypto';
 
 // ---------------------------------------------------------------------------

--- a/src/modules/retrieval-module.ts
+++ b/src/modules/retrieval-module.ts
@@ -20,9 +20,9 @@ import type {
   ToolDefinition,
   ToolCall,
   ToolResult,
-} from '@connectome/agent-framework';
-import type { Membrane, NormalizedRequest } from 'membrane';
-import type { ContextInjection } from '@connectome/context-manager';
+} from '@animalabs/agent-framework';
+import type { Membrane, NormalizedRequest } from '@animalabs/membrane';
+import type { ContextInjection } from '@animalabs/context-manager';
 import type { LessonsModule, Lesson } from './lessons-module.js';
 
 // ---------------------------------------------------------------------------

--- a/src/modules/subagent-module.ts
+++ b/src/modules/subagent-module.ts
@@ -26,10 +26,10 @@ import type {
   ToolResult,
   TraceEvent,
   ContextManager,
-} from '@connectome/agent-framework';
-import type { AgentFramework } from '@connectome/agent-framework';
-import { KnowledgeStrategy } from '@connectome/agent-framework';
-import type { ContentBlock } from 'membrane';
+} from '@animalabs/agent-framework';
+import type { AgentFramework } from '@animalabs/agent-framework';
+import { KnowledgeStrategy } from '@animalabs/agent-framework';
+import type { ContentBlock } from '@animalabs/membrane';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -543,7 +543,7 @@ export class SubagentModule implements Module {
     return {};
   }
 
-  async gatherContext(_agentName: string): Promise<import('@connectome/context-manager').ContextInjection[]> {
+  async gatherContext(_agentName: string): Promise<import('@animalabs/context-manager').ContextInjection[]> {
     if (!this.ctx) return [];
     const persisted = this.ctx.getState<{ hudEnabled?: boolean }>() ?? {};
     if (!persisted.hudEnabled) return [];

--- a/src/modules/tui-module.ts
+++ b/src/modules/tui-module.ts
@@ -14,7 +14,7 @@ import type {
   ToolDefinition,
   ToolCall,
   ToolResult,
-} from '@connectome/agent-framework';
+} from '@animalabs/agent-framework';
 
 export class TuiModule implements Module {
   readonly name = 'tui';

--- a/src/modules/wake-module.ts
+++ b/src/modules/wake-module.ts
@@ -21,8 +21,8 @@ import type {
   ToolCall,
   ToolResult,
   TraceEvent,
-} from '@connectome/agent-framework';
-import type { AgentFramework } from '@connectome/agent-framework';
+} from '@animalabs/agent-framework';
+import type { AgentFramework } from '@animalabs/agent-framework';
 
 // ---------------------------------------------------------------------------
 // Types

--- a/src/recipe.ts
+++ b/src/recipe.ts
@@ -68,7 +68,7 @@ export interface RecipeModules {
   subagents?: boolean | { defaultModel?: string };
   lessons?: boolean;
   retrieval?: boolean | { model?: string; maxInjected?: number };
-  wake?: boolean | import('@connectome/agent-framework').GateConfig;
+  wake?: boolean | import('@animalabs/agent-framework').GateConfig;
   workspace?: boolean | { mounts: RecipeWorkspaceMount[]; configMount?: boolean };
 }
 

--- a/src/synesthete.ts
+++ b/src/synesthete.ts
@@ -5,7 +5,7 @@
  * 2–4 word name that captures the session's topic/mood.
  */
 
-import type { Membrane } from 'membrane';
+import type { Membrane } from '@animalabs/membrane';
 
 const DEFAULT_EXAMPLES = [
   'Context Window Budgeting',

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -28,9 +28,9 @@ import {
   fg,
 } from '@opentui/core';
 import { createWriteStream, mkdirSync } from 'node:fs';
-import type { AgentFramework } from '@connectome/agent-framework';
-import type { AutobiographicalStrategy } from '@connectome/context-manager';
-import type { Membrane, NormalizedRequest } from 'membrane';
+import type { AgentFramework } from '@animalabs/agent-framework';
+import type { AutobiographicalStrategy } from '@animalabs/context-manager';
+import type { Membrane, NormalizedRequest } from '@animalabs/membrane';
 import type { SubagentModule, ActiveSubagent } from './modules/subagent-module.js';
 import { handleCommand, resetBranchState } from './commands.js';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,13 +7,7 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "outDir": "dist",
-    "rootDir": "src",
-    "paths": {
-      "@animalabs/chronicle": ["../chronicle/index.d.ts"],
-      "@animalabs/membrane": ["../membrane/dist/index.d.ts"],
-      "@animalabs/context-manager": ["../context-manager/dist/src/index.d.ts"],
-      "@animalabs/agent-framework": ["../agent-framework/dist/src/index.d.ts"]
-    }
+    "rootDir": "src"
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,13 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "paths": {
+      "@animalabs/chronicle": ["../chronicle/index.d.ts"],
+      "@animalabs/membrane": ["../membrane/dist/index.d.ts"],
+      "@animalabs/context-manager": ["../context-manager/dist/src/index.d.ts"],
+      "@animalabs/agent-framework": ["../agent-framework/dist/src/index.d.ts"]
+    }
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Summary
- Updates all dependencies from broken GitHub refs to `@animalabs/*` npm packages
- Renames all imports across src/ (~12 files) including inline `import()` type expressions
- Adds tsconfig `paths` for local development against sibling packages

## Part of
npm publishing initiative — depends on all `@animalabs/*` packages being published first.

## Test plan
- [ ] `npx tsc --noEmit` passes (verified locally with tsconfig paths)
- [ ] `npm install` succeeds after all deps are published to npm
- [ ] `bun src/index.ts` starts correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)