### PR TITLE
fix(warmup,host): identity handoff from import → warmup → live agent

### DIFF
--- a/docs/claudeai-evacuation.md
+++ b/docs/claudeai-evacuation.md
@@ -85,7 +85,7 @@ Useful flags:
 | Flag | Purpose |
 |---|---|
 | `--out <dir>` | Conhost data dir (default `./data`) |
-| `--agent <name>` | Participant name for assistant turns (default `agent` — **must equal the recipe's `agent.name`** or the API request builder will assign the wrong role) |
+| `--agent <name>` | Participant name for assistant turns (default `Claude`). The chosen value is recorded in the import-source sidecar; warmup and the bundled `claude-export-revive.json` recipe pick it up automatically. Override only if you have a reason to depart from `Claude`. |
 | `--filter <regex>` | Case-insensitive name regex; combines with the interactive picker |
 | `--dry-run` | Parse + report, don't write |
 | `--no-interactive` | Skip the picker; import everything (after `--filter`) |
@@ -148,7 +148,7 @@ Useful warmup flags:
 |---|---|
 | `--data-dir <dir>` | Conhost data dir (default `./data`) |
 | `--model <id>` | Compression model (default `claude-sonnet-4-5-20250929`) |
-| `--agent <name>` | Participant name for assistant turns (default `agent`). **Must match the value used at import** — otherwise Membrane will map assistant messages to role `user` and the API will reject the compression request. |
+| `--agent <name>` | Participant name for assistant turns. If omitted, read from the session's import-source sidecar; falls back to `Claude` otherwise. Must equal the value the session was imported with — Membrane formats the assistant role by string-comparing message participants against this name. |
 | `--max-spend <usd>` | Soft cap — halts gracefully when running cost hits the cap. Re-run to resume. |
 | `--l1-budget <n>`, `--l2-budget <n>`, `--l3-budget <n>` | Autobio tier token budgets |
 | `--merge-threshold <n>` | L1→L2 / L2→L3 merge threshold (default 6) |
@@ -205,7 +205,7 @@ No evacuator, no warmup. The canned `claude-export-revive.json` is sufficient fo
 - **Images without inline bytes are placeholder-only.** The export records `file_uuid` for images but doesn't include the bytes. Recovering them requires a separate cookie-authed fetch against claude.ai, which is not yet built.
 - **Thinking blocks are not native thinking blocks at replay.** They're wrapped text. The model can see and read its prior reasoning, but it's no longer thinking-flagged content for the API. New thinking happens normally in its own private channel.
 - **Tool calls to web-only tools are inert.** They stay visible as evidence of past activity but the tools themselves aren't registered. The transplant addendum tells the model this explicitly.
-- **The `--agent` name matters.** If you imported with a non-default `--agent <name>`, your recipe's `agent.name` must match exactly, or the API request builder will tag assistant turns with `role: user`.
+- **The `--agent` name matters, but the sidecar carries it forward.** The importer records the agent name in `<id>.import-source.json`; warmup reads it back, and the bundled revival recipe pins `agent.name: "Claude"` to match the default. If you override at import time (`--agent SomeOther`), update your recipe's `agent.name` to match, or warmup and the live agent will end up writing summaries to different Chronicle namespaces and the agent will appear amnesiac on first open.
 - **`memories.json` is optional.** If the export was made before persistent memories existed, or the user never enabled them, the file is absent or empty and the evacuator simply skips step 5.
 - **The leaked-prompt map drifts.** `MODEL_PROMPT_SOURCES` in `evacuator.ts` points to third-party githubusercontent URLs that may move. If a fetch fails, the dialog falls back to letting you paste a URL or local path.
 

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   },
   "dependencies": {
     "@animalabs/agent-framework": "^0.5.3",
-    "@animalabs/context-manager": "^0.5.0",
-    "@animalabs/chronicle": "^0.1.1",
+    "@animalabs/context-manager": "^0.5.2",
+    "@animalabs/chronicle": "^0.2.0",
     "@animalabs/membrane": "^0.5.46",
     "@opentui/core": "^0.1.82"
   },

