### PR TITLE
feat(host,tui): strategy config passthrough + status-line memory stats

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -299,13 +299,32 @@ async function createFramework(membrane: Membrane, storePath: string, recipe: Re
   // -- Build strategy --
   const strategyConfig = recipe.agent.strategy;
   const strategyType = strategyConfig?.type ?? 'autobiographical';
-  const autobiographicalOpts = {
+  const autobiographicalOpts: Record<string, unknown> = {
     headWindowTokens: strategyConfig?.headWindowTokens ?? 4000,
     recentWindowTokens: strategyConfig?.recentWindowTokens ?? 30000,
     compressionModel: strategyConfig?.compressionModel ?? model,
     autoTickOnNewMessage: true,
     maxMessageTokens: strategyConfig?.maxMessageTokens ?? 10000,
   };
+  // Pass-through additional fields if the recipe sets them (kept narrow:
+  // only fields the recipe schema actually accepts get forwarded).
+  for (const key of [
+    'enforceBudget',
+    'maxSpeculativeL1s',
+    'positionedRecallPairs',
+    'recallHeaderTemplate',
+    'targetChunkTokens',
+    'mergeThreshold',
+    'summaryTargetTokens',
+    'l1BudgetTokens',
+    'l2BudgetTokens',
+    'l3BudgetTokens',
+    'toolResultMaxLastN',
+    'toolUseInputMaxTokens',
+  ] as const) {
+    const v = (strategyConfig as Record<string, unknown> | undefined)?.[key];
+    if (v !== undefined) autobiographicalOpts[key] = v;
+  }
   const strategy = strategyType === 'passthrough'
     ? new PassthroughStrategy()
     : strategyType === 'frontdesk'

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ import { FrontdeskStrategy } from './strategies/frontdesk-strategy.js';
 import { SubagentModule } from './modules/subagent-module.js';
 import { LessonsModule } from './modules/lessons-module.js';
 import { RetrievalModule } from './modules/retrieval-module.js';
-import type { RecipeWorkspaceMount } from './recipe.js';
+import type { RecipeWorkspaceMount, RecipeStrategy } from './recipe.js';
 import { TuiModule } from './modules/tui-module.js';
 import { TimeModule } from './modules/time-module.js';
 import { FleetModule, type FleetModuleConfig } from './modules/fleet-module.js';
@@ -297,6 +297,14 @@ async function createFramework(membrane: Membrane, storePath: string, recipe: Re
   // No server augmentation needed — gate is wired via FrameworkConfig.gate
 
   // -- Build strategy --
+  //
+  // Build the options object with typed property access — no
+  // `Record<string, unknown>` cast on `strategyConfig`. Every field we
+  // forward is declared on `RecipeStrategy` (see recipe.ts); a typo in a
+  // recipe (e.g. `l1BudgetTokes`) now fails at recipe validation rather
+  // than silently being a no-op at strategy construction. AutobiographicalStrategy
+  // and FrontdeskStrategy share this option bag today; if strategy-specific
+  // fields are ever added, this should split into per-strategy types.
   const strategyConfig = recipe.agent.strategy;
   const strategyType = strategyConfig?.type ?? 'autobiographical';
   const autobiographicalOpts: Record<string, unknown> = {
@@ -306,9 +314,10 @@ async function createFramework(membrane: Membrane, storePath: string, recipe: Re
     autoTickOnNewMessage: true,
     maxMessageTokens: strategyConfig?.maxMessageTokens ?? 10000,
   };
-  // Pass-through additional fields if the recipe sets them (kept narrow:
-  // only fields the recipe schema actually accepts get forwarded).
-  for (const key of [
+  // Forward optional tuning fields when set. The key list is typed
+  // against `RecipeStrategy`, so an unknown field name is a compile
+  // error here rather than a silent no-op at runtime.
+  const passthroughKeys: ReadonlyArray<keyof RecipeStrategy> = [
     'enforceBudget',
     'maxSpeculativeL1s',
     'positionedRecallPairs',
@@ -321,8 +330,9 @@ async function createFramework(membrane: Membrane, storePath: string, recipe: Re
     'l3BudgetTokens',
     'toolResultMaxLastN',
     'toolUseInputMaxTokens',
-  ] as const) {
-    const v = (strategyConfig as Record<string, unknown> | undefined)?.[key];
+  ];
+  for (const key of passthroughKeys) {
+    const v = strategyConfig?.[key];
     if (v !== undefined) autobiographicalOpts[key] = v;
   }
   const strategy = strategyType === 'passthrough'

--- a/src/recipe.ts
+++ b/src/recipe.ts
@@ -20,10 +20,30 @@ import { dirname, isAbsolute, resolve } from 'node:path';
 
 export interface RecipeStrategy {
   type: 'autobiographical' | 'passthrough' | 'frontdesk';
+  // Core window/compression sizing
   headWindowTokens?: number;
   recentWindowTokens?: number;
   compressionModel?: string;
   maxMessageTokens?: number;
+  // Compression/merge tuning passed through to the underlying
+  // autobiographical strategy (and frontdesk, which extends it).
+  // Declared here so a typo in a recipe (e.g. `l1BudgetTokes`) fails
+  // at recipe validation rather than silently defaulting at strategy
+  // construction. Keep in sync with `AutobiographicalConfig` in
+  // @animalabs/context-manager; this interface is the source of truth
+  // for what the recipe loader accepts under `agent.strategy`.
+  enforceBudget?: boolean;
+  maxSpeculativeL1s?: number;
+  positionedRecallPairs?: boolean;
+  recallHeaderTemplate?: string;
+  targetChunkTokens?: number;
+  mergeThreshold?: number;
+  summaryTargetTokens?: number;
+  l1BudgetTokens?: number;
+  l2BudgetTokens?: number;
+  l3BudgetTokens?: number;
+  toolResultMaxLastN?: number;
+  toolUseInputMaxTokens?: number;
 }
 
 export interface RecipeAgent {

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -341,7 +341,18 @@ export async function runTui(app: AppContext): Promise<void> {
 
   function updateStatus() {
     statusLeft.content = formatStatusLeft(state, SPINNER[spinnerFrame], streamOutputTokens);
-    statusRight.content = formatTokens(state.tokens, verboseChat);
+    statusRight.content = formatTokens(state.tokens, verboseChat) + formatMemStats(getRootCM());
+  }
+
+  /** Best-effort handle to the root agent's ContextManager, for stats queries. */
+  function getRootCM(): { getRenderStats?: () => unknown; getStrategy?: () => { getStats?: () => unknown } } | null {
+    try {
+      const ag = app.framework.getAgent(rootAgentName);
+      if (!ag) return null;
+      return ag.getContextManager() as any;
+    } catch {
+      return null;
+    }
   }
 
   function beginStream() {
@@ -1181,12 +1192,22 @@ export async function runTui(app: AppContext): Promise<void> {
 
       case 'inference:usage': {
         // Per-round usage updates during yielding streams
-        const roundUsage = event.tokenUsage as { input?: number; output?: number } | undefined;
+        const roundUsage = event.tokenUsage as {
+          input?: number; output?: number; cacheCreation?: number; cacheRead?: number;
+        } | undefined;
         if (agent && roundUsage?.input) {
           agentContextTokens.set(agent, roundUsage.input);
           const short = agent.replace(/^(spawn|fork)-/, '').replace(/-\d+$/, '').replace(/-retry\d+$/, '');
           if (short !== agent) agentContextTokens.set(short, roundUsage.input);
           if (state.viewMode === 'fleet') updateFleetView();
+        }
+        // Update root-agent token state for status-line display.
+        if (agent === rootAgentName && roundUsage) {
+          if (roundUsage.input !== undefined) state.tokens.input = roundUsage.input;
+          if (roundUsage.output !== undefined) state.tokens.output = (state.tokens.output ?? 0) + (roundUsage.output ?? 0);
+          if (roundUsage.cacheRead !== undefined) state.tokens.cacheRead = roundUsage.cacheRead;
+          if (roundUsage.cacheCreation !== undefined) state.tokens.cacheWrite = roundUsage.cacheCreation;
+          updateStatus();
         }
         break;
       }
@@ -1995,10 +2016,77 @@ function formatTokens(tokens: TokenUsage, verbose: boolean): string {
   const total = tokens.input + tokens.output;
   if (total > 0) {
     let s = `${fmtTokens(tokens.input)}in ${fmtTokens(tokens.output)}out`;
-    if (tokens.cacheRead > 0) s += ` ${fmtTokens(tokens.cacheRead)}cache`;
+    if (tokens.cacheRead > 0) s += ` ${fmtTokens(tokens.cacheRead)}hit`;
+    if (tokens.cacheWrite > 0) s += ` ${fmtTokens(tokens.cacheWrite)}write`;
     parts.push(s);
   }
 
   parts.push(verbose ? 'C-v:terse' : 'C-v:verbose');
   return parts.join('  ');
+}
+
+/**
+ * Render strategy memory stats for the status line. Prefers the richer
+ * `getRenderStats()` (tail size + per-level token sums) and falls back to
+ * `getStats()` if only that's available.
+ *
+ * Output shape: `mem: L1=5/9k L2=1/2k tail=770/495k (3 pending, 1 merge)`
+ *   - L1=count/totalTokens (compact e.g. 9k = 9000)
+ *   - tail=messageCount/tokenCount
+ */
+function formatMemStats(
+  cm: { getRenderStats?: () => unknown; getStrategy?: () => { getStats?: () => unknown } } | null,
+): string {
+  if (!cm) return '';
+  try {
+    if (typeof cm.getRenderStats === 'function') {
+      const r = cm.getRenderStats() as {
+        head?: { messages: number; tokens: number };
+        tail?: { messages: number; tokens: number };
+        summaries?: {
+          l1?: { count: number; tokens: number };
+          l2?: { count: number; tokens: number };
+          l3?: { count: number; tokens: number };
+        };
+        pending?: { chunks: number; merges: number };
+      } | null;
+      if (!r) return '';
+      const sumLevel = (lvl?: { count: number; tokens: number }) =>
+        lvl && lvl.count > 0 ? `${lvl.count}/${fmtTokens(lvl.tokens)}t` : null;
+      const parts: string[] = [];
+      const l1 = sumLevel(r.summaries?.l1);
+      const l2 = sumLevel(r.summaries?.l2);
+      const l3 = sumLevel(r.summaries?.l3);
+      if (l1) parts.push(`L1=${l1}`);
+      if (l2) parts.push(`L2=${l2}`);
+      if (l3) parts.push(`L3=${l3}`);
+      if (r.tail && r.tail.messages > 0) parts.push(`tail=${r.tail.messages}msg/${fmtTokens(r.tail.tokens)}t`);
+      const tags: string[] = [];
+      if (r.pending && r.pending.chunks > 0) tags.push(`${r.pending.chunks} pending`);
+      if (r.pending && r.pending.merges > 0) tags.push(`${r.pending.merges} merge`);
+      if (parts.length === 0 && tags.length === 0) return '';
+      return `  mem: ${parts.join(' ')}${tags.length > 0 ? ` (${tags.join(', ')})` : ''}`;
+    }
+    // Fallback to old getStats
+    const strategy = cm.getStrategy?.();
+    if (!strategy?.getStats) return '';
+    const s = strategy.getStats() as {
+      l1?: number; l2?: number; l3?: number;
+      pendingMerges?: number;
+      chunksTotal?: number; chunksCompressed?: number;
+    };
+    const l1 = s.l1 ?? 0;
+    const l2 = s.l2 ?? 0;
+    const l3 = s.l3 ?? 0;
+    if (l1 === 0 && l2 === 0 && l3 === 0) return '';
+    const pending = (s.chunksTotal ?? 0) - (s.chunksCompressed ?? 0);
+    let out = `  mem: L1=${l1}`;
+    if (l2 > 0) out += ` L2=${l2}`;
+    if (l3 > 0) out += ` L3=${l3}`;
+    if (pending > 0) out += ` (${pending} pending)`;
+    if ((s.pendingMerges ?? 0) > 0) out += ` (${s.pendingMerges} merge)`;
+    return out;
+  } catch {
+    return '';
+  }
 }


### PR DESCRIPTION
## Summary

Two related observability + configurability additions, both downstream of [anima-research/context-manager#15](https://github.com/anima-research/context-manager/pull/15) (autobio audit-gaps).

### 1. Strategy config passthrough (\`src/index.ts\`)

The recipe's \`agent.strategy.{...}\` block now forwards 12 additional fields:

\`\`\`
enforceBudget, maxSpeculativeL1s, positionedRecallPairs, recallHeaderTemplate,
targetChunkTokens, mergeThreshold, summaryTargetTokens,
l1BudgetTokens, l2BudgetTokens, l3BudgetTokens,
toolResultMaxLastN, toolUseInputMaxTokens
\`\`\`

These all landed in context-manager via #15. Without passthrough, recipe authors couldn't actually use them — they'd silently be ignored at instantiation. Specifically blocks Lena's recipe, which relies on \`enforceBudget: false\` (no truncation, surface API-side overage instead) and \`maxSpeculativeL1s: 36\` (cap for the new background drain).

### 2. Status-line memory stats (\`src/tui.ts\`)

The TUI status line now shows live memory state when the active strategy implements \`getRenderStats()\`:

\`\`\`
12.3kin 2.1kout 8.5khit 200write  C-v:terse  mem: L1=8/16kt L2=1/2kt tail=770msg/495kt (4 pending, 1 merge)
\`\`\`

- **Per-level**: count + total tokens of visible (un-merged) summaries
- **tail**: message count + token estimate of the recent uncompressed window
- **pending**: chunks queued for compression / merges queued
- **cache**: \`hit\` = read tokens, \`write\` = creation tokens (now populated from \`inference:usage\` events; previously the \`TokenUsage\` fields existed but weren't wired)

Falls back to the older \`getStats()\`-only display for strategies that don't expose \`getRenderStats\` yet.

## Test plan

- [x] Verified live with Lena: status line updates per turn, shows L1 count growing, tail size shrinking as chunks form, eventually shows L2 after merge fires
- [x] Cache fields populate after first inference (`inference:usage` event handler now reads \`cacheRead\` / \`cacheCreation\`)
- [x] No regressions in existing tests (203/205 — same 2 pre-existing failures: FleetTreeAggregator e2e + CWD-relative allowlist)

## Companion PRs

Depends on [anima-research/context-manager#15](https://github.com/anima-research/context-manager/pull/15) for \`getRenderStats()\` + the new strategy config fields. Merge after that lands and a new context-manager publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)