### PR TITLE
Bump chronicle + context-manager to pick up assigning-append fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   },
   "dependencies": {
     "@animalabs/agent-framework": "^0.5.3",
-    "@animalabs/context-manager": "^0.5.0",
-    "@animalabs/chronicle": "^0.1.1",
+    "@animalabs/context-manager": "^0.5.2",
+    "@animalabs/chronicle": "^0.2.0",
     "@animalabs/membrane": "^0.5.46",
     "@opentui/core": "^0.1.82"
   },


### PR DESCRIPTION
## Summary

Bumps:
- \`@animalabs/chronicle\` ^0.1.1 → ^0.2.0
- \`@animalabs/context-manager\` ^0.5.0 → ^0.5.2

No conhost code changes — the fix is consumed transparently through context-manager.

## Why

A claude.ai export of a single ~2 Mtok conversation ballooned the resulting Chronicle store's \`records.log\` to **2.6 GiB**. Root cause was in \`MessageStore.append\`, which wrote two chronicle ops per message (Append + Edit to patch in the assigned id/sequence), and the Edit forced every threshold-triggered snapshot to be a Full snapshot of the entire messages array — O(N²) total snapshot bytes.

The upstream fix is structural: chronicle now offers \`appendToStateJsonAssigning\`, which splices the assigned id/sequence into the payload server-side under the write lock, so MessageStore writes one record per message. No Edit, no Full-snapshot promotion.

## Dependencies (must merge in order)

1. https://github.com/anima-research/chronicle/pull/8 — add \`appendToStateJsonAssigning\` + \`setAutoSnapshot\` toggle to chronicle (publish as 0.2.0).
2. https://github.com/anima-research/context-manager/pull/21 — migrate \`MessageStore.append\` to use the new method (publish as 0.5.2).
3. **This PR** — bump the conhost deps.

If maintainers prefer different version numbers for chronicle / CM than what's assumed here (^0.2.0 / ^0.5.2), the dep ranges in \`package.json\` need to follow.

## Verification (against local linked sources, before publish)

Synthetic 1500-message × 4 KB bulk import via the conhost importer path:

| Path           | records.log | Wall time |
| -------------- | ----------- | --------- |
| Before fix     | 763 MiB     | 7954 ms   |
| After fix      | 70 MiB      | 368 ms    |

10.9× smaller, 21× faster.

## Test plan

- [ ] \`bun install\` resolves the new ranges once upstream is published
- [ ] \`scripts/import-claudeai-export.ts\` against an existing export still produces a working session (no API change in CM)
- [ ] Open an imported session in the TUI and verify messages render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)