### PR TITLE
fix(webui): route cancel-subagent to owning fleet child

### DIFF
--- a/src/headless.ts
+++ b/src/headless.ts
@@ -329,6 +329,30 @@ export async function runHeadless(app: AppContext, argv: string[] = []): Promise
         }
         return;
       }
+      case 'cancel-subagent': {
+        const mod = app.framework.getAllModules().find((m) => m.name === 'subagent') as
+          | { cancelSubagent(name: string): boolean }
+          | undefined;
+        if (!mod) {
+          emit({
+            type: 'cancel-subagent-result',
+            corrId: cmd.corrId,
+            name: cmd.name,
+            cancelled: false,
+            reason: 'subagent module not loaded',
+          });
+          return;
+        }
+        const ok = mod.cancelSubagent(cmd.name);
+        emit({
+          type: 'cancel-subagent-result',
+          corrId: cmd.corrId,
+          name: cmd.name,
+          cancelled: ok,
+          ...(ok ? {} : { reason: 'subagent not running' }),
+        });
+        return;
+      }
       default: {
         const t = (cmd as { type?: unknown }).type;
         log(`unknown command type: ${String(t)}`);

--- a/src/modules/fleet-module.ts
+++ b/src/modules/fleet-module.ts
@@ -1597,6 +1597,18 @@ export class FleetModule implements Module {
     catch { return false; }
   }
 
+  /** Cancel a specific in-process subagent inside a fleet child. Response
+   *  arrives as a `cancel-subagent-result` event on the child's event stream;
+   *  the WUI handler matches on corrId to route the result back to the
+   *  originating browser client. Returns false if the named child isn't
+   *  running. */
+  cancelSubagentOnChild(childName: string, name: string, corrId?: string): boolean {
+    const child = this.children.get(childName);
+    if (!child || !child.socket) return false;
+    try { this.sendToChild(child, { type: 'cancel-subagent', name, corrId }); return true; }
+    catch { return false; }
+  }
+
   private async killChild(child: FleetChild): Promise<void> {
     if (child.status === 'exited' || child.status === 'crashed') return;
     const proc = child.process;

--- a/src/modules/fleet-types.ts
+++ b/src/modules/fleet-types.ts
@@ -33,7 +33,12 @@ export type IncomingCommand =
   /** Pull a recursive listing of one mount in the child. Response is `workspace-tree-snapshot`. */
   | { type: 'request-workspace-tree'; mount: string; corrId?: string }
   /** Read a workspace file from the child. Response is `workspace-file-snapshot`. */
-  | { type: 'request-workspace-file'; path: string; corrId?: string };
+  | { type: 'request-workspace-file'; path: string; corrId?: string }
+  /** Cancel a specific in-process subagent by display name. Response is
+   *  `cancel-subagent-result`. The child looks the agent up in its own
+   *  SubagentModule, so this is the only way to stop a subagent that lives
+   *  in a fleet child rather than the conductor. */
+  | { type: 'cancel-subagent'; name: string; corrId?: string };
 
 // ---------------------------------------------------------------------------
 // Child → Parent: events
@@ -115,6 +120,20 @@ export interface WorkspaceTreeSnapshotEvent {
   ts?: number;
 }
 
+/** Response to a {type:'cancel-subagent'} request. */
+export interface CancelSubagentResultEvent {
+  type: 'cancel-subagent-result';
+  corrId?: string;
+  /** Subagent display name the parent asked us to cancel. */
+  name: string;
+  /** True iff a matching live subagent was found and signalled to stop. */
+  cancelled: boolean;
+  /** Set when cancelled=false to explain why (e.g. "subagent module not
+   *  loaded", "subagent not running"). */
+  reason?: string;
+  ts?: number;
+}
+
 /** Response to a {type:'request-workspace-file'} request. */
 export interface WorkspaceFileSnapshotEvent {
   type: 'workspace-file-snapshot';
@@ -143,6 +162,7 @@ export type WireEvent =
   | WorkspaceMountsSnapshotEvent
   | WorkspaceTreeSnapshotEvent
   | WorkspaceFileSnapshotEvent
+  | CancelSubagentResultEvent
   // Arbitrary framework TraceEvent passthrough. The child stamps every emitted
   // event with `ts: Date.now()` in `emit()` (see headless.ts), so ts is always
   // present on the wire even when the underlying TraceEvent doesn't declare it.

--- a/src/modules/web-ui-module.ts
+++ b/src/modules/web-ui-module.ts
@@ -375,7 +375,8 @@ export class WebUiModule implements Module {
       && (eType === 'lessons-snapshot'
         || eType === 'workspace-mounts-snapshot'
         || eType === 'workspace-tree-snapshot'
-        || eType === 'workspace-file-snapshot')
+        || eType === 'workspace-file-snapshot'
+        || eType === 'cancel-subagent-result')
     ) {
       this.routeChildSnapshotResponse(eType, corrId, event as Record<string, unknown>);
       return; // don't fan out — these are private replies, not telemetry
@@ -485,6 +486,21 @@ export class WebUiModule implements Module {
         toLine: Number(event.toLine ?? 0),
         content: String(event.content ?? ''),
         truncated: Boolean(event.truncated),
+      });
+      return;
+    }
+    if (eType === 'cancel-subagent-result') {
+      const name = String(event.name ?? '');
+      const cancelled = Boolean(event.cancelled);
+      const reason = typeof event.reason === 'string' ? event.reason : undefined;
+      this.send(client, {
+        type: 'command-result',
+        lines: [{
+          text: cancelled
+            ? `cancelled subagent ${name}`
+            : `subagent ${name} not cancelled${reason ? ` (${reason})` : ''}`,
+          style: cancelled ? 'system' : 'tool',
+        }],
       });
       return;
     }
@@ -822,6 +838,15 @@ export class WebUiModule implements Module {
 
       case 'cancel-subagent': {
         if (!sharedServer?.app) return;
+        // Route to the owning fleet child if the WUI told us which one to
+        // target. Subagents inside a fleet child (e.g. Clerk-spawned forks)
+        // can't be cancelled locally — the conductor's framework doesn't have
+        // their SubagentModule.
+        if (parsed.childName) {
+          this.routeFleetRequest(client, parsed.childName, 'cancel-subagent',
+            (corrId, fleet) => fleet.cancelSubagentOnChild(parsed.childName!, parsed.name, corrId));
+          return;
+        }
         const subMod = sharedServer.app.framework
           .getAllModules()
           .find((m) => m.name === 'subagent') as

--- a/src/web/protocol.ts
+++ b/src/web/protocol.ts
@@ -337,10 +337,16 @@ export interface InterruptMessage {
   type: 'interrupt';
 }
 
-/** Cancel one specific in-process subagent by display name. */
+/** Cancel one specific in-process subagent by display name. If `childName`
+ *  is set, the cancel is forwarded to that fleet child's headless runtime;
+ *  otherwise the conductor's local SubagentModule is used. Required for
+ *  subagents that live inside a fleet child (e.g. Clerk-spawned subagents) —
+ *  the conductor typically has no SubagentModule loaded, so a non-routed
+ *  cancel would hit "subagent module not loaded". */
 export interface CancelSubagentMessage {
   type: 'cancel-subagent';
   name: string;
+  childName?: string;
 }
 
 /** Stop a fleet child gracefully. */
@@ -492,6 +498,8 @@ export function isClientMessage(value: unknown): value is WebUiClientMessage {
     case 'route-to-child':
       return isNonEmptyString(v.childName) && typeof v.content === 'string';
     case 'cancel-subagent':
+      return isNonEmptyString(v.name)
+        && (v.childName === undefined || isNonEmptyString(v.childName));
     case 'fleet-stop':
     case 'fleet-restart':
       return isNonEmptyString(v.name);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -329,8 +329,8 @@ export function App() {
     });
   };
 
-  const cancelSubagent = (name: string): void => {
-    wire.send({ type: 'cancel-subagent', name });
+  const cancelSubagent = (name: string, childName?: string): void => {
+    wire.send({ type: 'cancel-subagent', name, ...(childName ? { childName } : {}) });
   };
 
   const fleetStop = (name: string): void => {
@@ -349,9 +349,12 @@ export function App() {
     if (src.kind === 'peek') cancelSubagent(src.scope);
     else if (src.kind === 'child-event-all') fleetStop(src.childName);
     else if (src.kind === 'child-event-agent') {
-      // Agent inside a fleet child — there's no per-agent kill verb yet, so
-      // stopping the whole child is the closest analogue.
-      fleetStop(src.childName);
+      // For a subagent inside a fleet child, route the cancel to that
+      // child's SubagentModule rather than killing the whole child. The
+      // main framework agent of a child is not a subagent — for that we
+      // still have no per-agent kill verb, so fall back to fleetStop.
+      if (node.kind === 'subagent') cancelSubagent(src.agentName, src.childName);
+      else fleetStop(src.childName);
     }
   };
 

--- a/web/src/Tree.tsx
+++ b/web/src/Tree.tsx
@@ -14,8 +14,10 @@ export interface TreeSidebarProps {
   onSelectStream(node: UiNode): void;
   /** Open / focus the usage view for this node. */
   onSelectUsage(node: UiNode): void;
-  /** Cancel an in-process subagent by display name. */
-  onCancelSubagent(name: string): void;
+  /** Cancel an in-process subagent by display name. If the subagent lives
+   *  inside a fleet child, pass its name as `childName` so the server can
+   *  forward the cancel to that child's runtime. */
+  onCancelSubagent(name: string, childName?: string): void;
   /** Stop a fleet child gracefully. */
   onFleetStop(name: string): void;
   /** Restart a fleet child. */
@@ -60,7 +62,7 @@ function NodeRow(props: {
   onToggleExpand(): void;
   onSelectStream(): void;
   onSelectUsage(): void;
-  onCancelSubagent(name: string): void;
+  onCancelSubagent(name: string, childName?: string): void;
   onFleetStop(name: string): void;
   onFleetRestart(name: string): void;
 }) {
@@ -70,8 +72,15 @@ function NodeRow(props: {
   const isLiveSubagent = (): boolean =>
     props.node.kind === 'subagent' && props.node.agent?.status === 'running';
 
+  // Subagents inside a fleet child carry `child-event-agent` as their stream
+  // source; that's where the owning fleet child's name lives.
+  const owningFleetChild = (): string | undefined =>
+    props.node.streamSource.kind === 'child-event-agent'
+      ? props.node.streamSource.childName
+      : undefined;
+
   const stopHandler = (): (() => void) | null => {
-    if (isLiveSubagent()) return () => props.onCancelSubagent(props.node.label);
+    if (isLiveSubagent()) return () => props.onCancelSubagent(props.node.label, owningFleetChild());
     if (props.node.kind === 'fleet-child' && props.node.fleetChildName)
       return () => props.onFleetStop(props.node.fleetChildName!);
     return null;


### PR DESCRIPTION
## Summary

- The admin WUI's "stop" button on a subagent leaf failed with `subagent module not loaded` whenever the subagent lived inside a fleet child (e.g. a Clerk-spawned fork). The conductor has no `SubagentModule`, so the cancel hit the wrong process.
- Extend `cancel-subagent` with an optional `childName`. When set, the conductor forwards a new `cancel-subagent` IPC command to that fleet child's headless runtime, which calls its local `SubagentModule.cancelSubagent()`. The child replies with `cancel-subagent-result` (corrId-correlated), and the conductor translates it into a normal `command-result` line for the originating browser. Without `childName` the conductor-local path is unchanged.
- The SPA reads the owning fleet child name from the subagent leaf's `child-event-agent` stream source and threads it through `onCancelSubagent`. `stopFocusedNode` cancels the subagent specifically for a subagent inside a fleet child, rather than killing the whole child as a workaround.

## Why

Surfaced while investigating a zombie subagent that survived the parent's `sync-fork` timeout and stayed registered in the Clerk's `framework.agents` for ~30h, eventually double-replying to a user message alongside the main Clerk. The conductor's "stop" button was the only containment verb available, and it didn't reach the child where the subagent actually lives — operators had to restart the entire fleet child to clear one zombie.

The underlying ephemeral-agent leak (sync-fork timeout not cancelling inner inference; cleanup listener missing on natural `end_turn`) is being addressed separately in `agent-framework`. This PR is the containment-side fix: even when a zombie escapes that race, an operator can now stop just the zombie without nuking the host child.

## Test plan

- [ ] `npx tsc --noEmit` clean in both `connectome-host/` and `connectome-host/web/` (verified locally)
- [ ] Manual WUI test: open admin SPA, locate a running subagent under a fleet child, press stop → reply line reads `cancelled subagent <name>` (or `subagent <name> not cancelled (subagent not running)` if already gone), and the subagent disappears from the tree
- [ ] Manual WUI test: same flow for a local (conductor-owned) subagent still works — the path without `childName` is unchanged
- [ ] Manual WUI test: stop button on a fleet child itself (not a subagent inside it) still calls `fleet-stop` as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)