### PR TITLE
feat(recipe): ${VAR:-default} substitution syntax

### DIFF
--- a/src/recipe.ts
+++ b/src/recipe.ts
@@ -355,31 +355,43 @@ export const DEFAULT_RECIPE: Recipe = {
  * before schema validation, so secrets can live in `.env` (gitignored) while
  * the recipe itself stays commit-safe.
  *
- * Pattern:
- *   - `${FOO}` where `FOO` is `[A-Za-z_][A-Za-z0-9_]*`.
+ * Patterns:
+ *   - `${FOO}` — required.  Throws if FOO is unset (empty string OK).
+ *   - `${FOO:-default}` — optional.  Uses FOO when set and non-empty,
+ *     otherwise the literal default text.  Default may be empty
+ *     (`${FOO:-}`) to mean "use FOO or just empty string, never throw".
+ *   - VAR name: `[A-Za-z_][A-Za-z0-9_]*`.
+ *   - Default text: any chars except `}`.  No nested `${...}` parsing
+ *     and no escape syntax — keep recipes JSON-friendly.
  *   - Multiple occurrences in a single string are all substituted.
  *   - Non-string values (numbers, booleans, nulls) pass through unchanged.
  *   - Arrays and objects are walked recursively.
- *   - A missing env var throws with a message that names the variable and
- *     the recipe source, plus the advice to either set it or delete the
- *     section of the recipe that references it.
  *
  * No escape syntax yet — a literal `${...}` in recipe JSON is not a supported
  * case.  If that becomes needed, add `$$` → `$` unwrapping as a pre-pass.
  */
 export function substituteEnvVars(value: unknown, source: string): unknown {
   if (typeof value === 'string') {
-    return value.replace(/\$\{([A-Za-z_][A-Za-z0-9_]*)\}/g, (_match, name: string) => {
-      const v = process.env[name];
-      if (v === undefined) {
-        throw new Error(
-          `Recipe "${source}" references environment variable \${${name}} which is not set. ` +
-          `Add it to your .env file, or delete the section of the recipe that uses it ` +
-          `(e.g. remove the mcpServers entry for a source you don't have).`,
-        );
-      }
-      return v;
-    });
+    return value.replace(
+      /\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-([^}]*))?\}/g,
+      (_match, name: string, defaultValue: string | undefined) => {
+        const v = process.env[name];
+        if (defaultValue !== undefined) {
+          // ${VAR:-default} — use VAR if set + non-empty, else default.
+          return v !== undefined && v !== '' ? v : defaultValue;
+        }
+        // ${VAR} — required; empty string is allowed if explicitly set.
+        if (v === undefined) {
+          throw new Error(
+            `Recipe "${source}" references environment variable \${${name}} which is not set. ` +
+            `Add it to your .env file, supply a default with \${${name}:-...}, ` +
+            `or delete the section of the recipe that uses it ` +
+            `(e.g. remove the mcpServers entry for a source you don't have).`,
+          );
+        }
+        return v;
+      },
+    );
   }
   if (Array.isArray(value)) {
     return value.map((v) => substituteEnvVars(v, source));

--- a/test/recipe-env.test.ts
+++ b/test/recipe-env.test.ts
@@ -120,4 +120,38 @@ describe('loadRecipe — end-to-end with env substitution', () => {
 
     await expect(loadRecipe(recipePath)).rejects.toThrow(/NEVER_SET/);
   });
+
+  describe('${VAR:-default} syntax', () => {
+    test('uses default when var unset', () => {
+      delete process.env.LATER_SET;
+      expect(substituteEnvVars('${LATER_SET:-fallback}', 't')).toBe('fallback');
+    });
+
+    test('uses default when var is empty string', () => {
+      process.env.EMPTY_VAR = '';
+      expect(substituteEnvVars('${EMPTY_VAR:-fallback}', 't')).toBe('fallback');
+    });
+
+    test('uses var value when set and non-empty', () => {
+      process.env.SET_VAR = 'real-value';
+      expect(substituteEnvVars('${SET_VAR:-fallback}', 't')).toBe('real-value');
+    });
+
+    test('empty default is allowed', () => {
+      delete process.env.OPTIONAL_VAR;
+      expect(substituteEnvVars('${OPTIONAL_VAR:-}', 't')).toBe('');
+    });
+
+    test('does NOT throw on unset var with default', () => {
+      delete process.env.NEVER_SET;
+      expect(() => substituteEnvVars('${NEVER_SET:-default}', 't')).not.toThrow();
+    });
+
+    test('mixed default + required in same string', () => {
+      delete process.env.HOST;
+      delete process.env.PORT;
+      process.env.HOST = 'example.com';
+      expect(substituteEnvVars('${HOST}:${PORT:-21}', 't')).toBe('example.com:21');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Extends `substituteEnvVars` to recognize an optional-with-fallback form alongside the existing required `${VAR}`.

- `${VAR}` — unchanged.  Throws when VAR is unset (empty string still passes through).
- `${VAR:-default}` — uses VAR when set and non-empty, otherwise the literal default text.  Empty default (`${VAR:-}`) is allowed and means "use VAR or empty string, never throw".

Bash-`:-` semantics: empty OR unset triggers the default, matching what most operators expect from shell-style substitution.

## Why

Recipes with sensible defaults for optional knobs were already trying to write `${FTP_PORT:-21}` / `${FTP_SECURE:-false}` (see `lynx-conhost-recipes/knowledge-miner.json`), but the old regex only matched `${VAR}` so the literal `${FTP_PORT:-21}` passed through unmodified.  The MCP server then received a malformed env value, breaking startup.  Build tools (cook) were also blind to these vars because env-collectors mirror the same regex — so operators couldn't even discover them via `cook check`.

## Backward compatibility

Plain `${VAR}` behaviour is preserved exactly:
- `${FOO}` with `FOO=""` still substitutes to `""` (empty string is a valid value).
- `${FOO}` with FOO unset still throws with the existing error message + advice.

## Test plan

- [x] `bun test test/recipe-env.test.ts` — 6 new cases cover unset+default, empty+default, set+default, empty default, no-throw guarantee, and a `${HOST}:${PORT:-21}` mixed-form string.  Existing `${VAR}` tests untouched.
- [x] `npx tsc --noEmit` clean.

## Downstream

Build tools that mirror `substituteEnvVars` (e.g. connectome-cook's env-collector) need to update their regex to `/\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-([^}]*))?\}/g` and decide how to surface the default.  Cook's matching commit is at https://github.com/Tengro/connectome-cook/commit/b28a12b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)