### PR TITLE
fix(fleet): forward socketWaitTimeoutMs/readyTimeoutMs/etc from recipe

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -163,6 +163,10 @@ async function createFramework(membrane: Membrane, storePath: string, recipe: Re
     }
     if (fleetCfg.allowedRecipes !== undefined) fleetModuleConfig.allowedRecipes = fleetCfg.allowedRecipes;
     if (fleetCfg.defaultSubscription !== undefined) fleetModuleConfig.defaultSubscription = fleetCfg.defaultSubscription;
+    if (fleetCfg.socketWaitTimeoutMs !== undefined) fleetModuleConfig.socketWaitTimeoutMs = fleetCfg.socketWaitTimeoutMs;
+    if (fleetCfg.readyTimeoutMs !== undefined) fleetModuleConfig.readyTimeoutMs = fleetCfg.readyTimeoutMs;
+    if (fleetCfg.gracefulShutdownMs !== undefined) fleetModuleConfig.gracefulShutdownMs = fleetCfg.gracefulShutdownMs;
+    if (fleetCfg.sigtermEscalationMs !== undefined) fleetModuleConfig.sigtermEscalationMs = fleetCfg.sigtermEscalationMs;
     moduleInstances.push(new FleetModule(fleetModuleConfig));
   }
 

--- a/src/recipe.ts
+++ b/src/recipe.ts
@@ -280,6 +280,15 @@ export interface RecipeFleet {
   allowedRecipes?: string[];
   /** Default subscription sent to each child at handshake if they don't specify their own. */
   defaultSubscription?: string[];
+  /**
+   * Spawn-readiness timeouts forwarded to FleetModule.  Bump these when a
+   * child's startup work (heavy MCP servers, large state load) won't fit
+   * inside the FleetModule defaults (15s / 10s / 10s / 5s respectively).
+   */
+  socketWaitTimeoutMs?: number;
+  readyTimeoutMs?: number;
+  gracefulShutdownMs?: number;
+  sigtermEscalationMs?: number;
 }
 
 export interface RecipeFleetChild {
@@ -719,6 +728,11 @@ export function validateRecipe(raw: unknown): Recipe {
       if (fleet.defaultSubscription !== undefined) {
         if (!Array.isArray(fleet.defaultSubscription) || !fleet.defaultSubscription.every((s) => typeof s === 'string')) {
           throw new Error('fleet.defaultSubscription must be an array of strings');
+        }
+      }
+      for (const k of ['socketWaitTimeoutMs', 'readyTimeoutMs', 'gracefulShutdownMs', 'sigtermEscalationMs'] as const) {
+        if (fleet[k] !== undefined && (typeof fleet[k] !== 'number' || (fleet[k] as number) < 0)) {
+          throw new Error(`fleet.${k} must be a non-negative number`);
         }
       }
     }


### PR DESCRIPTION
## Summary

The recipe-to-`FleetModuleConfig` mapper in `src/index.ts` had an explicit allow-list that only forwarded `children`, `allowedRecipes`, and `defaultSubscription`. The four timeout fields declared on `FleetModuleConfig` (`socketWaitTimeoutMs`, `readyTimeoutMs`, `gracefulShutdownMs`, `sigtermEscalationMs`) were silently dropped — recipe-level overrides had no effect, defaults always applied.

## Why this matters

Surfaced by a Triumvirate miner deadlock in production:

- Data-lineage's MCP server takes ~13s to load its KDB+/Q graph (`226 projects, 6444 columns, 172 hosts, 781 instances`) at module import.
- With the default `socketWaitTimeoutMs: 15_000`, the conductor SIGKILLed the miner before its IPC socket could appear (~15.1s consistent death, `eventCount: 0`, `exitReason: SIGKILL`).
- Bumping `socketWaitTimeoutMs: 60000` in the recipe was a no-op until this fix — the field never reached `FleetModule`.
- Once forwarded, the miner reaches headless in ~20s as expected.

## Changes

- `src/recipe.ts`: adds the four optional fields to `RecipeFleet`, plus validation that they're non-negative numbers.
- `src/index.ts`: forwards each of the four fields to `FleetModuleConfig` if defined on the recipe.

Backwards-compatible — all four are optional, defaults preserved.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] Hot-patched the equivalent change in a running production conductor; miner that had been deadlocked for 6 days reached headless in 20.3s on first restart with `socketWaitTimeoutMs: 60000` in the recipe
- [ ] Unit test for validation (deferred — happy to add if maintainers prefer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)