--- a/recipes/claude-export-revive.json
+++ b/recipes/claude-export-revive.json
@@ -1,7 +1,7 @@
 {
   "name": "Continued from claude.ai",
   "agent": {
-    "name": "agent",
+    "name": "Claude",
     "model": "claude-sonnet-4-5-20250929",
     "maxTokens": 16384,
     "thinking": {

--- a/scripts/import-claudeai-export.ts
+++ b/scripts/import-claudeai-export.ts
@@ -506,6 +506,12 @@ async function importConversation(
         summary: conv.summary ?? null,
         createdAt: conv.created_at,
         updatedAt: conv.updated_at,
+        // The participant name assigned to assistant turns at import time.
+        // Recorded here so warmup and conhost can read it back and stay in
+        // sync without depending on a CLI flag the operator might forget.
+        // Bug source: warmup using its own default left summaries in one
+        // strategy namespace while the framework read from another.
+        agentName: opts.agentName,
         originalMessageCount: conv.chat_messages.length,
         importedMessageCount: path.length,
         branched,

--- a/scripts/import-claudeai-export.ts
+++ b/scripts/import-claudeai-export.ts
@@ -37,9 +37,13 @@
  *
  * Options:
  *   --out <dir>       Conhost data dir (default: ./data)
- *   --agent <name>    Participant name for assistant turns (default: "agent",
- *                     matching conhost's default; must equal the recipe's
- *                     `agent.name` for messages to be recognized as assistant)
+ *   --agent <name>    Participant name for assistant turns. Default: "Claude"
+ *                     — the natural choice for claude.ai-derived sessions
+ *                     and what the bundled `claude-export-revive.json`
+ *                     recipe pins `agent.name` to. The chosen value is
+ *                     written into the per-session import-source sidecar,
+ *                     so warmup and conhost can read it back without
+ *                     re-passing the flag.
  *   --filter <regex>  Only import conversations whose name matches (case-insens.)
  *   --dry-run         Parse and report; don't write
  */
@@ -75,7 +79,7 @@ function parseArgs(argv: string[]): Opts {
   }
   const exportDir = resolve(args[0]!);
   let outDir = resolve(process.cwd(), 'data');
-  let agentName = 'agent';
+  let agentName = 'Claude';
   let filter: RegExp | undefined;
   let dryRun = false;
   // Interactive by default if stdin is a TTY; --no-interactive forces off.

--- a/scripts/warmup-session.ts
+++ b/scripts/warmup-session.ts
@@ -24,10 +24,13 @@
  * Options:
  *   --data-dir <dir>   Conhost data dir (default: ./data)
  *   --model <id>       Compression model (default: claude-sonnet-4-5-20250929)
- *   --agent <name>     Participant name for assistant turns (default: "agent",
- *                      matching the importer's default; MUST match the value
- *                      used during import or Membrane will map assistant
- *                      messages to role 'user' and the API will reject them)
+ *   --agent <name>     Participant name for assistant turns. If omitted,
+ *                      read from the import-source sidecar written by
+ *                      `import-claudeai-export.ts`; falls back to "Claude"
+ *                      if neither is available. MUST match the value the
+ *                      session was imported with — Membrane formats the
+ *                      assistant role by string-comparing message
+ *                      participants against this name.
  *   --max-spend <usd>  Soft cap; halt gracefully if cost exceeds this
  *   --l1-budget <n>    L1 budget tokens (passed to autobio)
  *   --l2-budget <n>    Likewise L2
@@ -69,7 +72,14 @@ interface Opts {
   sessionRef: string;
   dataDir: string;
   model: string;
-  agentName: string;
+  /**
+   * Explicit `--agent <name>` from the CLI. When absent (undefined), the
+   * runner falls back to the session's import-source sidecar, then to
+   * "Claude". Distinguishing "not given" from "given as 'agent'" lets the
+   * sidecar (the durable record of what the importer wrote) override a
+   * stale default without overriding a deliberate operator choice.
+   */
+  agentName?: string;
   maxSpend: number | null;
   l1Budget?: number;
   l2Budget?: number;
@@ -89,7 +99,6 @@ function parseArgs(argv: string[]): Opts {
     sessionRef: args[0]!,
     dataDir: resolve(process.cwd(), 'data'),
     model: 'claude-sonnet-4-5-20250929',
-    agentName: 'agent',
     maxSpend: null,
   };
   for (let i = 1; i < args.length; i++) {
@@ -184,8 +193,18 @@ async function main() {
   }
   const storePath = sessionMgr.getStorePath(session.id);
 
+  // Resolve agent identity: explicit --agent wins; otherwise consult the
+  // import-source sidecar (the importer recorded the name it used for
+  // assistant turns); otherwise fall back to "Claude" — the natural default
+  // for claude.ai-derived sessions, which is the only data source the
+  // warmup script currently has.
+  const importSource = sessionMgr.getImportSource(session.id);
+  const agentName = opts.agentName ?? importSource?.agentName ?? 'Claude';
+
   console.error(`Warming up session "${session.name}" (${session.id})`);
   console.error(`Store: ${storePath}`);
+  console.error(`Agent: ${agentName}` +
+    (opts.agentName ? ' (--agent)' : importSource?.agentName ? ' (sidecar)' : ' (default)'));
   console.error(`Model: ${opts.model}`);
   if (opts.maxSpend !== null) console.error(`Max spend: $${opts.maxSpend.toFixed(2)}`);
 
@@ -194,11 +213,11 @@ async function main() {
   const spend: Spend = { inputTokens: 0, outputTokens: 0, cost: 0 };
   const adapter = new AnthropicAdapter({ apiKey: process.env.ANTHROPIC_API_KEY });
   const membrane = new Membrane(adapter, {
-    // Sessions imported by import-claudeai-export.ts store assistant turns
-    // under participant `agentName`. Membrane's default assistantParticipant
-    // is 'Claude'; without this override every assistant message would map
-    // to role 'user' and the API would reject tool_use blocks.
-    assistantParticipant: opts.agentName,
+    // Imported sessions store assistant turns under participant `agentName`.
+    // Membrane's default assistantParticipant is 'Claude'; if that disagrees
+    // with the stored participant every assistant message maps to role
+    // 'user' and the API rejects tool_use blocks.
+    assistantParticipant: agentName,
     hooks: {
       afterResponse: (response: NormalizedResponse) => {
         const u = response.usage;
@@ -220,7 +239,7 @@ async function main() {
     // Autobio uses summaryParticipant for the synthetic summary messages it
     // writes back; aligning with the imported agent name keeps the whole
     // conversation under a single participant.
-    summaryParticipant: opts.agentName,
+    summaryParticipant: agentName,
     autoTickOnNewMessage: false, // we drive ticks manually
     ...(opts.l1Budget !== undefined && { l1BudgetTokens: opts.l1Budget }),
     ...(opts.l2Budget !== undefined && { l2BudgetTokens: opts.l2Budget }),

--- a/scripts/warmup-session.ts
+++ b/scripts/warmup-session.ts
@@ -247,10 +247,20 @@ async function main() {
     ...(opts.mergeThreshold !== undefined && { mergeThreshold: opts.mergeThreshold }),
   });
 
+  // Match the namespace `AgentFramework.createAgent` uses for the live
+  // agent (`agents/${config.name}`). Without this, `ContextManager.open`
+  // falls back to `'default'` and warmup writes its summaries to
+  // `default/autobio:summaries` while the live agent reads from
+  // `agents/${agentName}/autobio:summaries` — they never meet, and on
+  // first session open the autobiography appears blank to the agent.
+  // This is *the* bug this branch exists to fix; the surrounding plumbing
+  // (sidecar agentName, defaults, live-Membrane assistantParticipant) is
+  // defense-in-depth around the same handoff.
   const cm = await ContextManager.open({
     store,
     strategy,
     membrane,
+    namespace: `agents/${agentName}`,
   });
 
   // -- Inspect initial state --

--- a/scripts/warmup-session.ts
+++ b/scripts/warmup-session.ts
@@ -44,6 +44,7 @@ import { ContextManager } from '@animalabs/context-manager';
 import { AutobiographicalStrategy } from '@animalabs/agent-framework';
 import { Membrane, AnthropicAdapter, type NormalizedResponse } from '@animalabs/membrane';
 import { SessionManager } from '../src/session-manager.js';
+import { resolveAgentName } from '../src/agent-name.js';
 
 // ---------------------------------------------------------------------------
 // Pricing (approximate, USD per 1M tokens). Used for the --max-spend gate
@@ -193,18 +194,24 @@ async function main() {
   }
   const storePath = sessionMgr.getStorePath(session.id);
 
-  // Resolve agent identity: explicit --agent wins; otherwise consult the
-  // import-source sidecar (the importer recorded the name it used for
-  // assistant turns); otherwise fall back to "Claude" — the natural default
-  // for claude.ai-derived sessions, which is the only data source the
-  // warmup script currently has.
   const importSource = sessionMgr.getImportSource(session.id);
-  const agentName = opts.agentName ?? importSource?.agentName ?? 'Claude';
+  const resolved = resolveAgentName({
+    explicit: opts.agentName,
+    sidecar: importSource?.agentName,
+    default: 'Claude',
+  });
 
   console.error(`Warming up session "${session.name}" (${session.id})`);
   console.error(`Store: ${storePath}`);
-  console.error(`Agent: ${agentName}` +
-    (opts.agentName ? ' (--agent)' : importSource?.agentName ? ' (sidecar)' : ' (default)'));
+  console.error(`Agent: ${resolved.name} (${resolved.source})`);
+  if (resolved.mismatch) {
+    console.error(
+      `WARNING: --agent "${resolved.mismatch.explicit}" overrides sidecar ` +
+      `"${resolved.mismatch.sidecar}". Any summaries previously written under ` +
+      `the sidecar name will be orphaned at agents/${resolved.mismatch.sidecar}/...`,
+    );
+  }
+  const agentName = resolved.name;
   console.error(`Model: ${opts.model}`);
   if (opts.maxSpend !== null) console.error(`Max spend: $${opts.maxSpend.toFixed(2)}`);
 
@@ -247,15 +254,8 @@ async function main() {
     ...(opts.mergeThreshold !== undefined && { mergeThreshold: opts.mergeThreshold }),
   });
 
-  // Match the namespace `AgentFramework.createAgent` uses for the live
-  // agent (`agents/${config.name}`). Without this, `ContextManager.open`
-  // falls back to `'default'` and warmup writes its summaries to
-  // `default/autobio:summaries` while the live agent reads from
-  // `agents/${agentName}/autobio:summaries` — they never meet, and on
-  // first session open the autobiography appears blank to the agent.
-  // This is *the* bug this branch exists to fix; the surrounding plumbing
-  // (sidecar agentName, defaults, live-Membrane assistantParticipant) is
-  // defense-in-depth around the same handoff.
+  // Match AgentFramework.createAgent's namespace (`agents/${config.name}`)
+  // so warmup writes summaries where the live agent reads them.
   const cm = await ContextManager.open({
     store,
     strategy,

--- a/src/agent-name.ts
+++ b/src/agent-name.ts
@@ -1,0 +1,58 @@
+/**
+ * Resolve which participant name an agent should use when several sources
+ * (CLI flag, import-source sidecar, hard-coded default) disagree.
+ *
+ * Centralising this priority is load-bearing: warmup and conhost agree on
+ * the name → strategy state lives at the same Chronicle namespace → the
+ * live agent reads what warmup wrote. The original bug
+ * (`agents/agent/autobio:summaries` empty vs `default/autobio:summaries`
+ * populated) was caused by exactly this resolution drifting between two
+ * scripts that defaulted differently and never compared notes.
+ */
+
+/** Which input the chosen name came from, for log lines and warnings. */
+export type AgentNameSource = 'explicit' | 'sidecar' | 'default';
+
+export interface ResolvedAgentName {
+  name: string;
+  source: AgentNameSource;
+  /**
+   * Set when both `explicit` and `sidecar` were provided and disagree.
+   * Callers should warn on this — the agent will use `explicit` (because
+   * an operator override beats a stored record) but the disagreement
+   * means some other consumer (e.g. warmup that wrote summaries under
+   * `sidecar`) has produced artifacts the live agent can't reach.
+   */
+  mismatch?: { explicit: string; sidecar: string };
+}
+
+/**
+ * Priority: `explicit` (CLI flag or non-default recipe field) > `sidecar`
+ * (per-session record written by the importer) > `default` (caller's
+ * context-specific fallback — `"Claude"` for the claudeai-revival
+ * scripts, `"agent"` for native conhost sessions).
+ *
+ * Empty strings on `explicit` or `sidecar` are treated as absent so an
+ * accidental `--agent ""` or a sidecar with `"agentName": ""` doesn't
+ * silently override the chain.
+ */
+export function resolveAgentName(inputs: {
+  explicit?: string;
+  sidecar?: string;
+  default: string;
+}): ResolvedAgentName {
+  const explicit = nonEmpty(inputs.explicit);
+  const sidecar = nonEmpty(inputs.sidecar);
+
+  const mismatch = explicit && sidecar && explicit !== sidecar
+    ? { explicit, sidecar }
+    : undefined;
+
+  if (explicit) return { name: explicit, source: 'explicit', ...(mismatch && { mismatch }) };
+  if (sidecar) return { name: sidecar, source: 'sidecar' };
+  return { name: inputs.default, source: 'default' };
+}
+
+function nonEmpty(s: string | undefined): string | undefined {
+  return typeof s === 'string' && s.length > 0 ? s : undefined;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ import { ActivityModule } from './modules/activity-module.js';
 import { WebUiModule } from './modules/web-ui-module.js';
 import { loadMcplServers, DEFAULT_CONFIG_PATH } from './mcpl-config.js';
 import { SessionManager } from './session-manager.js';
+import { resolveAgentName } from './agent-name.js';
 import { generateSessionName } from './synesthete.js';
 import {
   type Recipe,
@@ -69,6 +70,13 @@ interface AppContext {
   membrane: Membrane;
   sessionManager: SessionManager;
   recipe: Recipe;
+  /**
+   * Resolved at startup from recipe + active session's import sidecar +
+   * default. Used downstream by createFramework, setupSynesthete, etc. so
+   * the priority chain isn't recomputed (and potentially drifted) at each
+   * call site. Stays stable across `switchSession` — see note in main().
+   */
+  agentName: string;
   branchState: BranchState;
   userMessageCount: number;
 
@@ -115,8 +123,12 @@ async function resolveRecipe(): Promise<Recipe> {
 // Framework factory
 // ---------------------------------------------------------------------------
 
-async function createFramework(membrane: Membrane, storePath: string, recipe: Recipe): Promise<AgentFramework> {
-  const agentName = recipe.agent.name || 'agent';
+async function createFramework(
+  membrane: Membrane,
+  storePath: string,
+  recipe: Recipe,
+  agentName: string,
+): Promise<AgentFramework> {
   const model = config.model || recipe.agent.model || 'claude-opus-4-6';
   const modules = recipe.modules ?? {};
 
@@ -396,7 +408,7 @@ function getWebUiModule(framework: AgentFramework): WebUiModule | null {
 // ---------------------------------------------------------------------------
 
 function setupSynesthete(app: AppContext): void {
-  const agentName = app.recipe.agent.name || 'agent';
+  const agentName = app.agentName;
   const namingExamples = app.recipe.sessionNaming?.examples;
 
   app.framework.onTrace((event) => {
@@ -608,15 +620,6 @@ function countLines(path: string): number {
 
 async function main() {
   const recipe = await resolveRecipe();
-  // Resolve the agent's participant name once here so the Membrane below
-  // can be configured with it. AutobiographicalStrategy's compression
-  // requests don't set `assistantParticipant` themselves — they rely on
-  // the Membrane-level default. Without a name match the formatter maps
-  // every stored assistant turn to role 'user', collapses them into one
-  // multi-block user message, and the API rejects any tool_use blocks
-  // riding along. Symptom: post-warmup compressions silently fail on
-  // every chunk until the user notices the agent has lost continuity.
-  const agentName = recipe.agent.name || 'agent';
 
   const adapter = new AnthropicAdapter({ apiKey: config.apiKey! });
 
@@ -666,14 +669,42 @@ async function main() {
   // of main(), which blocks all other module init for no real benefit.
   if (llmCallCount >= ROTATE_AT) void rotateLlmCallLog();
 
+  // Session management — resolved before Membrane construction so the
+  // active session's import-source sidecar can contribute to agent-name
+  // resolution. Without that, a custom recipe that omits agent.name
+  // combined with a claudeai-imported session falls back to 'agent' on
+  // the live side while the importer + warmup default to 'Claude',
+  // re-creating the namespace fork this branch exists to close.
+  const sessionManager = new SessionManager(config.dataDir);
+  sessionManager.migrateIfNeeded();
+
+  let activeSession = sessionManager.getActiveSession();
+  if (!activeSession) {
+    activeSession = sessionManager.createSession();
+  }
+
+  const resolved = resolveAgentName({
+    explicit: recipe.agent.name,
+    sidecar: sessionManager.getImportSource(activeSession.id)?.agentName,
+    default: 'agent',
+  });
+  if (resolved.mismatch) {
+    console.warn(
+      `[recipe vs sidecar] agent name disagreement: recipe says ` +
+      `"${resolved.mismatch.explicit}", session ${activeSession.id}'s ` +
+      `import sidecar says "${resolved.mismatch.sidecar}". Using the ` +
+      `recipe value; warmup output under "${resolved.mismatch.sidecar}" ` +
+      `will be orphaned at agents/${resolved.mismatch.sidecar}/...`,
+    );
+  }
+  const agentName = resolved.name;
+
   const membrane = new Membrane(adapter, {
     formatter: new NativeFormatter(),
-    // Compression and other internal callers (autobio L1 builds,
-    // executeMerge, etc.) don't set request.assistantParticipant —
-    // they trust the Membrane-level default. Anchor it to the recipe's
-    // agent name so stored assistant turns get role='assistant' even
-    // for non-"Claude" agents (live-session counterpart of the warmup
-    // Bug 3 fix in scripts/warmup-session.ts).
+    // Anchor the assistant role for internal callers that don't set
+    // request.assistantParticipant themselves (autobio compression,
+    // executeMerge). Mismatch here flips stored assistant turns to
+    // role: 'user' and the API rejects tool_use blocks riding along.
     assistantParticipant: agentName,
     hooks: {
       beforeRequest: (normalizedRequest, rawRequest) => {
@@ -697,17 +728,8 @@ async function main() {
     },
   });
 
-  // Session management
-  const sessionManager = new SessionManager(config.dataDir);
-  sessionManager.migrateIfNeeded();
-
-  let activeSession = sessionManager.getActiveSession();
-  if (!activeSession) {
-    activeSession = sessionManager.createSession();
-  }
-
   const storePath = sessionManager.getStorePath(activeSession.id);
-  const framework = await createFramework(membrane, storePath, recipe);
+  const framework = await createFramework(membrane, storePath, recipe, agentName);
 
   // Build app context
   const app: AppContext = {
@@ -715,6 +737,7 @@ async function main() {
     membrane,
     sessionManager,
     recipe,
+    agentName,
     branchState: createBranchState(),
     userMessageCount: 0,
 
@@ -723,7 +746,11 @@ async function main() {
       await this.framework.stop();
       sessionManager.setActiveSession(id);
       const newStorePath = sessionManager.getStorePath(id);
-      this.framework = await createFramework(membrane, newStorePath, recipe);
+      // Note: agentName stays as resolved at startup. A per-session
+      // re-resolution would matter only if recipe.agent.name is absent
+      // AND the user switches between imports that used different
+      // --agent values; not the canonical flow.
+      this.framework = await createFramework(membrane, newStorePath, recipe, this.agentName);
       this.framework.start();
       this.userMessageCount = 0;
       resetBranchState(this.branchState);

--- a/src/index.ts
+++ b/src/index.ts
@@ -608,6 +608,15 @@ function countLines(path: string): number {
 
 async function main() {
   const recipe = await resolveRecipe();
+  // Resolve the agent's participant name once here so the Membrane below
+  // can be configured with it. AutobiographicalStrategy's compression
+  // requests don't set `assistantParticipant` themselves — they rely on
+  // the Membrane-level default. Without a name match the formatter maps
+  // every stored assistant turn to role 'user', collapses them into one
+  // multi-block user message, and the API rejects any tool_use blocks
+  // riding along. Symptom: post-warmup compressions silently fail on
+  // every chunk until the user notices the agent has lost continuity.
+  const agentName = recipe.agent.name || 'agent';
 
   const adapter = new AnthropicAdapter({ apiKey: config.apiKey! });
 
@@ -659,6 +668,13 @@ async function main() {
 
   const membrane = new Membrane(adapter, {
     formatter: new NativeFormatter(),
+    // Compression and other internal callers (autobio L1 builds,
+    // executeMerge, etc.) don't set request.assistantParticipant —
+    // they trust the Membrane-level default. Anchor it to the recipe's
+    // agent name so stored assistant turns get role='assistant' even
+    // for non-"Claude" agents (live-session counterpart of the warmup
+    // Bug 3 fix in scripts/warmup-session.ts).
+    assistantParticipant: agentName,
     hooks: {
       beforeRequest: (normalizedRequest, rawRequest) => {
         const entry = {

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -160,16 +160,28 @@ export class SessionManager {
   /**
    * Read the import-source sidecar for a session, if one exists.
    *
-   * Returns null when the session wasn't created by the importer (no sidecar),
-   * when the file can't be read, or when its contents don't parse as JSON.
-   * The caller gets a partial record — every field is optional, because
-   * sidecars written by older importer versions may be missing newer fields.
+   * Returns null when the session wasn't created by the importer (no
+   * sidecar), when the file can't be read, when its contents don't parse
+   * as JSON, or when the parsed value isn't a plain object (e.g. someone
+   * wrote `null` or an array). The caller gets a partial record — every
+   * field is optional, because sidecars written by older importer
+   * versions may be missing newer fields.
+   *
+   * Field-level types are NOT validated here: this is a filesystem trust
+   * boundary, but field-shape regressions would touch each consumer's
+   * usage site anyway, and the typeof-string guards in
+   * `resolveAgentName`/inline at call sites catch the values that
+   * actually flow through.
    */
   getImportSource(id: string): ImportSource | null {
     const path = join(this.sessionsDir, `${id}.import-source.json`);
     if (!existsSync(path)) return null;
     try {
-      return JSON.parse(readFileSync(path, 'utf-8')) as ImportSource;
+      const parsed: unknown = JSON.parse(readFileSync(path, 'utf-8'));
+      if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+        return null;
+      }
+      return parsed as ImportSource;
     } catch {
       return null;
     }

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -29,6 +29,36 @@ export interface SessionIndex {
   sessions: Record<string, SessionMeta>;
 }
 
+/**
+ * Provenance recorded by the claude.ai importer alongside each session.
+ * Fields are optional because older sessions imported before a given field
+ * existed will simply omit it. Callers reading this should treat every
+ * property as "may be missing" and provide their own fallbacks.
+ *
+ * Lives in `{dataDir}/sessions/{id}.import-source.json`, NOT inside the
+ * Chronicle store directory. Written once by the importer, never updated.
+ */
+export interface ImportSource {
+  conversationUuid?: string;
+  name?: string;
+  summary?: string | null;
+  /** Original `conv.created_at` from the export. */
+  createdAt?: string;
+  /** Original `conv.updated_at` from the export. */
+  updatedAt?: string;
+  /**
+   * Participant name assigned to assistant turns at import time. Warmup and
+   * conhost both read this so they don't disagree about the agent's identity
+   * — disagreement leaves strategy state in the wrong Chronicle namespace
+   * and the live agent silently amnesiac.
+   */
+  agentName?: string;
+  originalMessageCount?: number;
+  importedMessageCount?: number;
+  branched?: boolean;
+  importedAt?: string;
+}
+
 // ---------------------------------------------------------------------------
 // SessionManager
 // ---------------------------------------------------------------------------
@@ -125,6 +155,24 @@ export class SessionManager {
   /** Get the Chronicle store directory path for a session. */
   getStorePath(id: string): string {
     return join(this.sessionsDir, id);
+  }
+
+  /**
+   * Read the import-source sidecar for a session, if one exists.
+   *
+   * Returns null when the session wasn't created by the importer (no sidecar),
+   * when the file can't be read, or when its contents don't parse as JSON.
+   * The caller gets a partial record — every field is optional, because
+   * sidecars written by older importer versions may be missing newer fields.
+   */
+  getImportSource(id: string): ImportSource | null {
+    const path = join(this.sessionsDir, `${id}.import-source.json`);
+    if (!existsSync(path)) return null;
+    try {
+      return JSON.parse(readFileSync(path, 'utf-8')) as ImportSource;
+    } catch {
+      return null;
+    }
   }
 
   /** Get the currently active session, or null if none. */

--- a/test/agent-name.test.ts
+++ b/test/agent-name.test.ts
@@ -1,0 +1,62 @@
+import { describe, test, expect } from 'bun:test';
+import { resolveAgentName } from '../src/agent-name.js';
+
+// The whole point of this helper is to prevent the priority chain from
+// silently drifting (e.g. someone refactors "sidecar wins over CLI"
+// because the sidecar is "the source of truth"). Spell every case out so
+// any reversal lights up here, not in a six-month-later autobiography hole.
+
+describe('resolveAgentName', () => {
+  test('explicit wins over sidecar and default', () => {
+    const r = resolveAgentName({ explicit: 'CLI', sidecar: 'Sidecar', default: 'D' });
+    expect(r.name).toBe('CLI');
+    expect(r.source).toBe('explicit');
+  });
+
+  test('sidecar wins over default when no explicit', () => {
+    const r = resolveAgentName({ sidecar: 'Sidecar', default: 'D' });
+    expect(r.name).toBe('Sidecar');
+    expect(r.source).toBe('sidecar');
+  });
+
+  test('falls back to default when neither explicit nor sidecar', () => {
+    const r = resolveAgentName({ default: 'D' });
+    expect(r.name).toBe('D');
+    expect(r.source).toBe('default');
+  });
+
+  test('empty-string explicit falls through to sidecar', () => {
+    const r = resolveAgentName({ explicit: '', sidecar: 'S', default: 'D' });
+    expect(r.name).toBe('S');
+    expect(r.source).toBe('sidecar');
+  });
+
+  test('empty-string sidecar falls through to default', () => {
+    const r = resolveAgentName({ sidecar: '', default: 'D' });
+    expect(r.name).toBe('D');
+    expect(r.source).toBe('default');
+  });
+
+  test('mismatch reported when explicit and sidecar disagree', () => {
+    // Operator override still wins — but the mismatch is surfaced so the
+    // caller can log a warning. A previous warmup writing summaries under
+    // the sidecar name leaves them orphaned when the live agent runs
+    // under the explicit override; the user should know.
+    const r = resolveAgentName({ explicit: 'CLI', sidecar: 'OldImport', default: 'D' });
+    expect(r.name).toBe('CLI');
+    expect(r.source).toBe('explicit');
+    expect(r.mismatch).toEqual({ explicit: 'CLI', sidecar: 'OldImport' });
+  });
+
+  test('no mismatch reported when explicit equals sidecar', () => {
+    const r = resolveAgentName({ explicit: 'Claude', sidecar: 'Claude', default: 'D' });
+    expect(r.name).toBe('Claude');
+    expect(r.source).toBe('explicit');
+    expect(r.mismatch).toBeUndefined();
+  });
+
+  test('no mismatch when only one of explicit/sidecar is set', () => {
+    expect(resolveAgentName({ explicit: 'X', default: 'D' }).mismatch).toBeUndefined();
+    expect(resolveAgentName({ sidecar: 'X', default: 'D' }).mismatch).toBeUndefined();
+  });
+});

--- a/test/warmup-handoff.test.ts
+++ b/test/warmup-handoff.test.ts
@@ -60,6 +60,24 @@ describe('SessionManager.getImportSource', () => {
     expect(sm.getImportSource('broken')).toBeNull();
   });
 
+  test('returns null when sidecar JSON parses to a non-object root', () => {
+    // The trust-boundary gate added in src/session-manager.ts:
+    // valid JSON like `null`, `[]`, `"string"`, or a bare number parses
+    // successfully but would have produced an unusable `ImportSource`
+    // with whatever field accesses the call site does. The gate rejects
+    // these at the boundary so the rest of the code can assume a record.
+    const cases: Array<[string, string]> = [
+      ['null-root', 'null'],
+      ['array-root', '[1,2,3]'],
+      ['string-root', '"just a string"'],
+      ['number-root', '42'],
+    ];
+    for (const [id, body] of cases) {
+      writeFileSync(join(tmpDir, 'sessions', `${id}.import-source.json`), body);
+      expect(sm.getImportSource(id)).toBeNull();
+    }
+  });
+
   test('surfaces agentName specifically — guards against field rename', () => {
     // The whole point of this sidecar field is that warmup-session.ts can
     // read it back. If someone renames `agentName` upstream without

--- a/test/warmup-handoff.test.ts
+++ b/test/warmup-handoff.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Guard tests for the import → warmup → conhost identity handoff.
+ *
+ * The original bug: warmup-session.ts called ContextManager.open without a
+ * namespace argument, so AutobiographicalStrategy persisted summaries to
+ * the no-namespace default slot `default/autobio:summaries`. The live
+ * framework reads from `agents/${name}/autobio:summaries`. The two never
+ * met; the agent saw an empty autobiography on first open.
+ *
+ * The fix is in two parts:
+ *   1. `SessionManager.getImportSource` surfaces the agentName the
+ *      importer wrote into the sidecar, so warmup can derive a name
+ *      without an explicit CLI flag.
+ *   2. `warmup-session.ts` passes `namespace: 'agents/' + agentName`
+ *      to `ContextManager.open` so its writes land where the framework
+ *      reads.
+ *
+ * These tests pin both contracts. They don't run an LLM — they just
+ * check the surface area that has to remain intact for the handoff to
+ * work end-to-end.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { JsStore } from '@animalabs/chronicle';
+import { ContextManager } from '@animalabs/context-manager';
+import { AutobiographicalStrategy } from '@animalabs/agent-framework';
+import { SessionManager } from '../src/session-manager.js';
+
+describe('SessionManager.getImportSource', () => {
+  let tmpDir: string;
+  let sm: SessionManager;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'warmup-handoff-'));
+    mkdirSync(join(tmpDir, 'sessions'), { recursive: true });
+    sm = new SessionManager(tmpDir);
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('returns null when no sidecar exists', () => {
+    expect(sm.getImportSource('nonexistent')).toBeNull();
+  });
+
+  test('returns parsed JSON when sidecar exists', () => {
+    const sidecarPath = join(tmpDir, 'sessions', 'abc123.import-source.json');
+    writeFileSync(sidecarPath, JSON.stringify({ agentName: 'Claude', name: 'Truvari' }));
+    const result = sm.getImportSource('abc123');
+    expect(result).toEqual({ agentName: 'Claude', name: 'Truvari' });
+  });
+
+  test('returns null when sidecar contents are not valid JSON', () => {
+    const sidecarPath = join(tmpDir, 'sessions', 'broken.import-source.json');
+    writeFileSync(sidecarPath, '{not valid json');
+    expect(sm.getImportSource('broken')).toBeNull();
+  });
+
+  test('surfaces agentName specifically — guards against field rename', () => {
+    // The whole point of this sidecar field is that warmup-session.ts can
+    // read it back. If someone renames `agentName` upstream without
+    // migrating callers, both warmup and conhost lose their fallback and
+    // we silently regress to the original bug.
+    const sidecarPath = join(tmpDir, 'sessions', 'guard.import-source.json');
+    writeFileSync(sidecarPath, JSON.stringify({ agentName: 'TestAgent' }));
+    const result = sm.getImportSource('guard');
+    expect(result?.agentName).toBe('TestAgent');
+  });
+});
+
+describe('AutobiographicalStrategy state slot under explicit namespace', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'warmup-namespace-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("registers 'agents/${name}/autobio:summaries' when namespace is passed", async () => {
+    const storePath = join(tmpDir, 'store');
+    const store = JsStore.openOrCreate({ path: storePath });
+    try {
+      const strategy = new AutobiographicalStrategy({
+        compressionModel: 'claude-sonnet-4-5-20250929',
+        autoTickOnNewMessage: false,
+      });
+      await ContextManager.open({
+        store,
+        strategy,
+        namespace: 'agents/Claude',
+      });
+
+      const stateIds = store.listStates().map((s: { id: string }) => s.id);
+      // The slot the framework's main-agent ContextManager registers.
+      // If warmup-session.ts ever drops its namespace argument again, this
+      // assertion fails because the strategy lands at `default/` instead.
+      expect(stateIds).toContain('agents/Claude/autobio:summaries');
+      expect(stateIds).not.toContain('default/autobio:summaries');
+    } finally {
+      store.close?.();
+    }
+  });
+
+  test("falls back to 'default/autobio:summaries' when namespace is omitted (regression-witness)", async () => {
+    // This is intentionally NOT what warmup wants — it documents the
+    // failure mode and ensures the namespace-on path stays distinct from
+    // the namespace-off path. If both ended up at the same slot the
+    // first test above would be a tautology.
+    const storePath = join(tmpDir, 'store');
+    const store = JsStore.openOrCreate({ path: storePath });
+    try {
+      const strategy = new AutobiographicalStrategy({
+        compressionModel: 'claude-sonnet-4-5-20250929',
+        autoTickOnNewMessage: false,
+      });
+      await ContextManager.open({ store, strategy });
+
+      const stateIds = store.listStates().map((s: { id: string }) => s.id);
+      expect(stateIds).toContain('default/autobio:summaries');
+      expect(stateIds).not.toContain('agents/Claude/autobio:summaries');
+    } finally {
+      store.close?.();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the warmup-output-invisible-to-framework bug observed in the wild
on a 4010-message claude.ai-imported session: the autobiography Sonnet
4.5 spent ~16 hours producing was written to `default/autobio:summaries`
while the live agent reads from `agents/${name}/autobio:summaries`, so
the reporter's Claude opened the resumed conversation with no memory of
months of context and reported a December cliff (consistent with the
head window's content + an absent middle).

Two structural bugs plus three pieces of defense-in-depth around them:

- **`warmup-session.ts` namespace fix** (the actual bug):
  `ContextManager.open` was called without a namespace, falling back to
  the strategy's `'default'` sentinel. Live framework uses
  `'agents/${config.name}'`. The two slots never met. Now warmup
  passes `namespace: 'agents/${agentName}'`.
- **Live-session Membrane `assistantParticipant`**: conhost's
  Membrane previously had no `assistantParticipant` set. Compression
  requests don't set it on the request either, so they fell back to
  `'Claude'`. For any non-`Claude` agent name (current conhost
  default is `'agent'`), every stored assistant turn got mapped to
  `role: 'user'` and tool_use blocks ended up in user messages,
  which the API rejects. Symptom in the reporter's `llm-calls.jsonl`:
  13 byte-identical 56136-byte single-message-`role:user`
  compression attempts. Now the Membrane is configured with
  `assistantParticipant: agentName`.
- **Sidecar `agentName` metafile**: the importer records the agent name
  it used into `<id>.import-source.json`. `SessionManager.getImportSource()`
  surfaces it. Warmup reads it back so the operator doesn't have to
  pass `--agent` twice in a row to keep three places in sync.
- **Defaults flip to `"Claude"`**: importer + warmup defaults change
  from `'agent'` to `'Claude'` for the claudeai-revival workflow.
  Other recipes are unaffected (their stored data already uses
  whatever name they chose).
- **Revival recipe pins `agent.name: "Claude"`** to match the new
  default end-to-end.

## Commit-by-commit

| # | SHA | What |
|---|---|---|
| C1 | `0127237` | importer writes `agentName` to sidecar; `SessionManager.getImportSource()` + `ImportSource` type |
| C2 | `09b4cb5` | defaults flip to `"Claude"`; warmup `--agent → sidecar → "Claude"` priority; docs |
| C3 | `5ba4ae4` | warmup `namespace: 'agents/${agentName}'` — **the fix** |
| C4 | `c539159` | live-session Membrane `assistantParticipant: agentName` |
| C5 | `e1507a6` | `recipes/claude-export-revive.json` `agent.name: "Claude"` |
| C6 | `f982a0c` | 6 tests pinning the handoff contracts (no LLM in CI) |

## Test plan

- [ ] `bun test test/warmup-handoff.test.ts test/claudeai-export-importer.test.ts test/autobio-progress-snapshot.test.ts` — local: 40/40 pass
- [ ] Fresh import of a small claude.ai conversation; verify the sidecar contains `"agentName": "Claude"`
- [ ] Warmup that session; verify `bun scripts/check-autobio-namespace.ts <session>` (or direct `listStates` probe) shows summaries at `agents/Claude/autobio:summaries` and nothing at `default/autobio:summaries`
- [ ] Open the session in conhost against `recipes/claude-export-revive.json`; verify the agent's compiled prompt includes summaries (not just head + tail) and that subsequent post-warmup compressions land at the same slot

## Out of scope, deliberately

- The `token_budget` / `flag` block-type skip in the importer (stashed locally; debated — keeping these as `[unknown_block]` placeholders may better preserve the original model's read of the conversation; deserves its own design call before shipping).
- Pushing the runtime tool_result-split into the Membrane formatter (the architecturally-cleaner Bug 4/6/8 fix). The defense-in-depth versions are already in `context-manager` `fix/append-with-assigned-id`; the formatter shift can ride later as a separate cleanup PR once that lands.
- Migration script for users with existing `default/*` summaries. Per discussion, fresh re-import is preferred over data-stitching so the full pipeline gets validated end-to-end.

## Depends on

`f05baa6 chore(deps): bump chronicle to ^0.2.0, context-manager to ^0.5.2` (already at the base of this branch; can be folded if it merges first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)