### PR TITLE
feat(fleet): onIdle hook for debounced auto-command dispatch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ mcpl-servers.json
 my-recipe.json
 output/
 review-output/
+knowledge-requests/
 tsconfig.tsbuildinfo

--- a/recipes/triumvirate.json
+++ b/recipes/triumvirate.json
@@ -29,7 +29,11 @@
           "recipe": "recipes/knowledge-miner.json",
           "dataDir": "./data/miner",
           "autoStart": true,
-          "subscription": ["lifecycle", "inference:completed", "inference:speech", "tool:completed", "tool:failed", "inference:failed"]
+          "subscription": ["lifecycle", "inference:completed", "inference:speech", "tool:completed", "tool:failed", "inference:failed"],
+          "onIdle": {
+            "command": "/newtopic",
+            "debounceMs": 120000
+          }
         },
         {
           "name": "reviewer",

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -142,6 +142,14 @@ export async function runHeadless(app: AppContext, argv: string[] = []): Promise
     emit(traceEvent as unknown as Record<string, unknown>);
   });
 
+  // Filled in by the idle-tracking block below.  Called whenever an event
+  // has semantically reset the conversation head (currently: /newtopic).
+  // After a reset, the poll must wait for a fresh `inference:started`
+  // before emitting `lifecycle:idle` again — otherwise a post-compression
+  // idle would instantly trigger whatever auto-command is watching for
+  // idle (e.g. an onIdle hook that fires /newtopic) in an infinite loop.
+  let resetIdleTracking: () => void = (): void => { /* wired below */ };
+
   // -- Command dispatch --
   async function dispatchCommand(cmd: IncomingCommand): Promise<void> {
     switch (cmd.type) {
@@ -181,6 +189,14 @@ export async function runHeadless(app: AppContext, argv: string[] = []): Promise
         if (result.switchToSessionId) {
           await app.switchSession(result.switchToSessionId);
           emit({ type: 'command-output', text: 'Session switched.', style: 'system' });
+        }
+        // `/newtopic` compresses the head window; the head is now logically
+        // fresh.  Clear the idle-tracker so a subsequent lifecycle:idle
+        // won't fire until after the next real inference.  Relevant even
+        // outside onIdle-hook scenarios: any operator running /newtopic
+        // interactively gets the same well-defined post-reset state.
+        if (/^\/newtopic(?:\s|$)/.test(cmd.command)) {
+          resetIdleTracking();
         }
         if (result.quit) {
           await gracefulShutdown('command:/quit');
@@ -316,6 +332,17 @@ export async function runHeadless(app: AppContext, argv: string[] = []): Promise
     // and on inference:tool_calls_yielded (that round was a tool-use turn,
     // not the final speech).  Emitted on inference:completed if non-empty.
     let currentSpeech = '';
+
+    // Wire the module-level hook that the command dispatcher calls after
+    // /newtopic — clear every flag that the poll treats as "there's been
+    // meaningful activity worth compressing."
+    resetIdleTracking = (): void => {
+      hadAtLeastOneInference = false;
+      idleSince = 0;
+      idleEmitted = false;
+      currentSpeech = '';
+      log('idle-tracking reset (post-/newtopic)');
+    };
 
     app.framework.onTrace((event) => {
       const t = (event as { type?: string }).type;

--- a/src/index.ts
+++ b/src/index.ts
@@ -156,6 +156,7 @@ async function createFramework(membrane: Membrane, storePath: string, recipe: Re
         if (c.env !== undefined) entry.env = c.env;
         if (c.subscription !== undefined) entry.subscription = c.subscription;
         if (c.autoRestart !== undefined) entry.autoRestart = c.autoRestart;
+        if (c.onIdle !== undefined) entry.onIdle = c.onIdle;
         return entry;
       });
     }

--- a/src/modules/fleet-module.ts
+++ b/src/modules/fleet-module.ts
@@ -102,6 +102,30 @@ export interface AutoStartChild {
   autoStart?: boolean;
   /** Phase 5 honours this; accepted now for forward-compat. */
   autoRestart?: boolean;
+  /**
+   * When the child's `lifecycle:idle` event persists for `debounceMs` with
+   * no other activity, auto-dispatch the configured slash command via the
+   * same channel as `fleet--command`.  Any event from the child during the
+   * wait cancels the pending dispatch.  The hook re-arms on every
+   * subsequent idle, so it fires once per sustained-idle period rather
+   * than on every transient idle.
+   *
+   * Intended use: wire `{command: "/newtopic", debounceMs: 120000}` on a
+   * ticket-driven miner so that the inter-ticket idle automatically
+   * compresses the last task's context before the next ticket arrives.
+   *
+   * Note: the child's headless runtime clears its idle-tracking state on
+   * `/newtopic`, so the hook won't immediately re-fire on the post-
+   * compression idle — a fresh `inference:started` is required first.
+   */
+  onIdle?: OnIdleHook;
+}
+
+export interface OnIdleHook {
+  /** Slash command to dispatch (should start with "/"). */
+  command: string;
+  /** Sustained-idle threshold before firing.  Default 120_000 (2 min). */
+  debounceMs?: number;
 }
 
 interface LaunchInput {
@@ -112,6 +136,8 @@ interface LaunchInput {
   subscription?: string[];
   /** Respawn on crash. Default false. */
   autoRestart?: boolean;
+  /** Event-driven auto-dispatch hook; see AutoStartChild.onIdle. */
+  onIdle?: OnIdleHook;
 }
 
 type ChildStatus = 'starting' | 'ready' | 'exited' | 'crashed';
@@ -175,6 +201,10 @@ interface FleetChild {
    * tool calls.  Used by fleet--relay.
    */
   lastCompletedSpeech: string;
+  /** onIdle hook config copied from AutoStartChild.  null if not configured. */
+  onIdle: OnIdleHook | null;
+  /** Pending auto-dispatch timer for the onIdle hook, or null. */
+  onIdleTimer: ReturnType<typeof setTimeout> | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -254,6 +284,7 @@ export class FleetModule implements Module {
       if (child.env !== undefined) input.env = child.env;
       if (child.subscription !== undefined) input.subscription = child.subscription;
       if (child.autoRestart !== undefined) input.autoRestart = child.autoRestart;
+      if (child.onIdle !== undefined) input.onIdle = child.onIdle;
 
       this.handleLaunch(input, { viaAutoStart: true })
         .then((res) => {
@@ -385,6 +416,8 @@ export class FleetModule implements Module {
       killRequested: false,
       restartAttempts: [],
       lastCompletedSpeech: '',  // not persisted; rebuilt on next inference:speech
+      onIdle: null,             // not persisted; an orphan wouldn't have a live timer anyway
+      onIdleTimer: null,
     };
     if (p.env) child.env = p.env;
     return child;
@@ -501,6 +534,7 @@ export class FleetModule implements Module {
       autoRestart: true,
     };
     if (child.env !== undefined) input.env = child.env;
+    if (child.onIdle) input.onIdle = child.onIdle;
 
     // Drop the crashed record so handleLaunch can register a fresh one.
     this.children.delete(child.name);
@@ -522,6 +556,14 @@ export class FleetModule implements Module {
   async stop(): Promise<void> {
     // Mark shutdown so the process 'exit' handlers don't trigger autoRestart.
     this.stopping = true;
+
+    // Cancel any pending onIdle timers — no dispatches during shutdown.
+    for (const c of this.children.values()) {
+      if (c.onIdleTimer) {
+        clearTimeout(c.onIdleTimer);
+        c.onIdleTimer = null;
+      }
+    }
 
     if (this.detachMode) {
       // Detach: close socket references only; leave child processes alive so
@@ -862,6 +904,8 @@ export class FleetModule implements Module {
       killRequested: false,
       restartAttempts: [],
       lastCompletedSpeech: '',
+      onIdle: input.onIdle ?? null,
+      onIdleTimer: null,
     };
     if (input.env !== undefined) child.env = input.env;
     this.children.set(input.name, child);
@@ -918,6 +962,10 @@ export class FleetModule implements Module {
       child.status = code === 0 ? 'exited' : 'crashed';
       try { child.socket?.destroy(); } catch { /* noop */ }
       child.socket = null;
+      if (child.onIdleTimer) {
+        clearTimeout(child.onIdleTimer);
+        child.onIdleTimer = null;
+      }
 
       this.persistState();
 
@@ -1373,6 +1421,46 @@ export class FleetModule implements Module {
     }
     this.fanOutEvent(child.name, event);
     if (statusChanged) this.persistState();
+
+    // onIdle debounce timer: arm on lifecycle:idle, cancel on any other
+    // event.  Non-events (status flips) don't affect the timer.
+    if (child.onIdle) this.tickOnIdleTimer(child, event);
+  }
+
+  /**
+   * Debounce driver for the onIdle hook.  Called from recordEvent whenever
+   * the child has an `onIdle` config.  Semantics:
+   *   - lifecycle:idle → reset & start the timer (dispatches command after debounceMs)
+   *   - any other event → cancel the timer (activity resumed)
+   */
+  private tickOnIdleTimer(child: FleetChild, event: WireEvent): void {
+    if (!child.onIdle) return;
+    const hook = child.onIdle;
+
+    const isIdleEvent = event.type === 'lifecycle'
+      && (event as { phase?: string }).phase === 'idle';
+
+    // Any event (idle or otherwise) first cancels any pending timer.
+    if (child.onIdleTimer) {
+      clearTimeout(child.onIdleTimer);
+      child.onIdleTimer = null;
+    }
+
+    if (!isIdleEvent) return;
+
+    const delayMs = hook.debounceMs ?? 120_000;
+    child.onIdleTimer = setTimeout(() => {
+      child.onIdleTimer = null;
+      if (this.stopping) return;
+      if (child.status !== 'ready') return;
+      if (!child.socket) return;
+      try {
+        this.sendToChild(child, { type: 'command', command: hook.command });
+        console.error(`[fleet] onIdle dispatched "${hook.command}" to "${child.name}" after ${delayMs}ms idle`);
+      } catch (err) {
+        console.error(`[fleet] onIdle dispatch to "${child.name}" failed: ${String(err)}`);
+      }
+    }, delayMs);
   }
 
   private fanOutEvent(childName: string, event: WireEvent): void {

--- a/src/recipe.ts
+++ b/src/recipe.ts
@@ -134,7 +134,7 @@ export interface RecipeFleetChild {
   /**
    * Event subscription at handshake (supports glob like `tool:*`).
    * Relevant synthetic events the parent may care about:
-   *   - `lifecycle` (includes `ready` / `idle` / `exiting`) — required for fleet--await.
+   *   - `lifecycle` (includes `ready` / `idle` / `exiting`) — required for fleet--await AND for the `onIdle` hook below.
    *   - `inference:speech` — per-final-inference speech text, required for fleet--relay.
    *   - `inference:completed` / `inference:failed` / `tool:completed` / `tool:failed` — useful for status tracking.
    */
@@ -143,6 +143,26 @@ export interface RecipeFleetChild {
   autoStart?: boolean;
   /** Respawn on crash (Phase 5 honours this; schema accepts it now). */
   autoRestart?: boolean;
+  /**
+   * When the child's `lifecycle:idle` event persists for `debounceMs` with
+   * no other activity, auto-dispatch `command` via fleet--command.  Activity
+   * during the wait cancels the pending dispatch; the hook re-arms on each
+   * subsequent idle, so it fires once per sustained-idle period.
+   *
+   * Typical use: `{ "command": "/newtopic", "debounceMs": 120000 }` on a
+   * ticket-driven miner, so inter-ticket idle auto-compresses the prior
+   * task's context.  The child's headless runtime resets its idle-tracking
+   * after `/newtopic`, so the hook won't re-fire on the post-compression
+   * idle — a new `inference:started` is required first.
+   *
+   * Requires `subscription` to include `lifecycle` (or be omitted/`"*"`).
+   */
+  onIdle?: {
+    /** Slash command (should start with "/"). */
+    command: string;
+    /** Sustained-idle threshold in ms.  Default 120000 (2 min). */
+    debounceMs?: number;
+  };
 }
 
 export interface Recipe {
@@ -381,6 +401,19 @@ export function validateRecipe(raw: unknown): Recipe {
           }
           if (c.autoStart !== undefined && typeof c.autoStart !== 'boolean') {
             throw new Error(`fleet.children[${i}].autoStart must be a boolean`);
+          }
+          if (c.onIdle !== undefined) {
+            if (typeof c.onIdle !== 'object' || c.onIdle === null) {
+              throw new Error(`fleet.children[${i}].onIdle must be an object`);
+            }
+            const oi = c.onIdle as Record<string, unknown>;
+            if (typeof oi.command !== 'string' || !oi.command) {
+              throw new Error(`fleet.children[${i}].onIdle.command must be a non-empty string`);
+            }
+            if (oi.debounceMs !== undefined
+              && (typeof oi.debounceMs !== 'number' || oi.debounceMs <= 0)) {
+              throw new Error(`fleet.children[${i}].onIdle.debounceMs must be a positive number`);
+            }
           }
         }
       }

--- a/test/fleet-onidle.test.ts
+++ b/test/fleet-onidle.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Tests for FleetModule's onIdle hook: debounced auto-dispatch of a
+ * slash command when a child's lifecycle:idle persists without activity.
+ *
+ * Uses the mock headless child, which:
+ *   - Emits lifecycle:idle ~30ms after each text-command inference cycle
+ *   - Has a /hang command that simulates inference without a following idle
+ *   - Echoes any received command as a command-output event so tests can
+ *     observe auto-dispatched arrivals
+ */
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { FleetModule } from '../src/modules/fleet-module.js';
+
+const TEST_DIR = dirname(fileURLToPath(import.meta.url));
+const MOCK_CHILD_PATH = join(TEST_DIR, 'mock-headless-child.ts');
+
+async function launch(fleet: FleetModule, name: string, dataDir: string): Promise<void> {
+  const res = await fleet.handleToolCall({
+    id: `launch-${name}`,
+    name: 'launch',
+    input: { name, recipe: 'mock', dataDir },
+  });
+  if (!res.success) throw new Error(`launch ${name} failed: ${res.error}`);
+}
+
+async function send(fleet: FleetModule, name: string, content: string): Promise<void> {
+  const res = await fleet.handleToolCall({
+    id: `send-${name}-${Date.now()}`,
+    name: 'send',
+    input: { name, content },
+  });
+  if (!res.success) throw new Error(`send ${name} failed: ${res.error}`);
+}
+
+async function command(fleet: FleetModule, name: string, cmd: string): Promise<void> {
+  const res = await fleet.handleToolCall({
+    id: `cmd-${name}-${Date.now()}`,
+    name: 'command',
+    input: { name, command: cmd },
+  });
+  if (!res.success) throw new Error(`command ${cmd} to ${name} failed: ${res.error}`);
+}
+
+async function wait(ms: number): Promise<void> {
+  await new Promise((r) => setTimeout(r, ms));
+}
+
+describe('onIdle hook', () => {
+  let tmpDir: string;
+
+  beforeEach(() => { tmpDir = mkdtempSync(join(tmpdir(), 'fkm-onidle-')); });
+  afterEach(() => {
+    try { rmSync(tmpDir, { recursive: true, force: true }); } catch { /* noop */ }
+  });
+
+  test('fires configured command after sustained idle post-activity', async () => {
+    const fleet = new FleetModule({
+      childIndexPath: MOCK_CHILD_PATH,
+      autoStart: [],
+      socketWaitTimeoutMs: 10_000,
+      readyTimeoutMs: 5_000,
+      gracefulShutdownMs: 3_000,
+      sigtermEscalationMs: 1_000,
+    });
+    await fleet.start({} as unknown as Parameters<typeof fleet.start>[0]);
+
+    const seen: Array<{ type: string; text?: string }> = [];
+    fleet.onChildEvent('watcher', (_name, evt) => {
+      seen.push({ type: evt.type, text: (evt as { text?: string }).text });
+    });
+
+    // Launch with a short debounce so the test isn't slow.  Note: auto-
+    // start can't carry onIdle through here (this fleet has empty autoStart);
+    // we launch ad-hoc via the tool and then inject onIdle by hand via a
+    // subsequent spawn with the config.  Simpler path: use the auto-start
+    // config directly on the second fleet we build below.
+    await fleet.stop();
+
+    const fleet2 = new FleetModule({
+      childIndexPath: MOCK_CHILD_PATH,
+      autoStart: [{
+        name: 'watcher',
+        recipe: 'mock',
+        dataDir: join(tmpDir, 'watcher'),
+        onIdle: { command: '/help', debounceMs: 300 },
+      }],
+      socketWaitTimeoutMs: 10_000,
+      readyTimeoutMs: 5_000,
+      gracefulShutdownMs: 3_000,
+      sigtermEscalationMs: 1_000,
+    });
+
+    const seen2: Array<{ type: string; text?: string }> = [];
+    fleet2.onChildEvent('watcher', (_name, evt) => {
+      seen2.push({ type: evt.type, text: (evt as { text?: string }).text });
+    });
+
+    await fleet2.start({} as unknown as Parameters<typeof fleet2.start>[0]);
+    // wait for autoStart to finish
+    for (let t = 0; t < 50; t++) {
+      if (fleet2.getChildren().get('watcher')?.status === 'ready') break;
+      await wait(100);
+    }
+
+    // Trigger activity → mock emits lifecycle:idle ~30ms later.
+    await send(fleet2, 'watcher', 'do work');
+
+    // After idle fires, debounce is 300ms → /help auto-dispatches ~330ms later.
+    await wait(700);
+
+    const helpArrivals = seen2.filter((e) => e.type === 'command-output' && /mock help/.test(e.text ?? ''));
+    expect(helpArrivals.length).toBeGreaterThan(0);
+
+    await fleet2.stop();
+  }, 30_000);
+
+  test('activity during debounce cancels the pending dispatch', async () => {
+    const fleet = new FleetModule({
+      childIndexPath: MOCK_CHILD_PATH,
+      autoStart: [{
+        name: 'busy',
+        recipe: 'mock',
+        dataDir: join(tmpDir, 'busy'),
+        onIdle: { command: '/help', debounceMs: 500 },
+      }],
+      socketWaitTimeoutMs: 10_000,
+      readyTimeoutMs: 5_000,
+      gracefulShutdownMs: 3_000,
+      sigtermEscalationMs: 1_000,
+    });
+
+    const seen: Array<{ type: string; text?: string }> = [];
+    fleet.onChildEvent('busy', (_name, evt) => {
+      seen.push({ type: evt.type, text: (evt as { text?: string }).text });
+    });
+
+    await fleet.start({} as unknown as Parameters<typeof fleet.start>[0]);
+    for (let t = 0; t < 50; t++) {
+      if (fleet.getChildren().get('busy')?.status === 'ready') break;
+      await wait(100);
+    }
+
+    // First activity → idle arrives, 500ms timer starts.
+    await send(fleet, 'busy', 'first');
+
+    // Wait less than the debounce, then fire another activity — this should
+    // reset the pending timer before it ever triggers.
+    await wait(200);
+    await send(fleet, 'busy', 'second');
+
+    // If the first idle had triggered /help, we'd see "mock help" text within
+    // ~550ms of the first send.  We wait ~400ms total after the second send
+    // (still less than a fresh debounce window after its own idle, so /help
+    // shouldn't fire from round 2 either).
+    await wait(400);
+
+    const helpArrivals = seen.filter((e) => e.type === 'command-output' && /mock help/.test(e.text ?? ''));
+    expect(helpArrivals.length).toBe(0);
+
+    // Now wait long enough for round 2's idle+debounce to actually elapse;
+    // /help should fire from that one.
+    await wait(500);
+
+    const helpArrivalsAfter = seen.filter((e) => e.type === 'command-output' && /mock help/.test(e.text ?? ''));
+    expect(helpArrivalsAfter.length).toBeGreaterThan(0);
+
+    await fleet.stop();
+  }, 30_000);
+
+  test('recipe schema validation: onIdle.command must be non-empty string', async () => {
+    const { validateRecipe } = await import('../src/recipe.js');
+
+    expect(() => validateRecipe({
+      name: 'x',
+      agent: { systemPrompt: 'x' },
+      modules: { fleet: { children: [{ name: 'a', recipe: 'r.json', onIdle: {} }] } },
+    })).toThrow(/command must be a non-empty string/);
+
+    expect(() => validateRecipe({
+      name: 'x',
+      agent: { systemPrompt: 'x' },
+      modules: { fleet: { children: [{ name: 'a', recipe: 'r.json', onIdle: { command: '/newtopic', debounceMs: -1 } }] } },
+    })).toThrow(/debounceMs must be a positive number/);
+
+    expect(() => validateRecipe({
+      name: 'x',
+      agent: { systemPrompt: 'x' },
+      modules: { fleet: { children: [{ name: 'a', recipe: 'r.json', onIdle: 'oops' }] } },
+    })).toThrow(/onIdle must be an object/);
+
+    expect(() => validateRecipe({
+      name: 'x',
+      agent: { systemPrompt: 'x' },
+      modules: { fleet: { children: [{ name: 'a', recipe: 'r.json', onIdle: { command: '/newtopic', debounceMs: 60000 } }] } },
+    })).not.toThrow();
+  });
+
+  test('pending timer is cleared when child is killed', async () => {
+    const fleet = new FleetModule({
+      childIndexPath: MOCK_CHILD_PATH,
+      autoStart: [{
+        name: 'victim',
+        recipe: 'mock',
+        dataDir: join(tmpDir, 'victim'),
+        onIdle: { command: '/help', debounceMs: 5_000 },  // long enough we'd see a stuck timer
+      }],
+      socketWaitTimeoutMs: 10_000,
+      readyTimeoutMs: 5_000,
+      gracefulShutdownMs: 3_000,
+      sigtermEscalationMs: 1_000,
+    });
+
+    await fleet.start({} as unknown as Parameters<typeof fleet.start>[0]);
+    for (let t = 0; t < 50; t++) {
+      if (fleet.getChildren().get('victim')?.status === 'ready') break;
+      await wait(100);
+    }
+
+    // Arm the timer.
+    await send(fleet, 'victim', 'work');
+    await wait(100);
+
+    // Kill; the timer should get cleared internally and not fire after.
+    await fleet.handleToolCall({ id: 'k', name: 'kill', input: { name: 'victim' } });
+
+    // No observable assertion here beyond "no throws, process tests terminate
+    // cleanly without a dangling setTimeout keeping them open."  The onIdleTimer
+    // is cleared in proc.on('exit') + stop(); if it weren't, bun test would
+    // potentially hang at the end of this test.  We also check the child's
+    // internal timer field reflects cleanup.
+    const child = fleet.getChildren().get('victim');
+    expect(child?.onIdleTimer).toBeNull();
+
+    await fleet.stop();
+  }, 15_000);
+});

--- a/test/mock-headless-child.ts
+++ b/test/mock-headless-child.ts
@@ -121,6 +121,12 @@ function dispatch(msg: Record<string, unknown>): void {
       emit({ type: 'command-output', text: '  no real commands here', style: 'system' });
       return;
     }
+    // Echo any received command so tests can observe arrival of auto-
+    // dispatched slash commands (onIdle hook target).  We deliberately
+    // emit command-output rather than silently absorbing so the arrival
+    // is externally observable; the text carries the full command for
+    // matching in tests.
+    emit({ type: 'command-output', text: `mock-received-command: ${cmd}`, style: 'system' });
   }
 }
 


### PR DESCRIPTION
## Summary

Adds a per-child `onIdle` hook to `FleetModule` that auto-dispatches a slash command when a child's `lifecycle:idle` event persists for a configured debounce period. Use case that drove this: ticket-driven miners in the Knowledge Mining Triumvirate — between tickets, the miner's context should compress (`/newtopic`) automatically so the next ticket starts with a fresh head window, without needing the conductor agent to watch idle events and dispatch manually.

## What's in here

### `FleetModule.onIdle`
```jsonc
"children": [{
  "name": "miner",
  "recipe": "recipes/knowledge-miner.json",
  "onIdle": {
    "command": "/newtopic",
    "debounceMs": 120000
  }
}]
```

Semantics:
- On `lifecycle:idle` from the child → arm a `debounceMs` timer.
- Any subsequent event from the child → cancel the pending timer.
- Timer elapses → dispatch the configured slash command via the same `sendToChild` path `fleet--command` uses.
- Re-arms on every subsequent idle, so the hook fires once per sustained-idle period rather than on every between-round transient idle.
- Default `debounceMs`: 120_000 (2 minutes).

### Infinite-loop guard in the child runtime

Naively, `/newtopic` dispatch would create a loop: auto-`/newtopic` → `/newtopic` runs an LLM summary → child goes idle again → another `lifecycle:idle` fires → timer arms → another `/newtopic`, and so on over a near-empty head.

Fix: the child's headless runtime resets its idle-tracking state (`hadAtLeastOneInference`, `idleSince`, `idleEmitted`, `currentSpeech`) whenever `/newtopic` runs. No fresh `inference:started` = no new `lifecycle:idle`. The reset is wired through `dispatchCommand` in `src/headless.ts` so it covers both onIdle-dispatched and operator-typed `/newtopic`.

This also composes cleanly with the pre-existing invariant that boot-and-sit-idle doesn't emit `lifecycle:idle` until a real inference has happened once — so the hook can't fire on a brand-new child sitting quietly waiting for its first ticket.

### Triumvirate recipe wiring

`recipes/triumvirate.json` now wires `onIdle: { command: "/newtopic", debounceMs: 120000 }` on the miner as the demonstrator. The clerk and reviewer don't need it — the clerk's work is event-bounded (reply-or-ticket, then done), the reviewer's is file-driven (one pass per new library doc, then done). The miner is the only child whose task spans many inferences and benefits from explicit compression between tasks.

### Recipe schema

`RecipeFleetChild.onIdle?: { command, debounceMs? }` added to the tracked types. Validation enforces:
- `onIdle` is an object (if present)
- `command` is a non-empty string
- `debounceMs` is a positive number (if present)

Out-of-shape configs fail at recipe load, not at runtime.

### Timer-lifetime hygiene

- `proc.on('exit')` clears any pending `onIdleTimer` (no dangling setTimeout after the child dies).
- `FleetModule.stop()` iterates and clears before kill broadcast.
- `killChild()` path is covered by the `exit` handler.
- Adopt-on-restart (parent re-launch reattaching to a live child) sets `onIdle: null` on the reconstructed orphan — the original timer state isn't meaningful after reattach; first real idle post-reattach re-arms fresh against the new parent's config.

### `.gitignore`

Added `knowledge-requests/` — runtime ticket directory (clerk writes here), parallel to existing `output/` and `review-output/`. Noticed during local triumvirate testing; not strictly part of the onIdle feature but tightly coupled operationally.

## Test plan

92 tests total (4 new), all passing.

### New tests — `test/fleet-onidle.test.ts`

- [x] **fires configured command after sustained idle** — launch mock child with `onIdle: { command: "/help", debounceMs: 300 }`, send a text to drive an inference + idle, wait past the debounce, observe `/help` arrived at the child (mock echoes received commands as `command-output` events).
- [x] **activity during debounce cancels + re-arms** — launch with debounce 500ms, send first text (armed), wait 200ms, send second text (should cancel pending, re-arm on new idle), wait 400ms (< debounce from new arm → no dispatch yet), assert no `/help` arrived, wait another 500ms (past the new arm's debounce), assert `/help` did arrive.
- [x] **schema validation** — `validateRecipe` rejects non-object `onIdle`, missing/empty `command`, non-positive `debounceMs`; accepts well-formed.
- [x] **pending timer cleared on child kill** — arm a 5-second timer, send the `kill` tool, assert `child.onIdleTimer === null` (test harness would hang waiting for orphaned `setTimeout` otherwise).

### Mock child

`test/mock-headless-child.ts` extended to echo any unrecognized slash command as `command-output: mock-received-command: <cmd>` so the test can observe onIdle arrivals without needing the command to be meaningfully implemented in the mock.

## Manual verification for operators

After merging, update the triumvirate setup:

1. First run of the day, miner gets woken by a new ticket in `knowledge-requests/`.
2. Miner does its mining, writes docs to `library-mined/`.
3. Miner goes idle.
4. 2 minutes later (no new tickets) → `/fleet peek miner` should show a `command-output` line from the auto-dispatched `/newtopic`.
5. Next ticket arrives later that day → miner works with a fresh head window, no carryover from the prior ticket polluting its context.

If the miner's context feels too tight (you want more carryover between similar tickets), bump `debounceMs` on the triumvirate.json entry. If you want to disable the hook entirely for a given run, delete the `onIdle` block from the recipe.

## Out of scope

- Other event hooks (`onCrash`, `onReady`, `onToolFailure`). `onIdle` was the concrete need. If new ones land, the same shape (`{ event: "...", command, debounceMs? }`) would extend cleanly.
- Text-message dispatch (as opposed to slash-command). Deliberate: slash commands are structured and idempotent; text messages trigger inference and would compound the noise problem onIdle is supposed to reduce.
- TUI-path reset of idle tracking. The TUI's internal state machine doesn't use the headless `hadAtLeastOneInference` flag, so nothing to reset there — the equivalent happens naturally via `refreshFromStore` on branch changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)