### PR TITLE
feat: /usage command, usage tracking, async timeout fix

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,14 +1,15 @@
-# Forking Knowledge Miner
+# connectome-host
 
-A TUI-driven application that points forking LLM agents at data sources to extract, organize, and persist structured knowledge. Built on the Afcomech stack (Agent Framework + Context Manager + Membrane + Chronicle) as a dogfooding exercise.
+A general-purpose agent TUI host with recipe-based configuration. Point it at any use case by loading a recipe — a JSON file that defines the system prompt, MCP servers, modules, and agent settings. Built on the Connectome stack (Agent Framework + Context Manager + Membrane + Chronicle).
 
 ## Goals
 
-1. **Social knowledge extraction** — read Zulip streams, identify decisions, patterns, people, and processes, persist findings as structured lessons with confidence scores and provenance
-2. **Parallel exploration** — spawn and fork subagents to analyze multiple streams/topics concurrently, synthesize their findings
-3. **Semantic memory** — automatically surface relevant prior knowledge before each inference using a cheap LLM-as-retriever pipeline
+1. **Recipe-driven configuration** — a single JSON file defines the entire agent personality: system prompt, model, MCP servers, module toggles, context strategy, session naming hints
+2. **Parallel exploration** — spawn and fork subagents to work on multiple tasks concurrently, with fleet tree view and live peeking
+3. **Semantic memory** — persistent lesson store with confidence scoring, plus LLM-as-retriever pipeline for automatic context injection
 4. **Reversibility** — Chronicle-backed undo/redo, named checkpoints, branch exploration via slash commands
-5. **Dogfood the AF** — stress-test the agent framework's module system, MCPL integration, context strategies, and multi-agent capabilities
+5. **Session management** — isolated Chronicle stores per session, auto-naming via Haiku
+6. **Dogfood the AF** — stress-test the agent framework's module system, MCPL integration, context strategies, and multi-agent capabilities
 
 ## Architecture
 
@@ -25,21 +26,22 @@ A TUI-driven application that points forking LLM agents at data sources to extra
                     ┌───────────┴───────────┐
                     │   Agent Framework     │
                     │  ┌─────────────────┐  │
-                    │  │  researcher     │  │  main agent (Opus)
+                    │  │  recipe agent   │  │  name, model, prompt from recipe
                     │  │  (event loop)   │  │
                     │  └────────┬────────┘  │
                     │           │            │
                     │  ┌────────┴────────┐  │
-                    │  │   Modules       │  │
+                    │  │   Modules       │  │  (recipe-toggleable)
                     │  │  - subagent     │──┼── spawn/fork ephemeral agents
                     │  │  - lessons      │──┼── CRUD knowledge store (Chronicle)
                     │  │  - retrieval    │──┼── LLM-as-retriever (Haiku)
-                    │  │  - tui          │  │
+                    │  │  - workspace    │──┼── mount-based filesystem (Chronicle-backed)
+                    │  │  - tui          │  │  (always-on)
                     │  └────────┬────────┘  │
                     │           │            │
                     │  ┌────────┴────────┐  │
-                    │  │  MCPL Server    │  │
-                    │  │  (zulip-mcp)    │──┼── list_streams, get_messages, ...
+                    │  │  MCPL Servers   │  │  from recipe + mcpl-servers.json
+                    │  │  (stdio or ws)  │──┼── any MCP/MCPL server
                     │  └─────────────────┘  │
                     └───────────────────────┘
 ```
@@ -48,28 +50,53 @@ A TUI-driven application that points forking LLM agents at data sources to extra
 
 1. User types a message in the TUI
 2. `TuiModule` converts it to a context message + triggers inference
-3. The researcher agent reads the conversation, calls tools (Zulip, subagent, lessons)
+3. The agent reads the conversation, calls tools (MCPL servers, subagent, lessons, etc.)
 4. Before each inference, `RetrievalModule` and `LessonsModule` inject relevant knowledge via `gatherContext()`
 5. Trace events (`inference:tokens`, `tool:started`, etc.) drive the TUI's streaming display
 
 ## Project Structure
 
 ```
-zulip-app/
+connectome-host/
   src/
-    index.ts                 Entry point, framework bootstrap, dual-mode (TUI / piped)
+    index.ts                 Entry point, recipe resolution, framework factory
     tui.ts                   OpenTUI-based terminal interface (@opentui/core)
-    commands.ts              Slash command handler (Chronicle reversibility)
-    prompts/
-      system.ts              Researcher agent system prompt
+    commands.ts              Slash command handler (Chronicle reversibility, /mcp, /session, etc.)
+    recipe.ts                Recipe loading, validation, persistence, CLI parsing
+    mcpl-config.ts           File-driven MCPL server config (mcpl-servers.json)
+    session-manager.ts       Session index, isolation, migration
+    synesthete.ts            Auto-naming sessions via Haiku
     modules/
       tui-module.ts          Event bridge: external-message → context + inference
-      subagent-module.ts     Spawn, fork, launch, wait
+      subagent-module.ts     Spawn, fork, peek, hud, concurrency, return
       lessons-module.ts      Knowledge CRUD + gatherContext injection
       retrieval-module.ts    3-step LLM-as-retriever pipeline
+      wake-module.ts         Legacy subscriptions (gating migrated to AF's EventGate)
+    strategies/              (reserved for future domain-specific strategies)
+    types/
+      bun-ffi.d.ts           Bun FFI type declarations
+  recipes/
+    zulip-miner.json         Knowledge extraction from Zulip workspaces
+    knowledge-miner.json     General-purpose knowledge extraction
+    mcpl-editor-test.json    Collaborative markdown editor testing via WebSocket MCPL
 ```
 
 ## Components
+
+### Recipe System (`recipe.ts`)
+
+Recipes are JSON files that configure everything domain-specific. See [README.md](README.md) for the full recipe schema.
+
+**Loading precedence**:
+1. CLI argument (`bun src/index.ts recipes/foo.json` or `bun src/index.ts https://...`)
+2. Saved recipe from last run (`data/.recipe.json`)
+3. Built-in default (generic assistant with all modules enabled)
+
+**System prompt from URL**: If `agent.systemPrompt` is an HTTP(S) URL (no spaces/newlines), the text is fetched at load time.
+
+**MCP server merging**: Recipe servers merge with `mcpl-servers.json`. The file wins on conflict, so `/mcp add` can override recipe defaults.
+
+**Transport support**: Recipe MCP servers support both stdio (`command` + `args`) and WebSocket (`url` + `transport: 'websocket'` + optional `token`).
 
 ### TUI (`tui.ts`)
 
@@ -90,25 +117,29 @@ Built on [OpenTUI](https://github.com/anomalyco/opentui) (`@opentui/core`) — t
 - **Conversation area**: `ScrollBoxRenderable` with `stickyScroll: true` — auto-scrolls as content is added. Each message or tool notification is a `TextRenderable` child node.
 - **Status bar**: Two `TextRenderable` nodes in a `BoxRenderable` with `justifyContent: 'space-between'`. Left side shows agent state, current tool, and subagent count. Right side shows cumulative token usage across the session (all agents).
 - **Input**: `InputRenderable` with `ENTER` event for submitting messages and commands.
-- **Keyboard**: Tab toggles subagent details in the status bar. Ctrl-C exits.
+- **Keyboard**: Tab toggles fleet view (subagent tree). Esc interrupts the agent. Ctrl+V toggles verbose mode. Ctrl+B detaches a sync subagent to background. Ctrl+C exits.
 
 **Streaming**: Tokens arrive via `inference:tokens` trace events. A plain string buffer tracks accumulated text and assigns the full string to `TextRenderable.content` each time (the `.content` property is a `StyledText` object, not a string — `+=` would break).
 
-**Token tracking**: Every `inference:completed` trace event (researcher + all subagents) adds to a session-wide counter tracking input tokens, output tokens, cache reads, and cache writes. Displayed compactly: `1.2kin 0.5kout 3.4kcache`.
+**Token tracking**: `usage:updated` trace events (from all agents) feed a session-wide counter tracking input tokens, output tokens, cache reads, and cache writes. Displayed compactly: `1.2kin 0.5kout 3.4kcache`.
 
 **Dual mode**: If stdout is not a TTY (piped/CI), falls back to a plain readline loop with `waitForInference` promise gating. No OpenTUI dependency on this path.
 
 ### Subagent Module (`subagent-module.ts`)
 
-Enables the researcher to delegate work to parallel ephemeral agents.
+Enables the agent to delegate work to parallel ephemeral agents.
 
 **Tools**:
 | Tool | Behavior |
 |------|----------|
-| `subagent:spawn` | Fresh agent with system prompt + task. Blocks until complete. |
-| `subagent:fork` | Agent inheriting parent's full message history. Blocks until complete. |
-| `subagent:launch` | Non-blocking spawn or fork. Returns task ID immediately. |
-| `subagent:wait` | Block until specific or all launched tasks complete. |
+| `subagent--spawn` | Fresh agent with system prompt + task. Async by default (returns immediately). |
+| `subagent--fork` | Agent inheriting parent's compiled context. Async by default. |
+| `subagent--hud` | Toggle fleet status HUD overlay (injected before each inference). |
+| `subagent--concurrency` | View/adjust concurrency ceiling (auto-adapts to rate limits). |
+| `subagent--peek` | Live state of a running subagent (status, messages, streaming output). |
+| `subagent--return` | Subagent calls this to deliver results back to parent and exit. |
+
+**Async by default**: Spawn and fork return immediately; results arrive as messages + inference-request events. Pass `sync: true` to block until completion. Sync tasks are detachable (Ctrl+B or `timeoutMs` auto-detach).
 
 **Interaction model** (parallel-async-await): When the LLM emits multiple spawn/fork calls in a single turn, the AF dispatches them concurrently. The parent blocks on `waiting_for_tools` until all results arrive together — natural fan-out without explicit orchestration.
 
@@ -116,9 +147,29 @@ Enables the researcher to delegate work to parallel ephemeral agents.
 
 **Depth limiting**: Constructor takes `maxDepth` (default 3). At the depth limit, subagent tools are stripped from the child's tool set.
 
+**Concurrency**: Adaptive concurrency control — halves on HTTP 429, recovers after consecutive successes.
+
 **Terminology**: "Fork" and "branch" are distinct concepts:
 - **Fork** = spawning a subagent that inherits the parent's compiled messages (agent-level, message copy)
 - **Branch** = Chronicle state branch for undo/redo/checkpointing (storage-level, user-facing)
+
+### EventGate (replaces WakeModule)
+
+MCPL event gating is now a core Agent Framework feature. Configuration is file-based (`{storePath}/config/gate.json`) and controlled via `GateOptions` in `FrameworkConfig`. The recipe's `modules.wake` key controls whether gating is enabled and can provide initial policy config.
+
+The legacy `wake-module.ts` still exists in the codebase but is **not instantiated** — gating was migrated to AF's EventGate in commit `601bc8c`.
+
+### Workspace Module (from AF)
+
+Mount-based filesystem access backed by Chronicle, imported from `@connectome/agent-framework`. Replaces the former `FilesModule` + `LocalFilesModule`.
+
+**Default mounts** (when recipe doesn't specify):
+- `input` — read-only, `./input`
+- `products` — read-write, `./output`
+
+**Recipe-configurable**: `modules.workspace.mounts` overrides the default mounts. `modules.workspace.configMount: true` adds a special `_config` mount that version-controls gate config via Chronicle.
+
+Disabled entirely with `modules.workspace: false` (no filesystem access at all).
 
 ### Lessons Module (`lessons-module.ts`)
 
@@ -165,12 +216,25 @@ Semantic memory lookup using a three-step LLM-as-retriever pipeline. Runs in `ga
 - Fails open: on error, returns empty (never blocks inference)
 - Short-circuits: if only 3 or fewer candidates, skips validation step
 
-### Slash Commands (`commands.ts`)
+### Session Manager (`session-manager.ts`)
 
-Chronicle-backed reversibility exposed through the TUI.
+Each session is an isolated Chronicle store under `{dataDir}/sessions/{id}/`. A JSON index (`sessions.json`) tracks metadata.
+
+**Features**: create, delete, rename, switch, find (by name or ID prefix), legacy store migration.
+
+### Synesthete (`synesthete.ts`)
+
+Auto-generates session names via a Haiku call after the 3rd user message. Produces 2–4 word names. Recipe can provide naming examples to steer the style.
+
+### Slash Commands (`commands.ts`)
 
 | Command | Effect |
 |---------|--------|
+| `/help` | List all commands |
+| `/quit`, `/q` | Exit |
+| `/status` | Agent state, branch, queue depth |
+| `/clear` | Clear conversation display |
+| `/lessons` | Show lesson library sorted by confidence |
 | `/undo` | Branch at the message before the last agent turn, switch to it |
 | `/redo` | Pop from redo stack, switch back |
 | `/checkpoint <name>` | Save `(branchId, branchName)` as named point |
@@ -178,49 +242,43 @@ Chronicle-backed reversibility exposed through the TUI.
 | `/branches` | List all Chronicle branches with head positions |
 | `/checkout <name>` | Switch to named branch |
 | `/history` | Show last 20 messages in summary form |
-| `/lessons` | Show lesson library sorted by confidence |
-| `/status` | Agent state, branch, queue depth |
-| `/clear` | Clear scroll region |
+| `/mcp list` | List MCPL servers from `mcpl-servers.json` |
+| `/mcp add <id> <cmd> [args...]` | Add or overwrite a server |
+| `/mcp remove <id>` | Remove a server |
+| `/mcp env <id> KEY=VALUE [...]` | Set env vars on a server |
+| `/budget [tokens]` | Show/set stream token budget (e.g. `/budget 150k`, `/budget 1m`) |
+| `/session` | Show current session |
+| `/session list` | List all sessions |
+| `/session new [name]` | Create and switch to new session |
+| `/session switch <name>` | Switch to session (by name or ID) |
+| `/session rename <name>` | Rename current session |
+| `/session delete <name>` | Delete a session |
+| `/recipe` | Show current recipe info |
+| `/newtopic [context]` | Reset head window (auto-summarize or with user context) |
+| `/usage` | Show session token usage and cost breakdown |
 
 ## Framework Integration
 
 The app runs on the `mcpl-first-class` branch of the Agent Framework, which embeds MCPL server management directly in the framework core.
 
-**Key AF extensions made for this app**:
+**Key AF extensions used**:
 - `createEphemeralAgent()` — creates an agent + context manager with an isolated temp Chronicle store; returns a cleanup function
 - `runEphemeralToCompletion()` — temporarily registers an ephemeral agent in the framework's agent map, triggers inference through the normal event loop (full trace events, logging, tool dispatch), resolves when the agent returns to idle
-- `executeToolCall()` — routes tool calls to module registry or MCPL servers (used by subagents to access Zulip tools)
+- `executeToolCall()` — routes tool calls to module registry or MCPL servers (used by subagents to access tools)
+- `KnowledgeStrategy` — context strategy used for subagent fork/spawn context (from `@connectome/agent-framework`)
 
-**Configuration** (from `index.ts`):
-```typescript
-const framework = await AgentFramework.create({
-  storePath: './data/store',
-  membrane,
-  agents: [{
-    name: 'researcher',
-    model: 'claude-opus-4-20250514',
-    systemPrompt: SYSTEM_PROMPT,
-    strategy: new PassthroughStrategy(),
-  }],
-  modules: [tuiModule, subagentModule, lessonsModule, retrievalModule],
-  mcplServers: [{
-    id: 'zulip',
-    command: 'node',
-    args: ['../zulip-mcp/build/index.js'],
-    env: { ZULIP_RC_PATH: '.zuliprc' },
-  }],
-});
-```
+**Configuration** is recipe-driven — see `createFramework()` in `index.ts`. The framework factory:
+1. Builds the module list based on recipe toggles (subagent, lessons, retrieval, workspace)
+2. Merges recipe MCP servers with `mcpl-servers.json` (file wins)
+3. Configures EventGate via `GateOptions` (file-based, per-session)
+4. Selects context strategy from recipe (`autobiographical` or `passthrough`, defaults to autobiographical)
 
 ## Environment
 
 ```
 ANTHROPIC_API_KEY         Required. API key for Membrane.
-MODEL                     Model for the researcher agent. Default: claude-opus-4-20250514
-STORE_PATH                Chronicle store location. Default: ./data/store
-ZULIP_MCP_CMD             Zulip MCP server command. Default: node
-ZULIP_MCP_ARGS            Zulip MCP server args. Default: ../zulip-mcp/build/index.js
-ZULIP_RC_PATH             Path to .zuliprc for Zulip bot credentials.
+MODEL                     Override model for the main agent. Default: from recipe or claude-opus-4-6
+DATA_DIR                  Data directory for sessions and recipes. Default: ./data
 ```
 
 ## Runtime
@@ -233,6 +291,9 @@ ZULIP_RC_PATH             Path to .zuliprc for Zulip bot credentials.
 # Interactive TUI (requires TTY)
 bun src/index.ts
 
+# Load a recipe
+bun src/index.ts recipes/zulip-miner.json
+
 # Piped mode (CI / testing)
 echo -e "/help\n/status\n/quit" | bun src/index.ts
 
@@ -244,31 +305,11 @@ bun --watch src/index.ts
 
 | Package | Source |
 |---------|--------|
-| `@connectome/agent-framework` | `../agent-framework` (mcpl-first-class branch) |
-| `@connectome/context-manager` | `../context-manager` |
-| `chronicle` | `../chronicle` (Rust + N-API bindings) |
-| `membrane` | `../membrane` |
+| `@connectome/agent-framework` | `../agent-framework` (local) |
+| `@connectome/context-manager` | `../context-manager` (local) |
+| `chronicle` | `../chronicle` (Rust + N-API bindings, local) |
+| `membrane` | `../membrane` (local) |
 | `@opentui/core` | npm (native Zig terminal UI, powers OpenCode) |
-| `zulip-mcp` | `../zulip-mcp` (cloned from `antra-tess/zulip_mcp`) |
-
-## Status
-
-| Feature | Status |
-|---------|--------|
-| Scaffold + bootstrap | Done |
-| Zulip MCP integration | Done |
-| OpenTUI TUI (streaming, status bar, input) | Done |
-| Token usage tracking (session-wide) | Done |
-| Piped/CI mode | Done |
-| Subagent spawn/fork/launch/wait | Done |
-| Lessons CRUD + persistence | Done |
-| Retrieval pipeline (LLM-as-retriever) | Done |
-| Chronicle reversibility (undo/redo/checkpoint) | Done |
-| Subagent TUI visibility (Tab toggle) | Done |
-| Bun + Chronicle compatibility | Validated (56 tests) |
-| End-to-end knowledge extraction session | Not yet tested |
-| KnowledgeStrategy (context compression) | Not started |
-| Tests | Not started |
 
 ## Roadmap
 
@@ -286,8 +327,8 @@ The context-manager's `AutobiographicalStrategy` currently does single-level com
 - **Self-voice framing**: summaries injected as assistant messages (the model's own recollections), not Q&A pairs
 - **Source range tracking**: each compressed chunk records which message sequences it covers (Chronicle is lossless, but we need the mapping)
 
-### 3. KnowledgeStrategy for FKM
-Domain-aware compression strategy that understands knowledge extraction semantics. Prioritizes lesson-relevant messages, research leads, and synthesis differently from generic conversation. Builds on top of the hierarchical compression work.
+### 3. Domain-specific context strategies
+Recipe-aware compression strategies that understand domain semantics. For example, a knowledge extraction strategy that prioritizes lesson-relevant messages, research leads, and synthesis differently from generic conversation. Builds on top of the hierarchical compression work.
 
 ### 4. Undo/redo at the framework level
 Currently each app builds its own undo/redo on top of Chronicle branching. Should be a first-class framework feature:
@@ -296,13 +337,11 @@ Currently each app builds its own undo/redo on top of Chronicle branching. Shoul
 - Branch at the recorded sequence, switch to the new branch
 - Emit trace events so TUI/UI layers know to refresh
 
-### 5. MCPL integration in FKM
-FKM currently has config-only MCPL support — servers launch via `mcpl-servers.json` and the framework starts them, but nothing handles incoming activity:
-- No `shouldTriggerInference` callbacks for routing push events to inference
-- No processing of push events or channel messages in the TUI or modules
-- No visibility into MCPL server status or activity in the TUI
-- MCPL-triggered inference is indistinguishable from user-triggered
-- Need interaction model: how does MCPL-pushed content appear in the conversation view?
+### 5. MCPL integration depth
+connectome-host has config-level MCPL support and wake subscriptions, but deeper integration is needed:
+- Visibility into MCPL server status and activity in the TUI
+- MCPL-triggered inference distinguished from user-triggered in the conversation view
+- Interaction model for how MCPL-pushed content appears and is handled
 
 ## TUI Evolution
 
@@ -314,4 +353,5 @@ FKM currently has config-only MCPL support — servers launch via `mcpl-servers.
 
 - **`TextRenderable.content` is a `StyledText` object**, not a string. Using `+=` silently breaks (stringifies as `[object Object]`). Always track text in a plain string buffer and assign the full string via `=`.
 - **Bun auto-loads `.env`** — no `dotenv` package needed.
-- **`child_process.spawn`** works in Bun (needed for MCPL server connections to zulip-mcp).
+- **`child_process.spawn`** works in Bun (needed for MCPL server connections).
+- **Tool name separator**: module tools use `--` separator (e.g. `subagent--fork`, `wake--subscribe`), not `:`.

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -28,6 +28,7 @@ import type { AgentFramework } from '@animalabs/agent-framework';
 import type { ContextManager } from '@animalabs/context-manager';
 import type { Recipe } from './recipe.js';
 import { readMcplServersFile, saveMcplServers, DEFAULT_CONFIG_PATH } from './mcpl-config.js';
+import { fmtTokens } from './tui.js';
 
 /** Imported lazily to avoid circular deps — index.ts re-exports the type. */
 interface AppContext {
@@ -373,12 +374,7 @@ function handleRecipe(app: AppContext): CommandResult {
 function handleUsage(app: AppContext): CommandResult {
   const snapshot = app.framework.getSessionUsage();
   const lines: Line[] = [];
-
-  const fmt = (n: number) => {
-    if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M';
-    if (n >= 1_000) return (n / 1_000).toFixed(1) + 'k';
-    return String(n);
-  };
+  const fmt = fmtTokens;
 
   const fmtCost = (cost?: { total: number; currency: string }) => {
     if (!cost) return '';
@@ -386,22 +382,20 @@ function handleUsage(app: AppContext): CommandResult {
   };
 
   const { totals } = snapshot;
-  const costStr = fmtCost(totals.estimatedCost);
   lines.push({ text: '--- Session Usage ---', style: 'system' });
   lines.push({
-    text: `  Total: ${fmt(totals.inputTokens)} in  ${fmt(totals.outputTokens)} out  ${fmt(totals.cacheReadTokens)} cache read  ${fmt(totals.cacheCreationTokens)} cache write${costStr}`,
+    text: `  Total: ${fmt(totals.inputTokens)} in  ${fmt(totals.outputTokens)} out  ${fmt(totals.cacheReadTokens)} cache read  ${fmt(totals.cacheCreationTokens)} cache write${fmtCost(totals.estimatedCost)}`,
     style: 'system',
   });
   lines.push({ text: `  Inferences: ${snapshot.inferenceCount}`, style: 'system' });
 
-  if (snapshot.byAgent.length > 1) {
+  if (snapshot.byAgent.length > 0) {
     lines.push({ text: '', style: 'system' });
     lines.push({ text: '--- Per Agent ---', style: 'system' });
     for (const agent of snapshot.byAgent) {
       const u = agent.usage;
-      const ac = fmtCost(u.estimatedCost);
       lines.push({
-        text: `  ${agent.agentName}  ${fmt(u.inputTokens)} in  ${fmt(u.outputTokens)} out  ${fmt(u.cacheReadTokens)} cache${ac}  (${agent.inferenceCount} inf)`,
+        text: `  ${agent.agentName}  ${fmt(u.inputTokens)} in  ${fmt(u.outputTokens)} out  ${fmt(u.cacheReadTokens)} cache read  ${fmt(u.cacheCreationTokens)} cache write${fmtCost(u.estimatedCost)}  (${agent.inferenceCount} inf)`,
         style: 'system',
       });
     }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -18,6 +18,7 @@
  *   /recipe        — Show current recipe info
  *   /newtopic      — Reset head window (auto-summarize or with user context)
  *   /export        — Export lessons to ./output/ (JSON + markdown)
+ *   /usage         — Show session token usage and costs
  *   /help          — List commands
  */
 
@@ -137,6 +138,7 @@ export function handleCommand(command: string, app: AppContext): CommandResult {
           { text: '  /session delete <name> Delete a session', style: 'system' },
           { text: '  /recipe                Show current recipe info', style: 'system' },
           { text: '  /newtopic [context]    Reset head window (auto-summarize if empty)', style: 'system' },
+          { text: '  /usage                 Show session token usage and costs', style: 'system' },
         ],
       };
 
@@ -187,6 +189,9 @@ export function handleCommand(command: string, app: AppContext): CommandResult {
 
     case 'newtopic':
       return handleNewTopic(app, args);
+
+    case 'usage':
+      return handleUsage(app);
 
     default:
       return {
@@ -357,6 +362,50 @@ function handleRecipe(app: AppContext): CommandResult {
 
   const mcpCount = r.mcpServers ? Object.keys(r.mcpServers).length : 0;
   lines.push({ text: `  MCP servers (recipe): ${mcpCount}`, style: 'system' });
+
+  return { lines };
+}
+
+// ---------------------------------------------------------------------------
+// /usage — session token usage and cost breakdown
+// ---------------------------------------------------------------------------
+
+function handleUsage(app: AppContext): CommandResult {
+  const snapshot = app.framework.getSessionUsage();
+  const lines: Line[] = [];
+
+  const fmt = (n: number) => {
+    if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M';
+    if (n >= 1_000) return (n / 1_000).toFixed(1) + 'k';
+    return String(n);
+  };
+
+  const fmtCost = (cost?: { total: number; currency: string }) => {
+    if (!cost) return '';
+    return `  $${cost.total.toFixed(4)}`;
+  };
+
+  const { totals } = snapshot;
+  const costStr = fmtCost(totals.estimatedCost);
+  lines.push({ text: '--- Session Usage ---', style: 'system' });
+  lines.push({
+    text: `  Total: ${fmt(totals.inputTokens)} in  ${fmt(totals.outputTokens)} out  ${fmt(totals.cacheReadTokens)} cache read  ${fmt(totals.cacheCreationTokens)} cache write${costStr}`,
+    style: 'system',
+  });
+  lines.push({ text: `  Inferences: ${snapshot.inferenceCount}`, style: 'system' });
+
+  if (snapshot.byAgent.length > 1) {
+    lines.push({ text: '', style: 'system' });
+    lines.push({ text: '--- Per Agent ---', style: 'system' });
+    for (const agent of snapshot.byAgent) {
+      const u = agent.usage;
+      const ac = fmtCost(u.estimatedCost);
+      lines.push({
+        text: `  ${agent.agentName}  ${fmt(u.inputTokens)} in  ${fmt(u.outputTokens)} out  ${fmt(u.cacheReadTokens)} cache${ac}  (${agent.inferenceCount} inf)`,
+        style: 'system',
+      });
+    }
+  }
 
   return { lines };
 }

--- a/src/modules/subagent-module.ts
+++ b/src/modules/subagent-module.ts
@@ -438,7 +438,7 @@ export class SubagentModule implements Module {
               description: 'Tool names the subagent can use (default: all). Note: subagent--return is always included automatically.',
             },
             sync: { type: 'boolean', description: 'If true, block until subagent completes (default: false)' },
-            timeoutMs: { type: 'number', description: 'Execution timeout in milliseconds. For async tasks, the subagent is cancelled after this duration. For sync tasks, auto-detaches to background after this duration (result delivered as message). Example: 600000 = 10 minutes.' },
+            timeoutMs: { type: 'number', description: 'Execution timeout in milliseconds. Sync tasks default to 600s (auto-detaches to background). Async tasks have no default timeout — only set this if you need a hard deadline.' },
           },
           required: ['name', 'systemPrompt', 'task'],
         },
@@ -454,7 +454,7 @@ export class SubagentModule implements Module {
             systemPrompt: { type: 'string', description: 'Override system prompt (optional, defaults to parent)' },
             model: { type: 'string', description: 'Model override (optional)' },
             sync: { type: 'boolean', description: 'If true, block until fork completes (default: false)' },
-            timeoutMs: { type: 'number', description: 'Execution timeout in milliseconds. For async tasks, the subagent is cancelled after this duration. For sync tasks, auto-detaches to background after this duration (result delivered as message). Example: 600000 = 10 minutes.' },
+            timeoutMs: { type: 'number', description: 'Execution timeout in milliseconds. Sync tasks default to 600s (auto-detaches to background). Async tasks have no default timeout — only set this if you need a hard deadline.' },
           },
           required: ['name', 'task'],
         },
@@ -990,13 +990,14 @@ export class SubagentModule implements Module {
   // Execution Timeout
   // =========================================================================
 
-  private withTimeout<T>(promise: Promise<T>, name: string): Promise<T> {
+  private withTimeout<T>(promise: Promise<T>, name: string, timeoutMs?: number): Promise<T> {
+    if (timeoutMs === undefined) return promise;
     return Promise.race([
       promise,
       new Promise<never>((_, reject) =>
         setTimeout(
-          () => reject(new Error(`Subagent ${name} timed out after ${this.maxExecutionMs}ms`)),
-          this.maxExecutionMs,
+          () => reject(new Error(`Subagent ${name} timed out after ${timeoutMs}ms`)),
+          timeoutMs,
         )
       ),
     ]);
@@ -1044,27 +1045,20 @@ export class SubagentModule implements Module {
 
     const parentAgentName = callerAgentName ?? this.config.parentAgentName ?? 'agent';
 
-    // Apply per-task timeout override if provided
-    const savedMaxExecution = this.maxExecutionMs;
-    if (input.timeoutMs !== undefined) {
-      this.maxExecutionMs = input.timeoutMs;
-    }
-
-    // Sync mode: block until completion, but detachable mid-flight
+    // Sync mode: block until completion, but detachable mid-flight.
+    // Default timeout applies (600s) — auto-detaches to background.
     if (input.sync) {
-      const promise = this.runSpawn(input, callerAgentName, callerDepth);
-
-      // Create a detachable wrapper: resolves either when the subagent completes
-      // or when detach() is called (user Ctrl+B or auto-timeout)
+      const timeoutMs = input.timeoutMs ?? this.maxExecutionMs;
+      const promise = this.runSpawn(input, callerAgentName, callerDepth, timeoutMs);
       const result = await this.runDetachable(input.name, 'spawn', promise, parentAgentName, input.timeoutMs);
-      this.maxExecutionMs = savedMaxExecution;
       return result;
     }
 
-    // Async mode (default): fire-and-forget, deliver result as message
-    const promise = this.runSpawn(input, callerAgentName, callerDepth);
+    // Async mode (default): fire-and-forget, deliver result as message.
+    // No default timeout — async agents run until they finish unless
+    // the caller explicitly sets timeoutMs.
+    const promise = this.runSpawn(input, callerAgentName, callerDepth, input.timeoutMs);
     this.asyncHandles.set(input.name, { name: input.name, type: 'spawn', promise, parentAgentName });
-    this.maxExecutionMs = savedMaxExecution;
 
     promise
       .then(result => this.deliverAsyncResult(input.name, result, parentAgentName))
@@ -1085,25 +1079,20 @@ export class SubagentModule implements Module {
 
     const parentAgentName = callerAgentName ?? this.config.parentAgentName ?? 'agent';
 
-    // Apply per-task timeout override if provided
-    const savedMaxExecution = this.maxExecutionMs;
-    if (input.timeoutMs !== undefined) {
-      this.maxExecutionMs = input.timeoutMs;
-    }
-
-    // Sync mode: block until completion, but detachable mid-flight
+    // Sync mode: block until completion, but detachable mid-flight.
+    // Default timeout applies (600s) — auto-detaches to background.
     if (input.sync) {
-      const promise = this.runFork(input, callerAgentName, callerDepth);
-
+      const timeoutMs = input.timeoutMs ?? this.maxExecutionMs;
+      const promise = this.runFork(input, callerAgentName, callerDepth, timeoutMs);
       const result = await this.runDetachable(input.name, 'fork', promise, parentAgentName, input.timeoutMs);
-      this.maxExecutionMs = savedMaxExecution;
       return result;
     }
 
-    // Async mode (default): fire-and-forget, deliver result as message
-    const promise = this.runFork(input, callerAgentName, callerDepth);
+    // Async mode (default): fire-and-forget, deliver result as message.
+    // No default timeout — async agents run until they finish unless
+    // the caller explicitly sets timeoutMs.
+    const promise = this.runFork(input, callerAgentName, callerDepth, input.timeoutMs);
     this.asyncHandles.set(input.name, { name: input.name, type: 'fork', promise, parentAgentName });
-    this.maxExecutionMs = savedMaxExecution;
 
     promise
       .then(result => this.deliverAsyncResult(input.name, result, parentAgentName))
@@ -1290,7 +1279,7 @@ export class SubagentModule implements Module {
   // Subagent Execution
   // =========================================================================
 
-  private async runSpawn(input: SpawnInput, _callerAgentName?: string, callerDepth = 0): Promise<SubagentResult> {
+  private async runSpawn(input: SpawnInput, _callerAgentName?: string, callerDepth = 0, executionTimeoutMs?: number): Promise<SubagentResult> {
     const { waitedMs } = await this.acquireSlot();
     const childDepth = callerDepth + 1;
 
@@ -1355,6 +1344,7 @@ export class SubagentModule implements Module {
             this.withTimeout(
               framework.runEphemeralToCompletion(agent, contextManager),
               input.name,
+              executionTimeoutMs,
             ),
             cancelPromise,
           ]);
@@ -1421,7 +1411,7 @@ export class SubagentModule implements Module {
     }
   }
 
-  private async runFork(input: ForkInput, callerAgentName?: string, callerDepth = 0): Promise<SubagentResult> {
+  private async runFork(input: ForkInput, callerAgentName?: string, callerDepth = 0, executionTimeoutMs?: number): Promise<SubagentResult> {
     const { waitedMs } = await this.acquireSlot();
     const childDepth = callerDepth + 1;
 
@@ -1537,6 +1527,7 @@ export class SubagentModule implements Module {
             this.withTimeout(
               framework.runEphemeralToCompletion(agent, contextManager),
               input.name,
+              executionTimeoutMs,
             ),
             cancelPromise,
           ]);

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -849,7 +849,7 @@ export async function runTui(app: AppContext): Promise<void> {
         break;
       }
 
-      case 'billing:updated': {
+      case 'usage:updated': {
         const totals = (event as { totals: { inputTokens: number; outputTokens: number; cacheCreationTokens: number; cacheReadTokens: number } }).totals;
         state.tokens.input = totals.inputTokens;
         state.tokens.output = totals.outputTokens;

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -32,7 +32,15 @@ import type { AgentFramework } from '@animalabs/agent-framework';
 import type { AutobiographicalStrategy } from '@animalabs/context-manager';
 import type { Membrane, NormalizedRequest } from '@animalabs/membrane';
 import type { SubagentModule, ActiveSubagent } from './modules/subagent-module.js';
+import type { SessionUsage } from '@connectome/agent-framework';
 import { handleCommand, resetBranchState } from './commands.js';
+
+/** Format a token count compactly: 1.2M / 3.5k / 42. */
+export function fmtTokens(n: number): string {
+  if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M';
+  if (n >= 1_000) return (n / 1_000).toFixed(1) + 'k';
+  return String(n);
+}
 
 interface AppContext {
   framework: AgentFramework;
@@ -413,11 +421,7 @@ export async function runTui(app: AppContext): Promise<void> {
     updateStatus();
   }
 
-  const fmtK = (n: number) => {
-    if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M';
-    if (n >= 1_000) return (n / 1_000).toFixed(1) + 'k';
-    return String(n);
-  };
+  const fmtK = fmtTokens;
 
   // ── Fleet tree view ────────────────────────────────────────────────
 
@@ -850,7 +854,7 @@ export async function runTui(app: AppContext): Promise<void> {
       }
 
       case 'usage:updated': {
-        const totals = (event as { totals: { inputTokens: number; outputTokens: number; cacheCreationTokens: number; cacheReadTokens: number } }).totals;
+        const { totals } = event as { totals: SessionUsage };
         state.tokens.input = totals.inputTokens;
         state.tokens.output = totals.outputTokens;
         state.tokens.cacheRead = totals.cacheReadTokens;
@@ -1424,13 +1428,8 @@ function formatTokens(tokens: TokenUsage, verbose: boolean): string {
 
   const total = tokens.input + tokens.output;
   if (total > 0) {
-    const fmt = (n: number) => {
-      if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M';
-      if (n >= 1_000) return (n / 1_000).toFixed(1) + 'k';
-      return String(n);
-    };
-    let s = `${fmt(tokens.input)}in ${fmt(tokens.output)}out`;
-    if (tokens.cacheRead > 0) s += ` ${fmt(tokens.cacheRead)}cache`;
+    let s = `${fmtTokens(tokens.input)}in ${fmtTokens(tokens.output)}out`;
+    if (tokens.cacheRead > 0) s += ` ${fmtTokens(tokens.cacheRead)}cache`;
     parts.push(s);
   }
 

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -823,18 +823,12 @@ export async function runTui(app: AppContext): Promise<void> {
       }
 
       case 'inference:completed': {
-        const usage = event.tokenUsage as { input?: number; output?: number; cacheRead?: number; cacheCreation?: number } | undefined;
-        if (usage) {
-          state.tokens.input += usage.input ?? 0;
-          state.tokens.output += usage.output ?? 0;
-          state.tokens.cacheRead += usage.cacheRead ?? 0;
-          state.tokens.cacheWrite += usage.cacheCreation ?? 0;
-          // Track context size per agent (store by both full and short name)
-          if (agent && usage.input) {
-            agentContextTokens.set(agent, usage.input);
-            const short = agent.replace(/^(spawn|fork)-/, '').replace(/-\d+$/, '').replace(/-retry\d+$/, '');
-            if (short !== agent) agentContextTokens.set(short, usage.input);
-          }
+        const usage = event.tokenUsage as { input?: number; output?: number } | undefined;
+        // Track context size per agent (store by both full and short name)
+        if (usage && agent && usage.input) {
+          agentContextTokens.set(agent, usage.input);
+          const short = agent.replace(/^(spawn|fork)-/, '').replace(/-\d+$/, '').replace(/-retry\d+$/, '');
+          if (short !== agent) agentContextTokens.set(short, usage.input);
         }
 
         if (agent === rootAgentName) {
@@ -851,6 +845,16 @@ export async function runTui(app: AppContext): Promise<void> {
           }
           if (streaming) endStream();
         }
+        updateStatus();
+        break;
+      }
+
+      case 'billing:updated': {
+        const totals = (event as { totals: { inputTokens: number; outputTokens: number; cacheCreationTokens: number; cacheReadTokens: number } }).totals;
+        state.tokens.input = totals.inputTokens;
+        state.tokens.output = totals.outputTokens;
+        state.tokens.cacheRead = totals.cacheReadTokens;
+        state.tokens.cacheWrite = totals.cacheCreationTokens;
         updateStatus();
         break;
       }


### PR DESCRIPTION
## Summary

- **`/usage` command**: shows session token usage with per-agent breakdown and estimated costs
- **TUI migration**: token tracking moved from manual accumulation in `inference:completed` to the framework's `usage:updated` trace (single source of truth)
- **Shared `fmtTokens()`**: extracted from three duplicate closures across tui.ts and commands.ts
- **Async subagent timeout fix**: async subagents no longer have a default 600s timeout — they run until completion unless the caller explicitly sets `timeoutMs`. Sync subagents retain the 600s default. Also removes the racy shared `this.maxExecutionMs` mutation pattern.

Depends on: antra-tess/membrane#12, anima-research/agent-framework#23

## Test plan

- [x] `npx tsc --noEmit` — clean (pre-existing errors in commands.ts unrelated)
- [x] Manual: `/usage` displays per-agent token breakdown with costs
- [x] Manual: async subagents run beyond 600s without being killed

🤖 Generated with [Claude Code](https://claude.com/claude-code)