### PR TITLE
feat(tui): dedicated render lane for thinking blocks

### DIFF
--- a/src/tui.ts
+++ b/src/tui.ts
@@ -128,6 +128,7 @@ const RED = '#cc0000';
 const GRAY = '#888888';
 const DIM_GRAY = '#555555';
 const WHITE = '#cccccc';
+const THINKING_DIM = '#8a7aa8';
 
 // ---------------------------------------------------------------------------
 // Main
@@ -355,8 +356,11 @@ export async function runTui(app: AppContext): Promise<void> {
     }
   }
 
+  let currentStreamBlockType: 'text' | 'thinking' | 'tool_call' | 'tool_result' = 'text';
+
   function beginStream() {
     currentStreamBuffer = '';
+    currentStreamBlockType = 'text';
     currentStreamText = new TextRenderable(renderer, {
       id: `stream-${++messageCounter}`,
       content: '',
@@ -364,6 +368,38 @@ export async function runTui(app: AppContext): Promise<void> {
     });
     scrollBox.add(currentStreamText);
     streaming = true;
+  }
+
+  /**
+   * Switch the active stream element to a different block lane. Called from
+   * inference:content_block (block_start). If the new block is the same lane
+   * as the current one, this is a no-op — Anthropic's stream occasionally
+   * splits a single logical "lane" across multiple blocks (e.g. interleaved
+   * thinking) and we want them visually contiguous within their kind.
+   */
+  function switchStreamBlock(blockType: 'text' | 'thinking' | 'tool_call' | 'tool_result') {
+    if (currentStreamBlockType === blockType && currentStreamText) return;
+    if (blockType !== 'text' && blockType !== 'thinking') {
+      currentStreamBlockType = blockType;
+      return;
+    }
+    currentStreamBuffer = '';
+    currentStreamBlockType = blockType;
+    if (blockType === 'thinking') {
+      currentStreamBuffer = '💭 ';
+      currentStreamText = new TextRenderable(renderer, {
+        id: `stream-thinking-${++messageCounter}`,
+        content: currentStreamBuffer,
+        fg: THINKING_DIM,
+      });
+    } else {
+      currentStreamText = new TextRenderable(renderer, {
+        id: `stream-${++messageCounter}`,
+        content: '',
+        fg: WHITE,
+      });
+    }
+    scrollBox.add(currentStreamText);
   }
 
   function streamToken(text: string) {
@@ -377,6 +413,7 @@ export async function runTui(app: AppContext): Promise<void> {
     streaming = false;
     currentStreamText = null;
     currentStreamBuffer = '';
+    currentStreamBlockType = 'text';
   }
 
   function loadSessionHistory() {
@@ -397,6 +434,11 @@ export async function runTui(app: AppContext): Promise<void> {
             addLine(`You: ${(block as { text: string }).text}`, GREEN);
           } else {
             addLine((block as { text: string }).text, WHITE);
+          }
+        } else if (block.type === 'thinking') {
+          const t = (block as { thinking?: string }).thinking;
+          if (t && t.trim()) {
+            addLine(`💭 ${t}`, THINKING_DIM);
           }
         } else if (block.type === 'tool_use') {
           toolNames.push((block as { name: string }).name);
@@ -1162,14 +1204,34 @@ export async function runTui(app: AppContext): Promise<void> {
         break;
       }
 
+      case 'inference:content_block': {
+        if (agent === rootAgentName && event.event === 'block_start') {
+          const bt = event.blockType as 'text' | 'thinking' | 'tool_call' | 'tool_result';
+          if (bt === 'text' || bt === 'thinking') {
+            if (!streaming) beginStream();
+            switchStreamBlock(bt);
+          }
+        }
+        break;
+      }
+
       case 'inference:tokens': {
         const content = event.content as string;
+        const blockType = event.blockType as
+          | 'text' | 'thinking' | 'tool_call' | 'tool_result' | undefined;
         if (content) {
           if (agent === rootAgentName && backgrounded) {
             // Silently accumulate tokens while backgrounded
             backgroundBuffer += content;
             streamOutputTokens += Math.ceil(content.length / 4);
           } else if (agent === rootAgentName && streaming) {
+            // Belt-and-braces: if a token's blockType disagrees with what
+            // block_start announced (or block_start was missed), switch lanes
+            // before appending so thinking doesn't leak into the text element.
+            if (blockType && (blockType === 'text' || blockType === 'thinking')
+              && blockType !== currentStreamBlockType) {
+              switchStreamBlock(blockType);
+            }
             streamToken(content);
             streamOutputTokens += Math.ceil(content.length / 4);
             spinnerFrame = (spinnerFrame + 1) % SPINNER.length;

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -129,6 +129,10 @@ const GRAY = '#888888';
 const DIM_GRAY = '#555555';
 const WHITE = '#cccccc';
 const THINKING_DIM = '#8a7aa8';
+const THINKING_PREFIX = '💭 ';
+
+/** Block kinds the membrane can route into a stream lane. */
+type StreamBlockType = 'text' | 'thinking' | 'tool_call' | 'tool_result';
 
 // ---------------------------------------------------------------------------
 // Main
@@ -356,7 +360,7 @@ export async function runTui(app: AppContext): Promise<void> {
     }
   }
 
-  let currentStreamBlockType: 'text' | 'thinking' | 'tool_call' | 'tool_result' = 'text';
+  let currentStreamBlockType: StreamBlockType = 'text';
 
   function beginStream() {
     currentStreamBuffer = '';
@@ -377,8 +381,14 @@ export async function runTui(app: AppContext): Promise<void> {
    * splits a single logical "lane" across multiple blocks (e.g. interleaved
    * thinking) and we want them visually contiguous within their kind.
    */
-  function switchStreamBlock(blockType: 'text' | 'thinking' | 'tool_call' | 'tool_result') {
+  function switchStreamBlock(blockType: StreamBlockType) {
     if (currentStreamBlockType === blockType && currentStreamText) return;
+    // Tool blocks (tool_call / tool_result) aren't rendered as a stream lane
+    // here — they're surfaced via the tool:* trace events instead. We still
+    // need to update currentStreamBlockType so that when tokens swing back to
+    // text or thinking, the next switchStreamBlock() call sees a "different
+    // lane than before" and creates a fresh TextRenderable instead of
+    // appending to the prior element across a tool sandwich.
     if (blockType !== 'text' && blockType !== 'thinking') {
       currentStreamBlockType = blockType;
       return;
@@ -386,7 +396,7 @@ export async function runTui(app: AppContext): Promise<void> {
     currentStreamBuffer = '';
     currentStreamBlockType = blockType;
     if (blockType === 'thinking') {
-      currentStreamBuffer = '💭 ';
+      currentStreamBuffer = THINKING_PREFIX;
       currentStreamText = new TextRenderable(renderer, {
         id: `stream-thinking-${++messageCounter}`,
         content: currentStreamBuffer,
@@ -438,7 +448,7 @@ export async function runTui(app: AppContext): Promise<void> {
         } else if (block.type === 'thinking') {
           const t = (block as { thinking?: string }).thinking;
           if (t && t.trim()) {
-            addLine(`💭 ${t}`, THINKING_DIM);
+            addLine(`${THINKING_PREFIX}${t}`, THINKING_DIM);
           }
         } else if (block.type === 'tool_use') {
           toolNames.push((block as { name: string }).name);
@@ -1206,7 +1216,10 @@ export async function runTui(app: AppContext): Promise<void> {
 
       case 'inference:content_block': {
         if (agent === rootAgentName && event.phase === 'block_start') {
-          const bt = event.blockType as 'text' | 'thinking' | 'tool_call' | 'tool_result';
+          // `as string` rather than narrowing to StreamBlockType up front:
+          // honest about the trust boundary. Anthropic ships block types we
+          // may not have enumerated yet (e.g. redacted_thinking); ignore them.
+          const bt = event.blockType as string;
           if (bt === 'text' || bt === 'thinking') {
             if (!streaming) beginStream();
             switchStreamBlock(bt);
@@ -1217,8 +1230,7 @@ export async function runTui(app: AppContext): Promise<void> {
 
       case 'inference:tokens': {
         const content = event.content as string;
-        const blockType = event.blockType as
-          | 'text' | 'thinking' | 'tool_call' | 'tool_result' | undefined;
+        const blockType = event.blockType as string | undefined;
         if (content) {
           if (agent === rootAgentName && backgrounded) {
             // Silently accumulate tokens while backgrounded

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -1205,7 +1205,7 @@ export async function runTui(app: AppContext): Promise<void> {
       }
 
       case 'inference:content_block': {
-        if (agent === rootAgentName && event.event === 'block_start') {
+        if (agent === rootAgentName && event.phase === 'block_start') {
           const bt = event.blockType as 'text' | 'thinking' | 'tool_call' | 'tool_result';
           if (bt === 'text' || bt === 'thinking') {
             if (!streaming) beginStream();


### PR DESCRIPTION
## Summary

Extended-thinking content was streaming into the same WHITE text element as the assistant's reply, indistinguishable from it. Once an assistant turn finished, only the visible-text part lived on as a `TextRenderable` — thinking blocks loaded from Chronicle on session restart were dropped entirely by `loadSessionHistory`.

This PR adds a proper lane for thinking content in the TUI:

- New `THINKING_DIM` colour (\`#8a7aa8\`, muted violet).
- Stream rendering tracks \`currentStreamBlockType\` and routes tokens to a separately-styled \`TextRenderable\` per block lane. Switching is driven by the new \`inference:content_block\` trace event from agent-framework on \`block_start\`; same-lane re-entry is a no-op.
- Thinking elements get a \`💭 \` prefix so they read clearly even without colour.
- \`inference:tokens\` carries a belt-and-braces lane correction: if a chunk's \`blockType\` disagrees with what \`block_start\` announced (or block_start was missed), the lane switches before appending.
- \`loadSessionHistory\` now renders \`block.type === 'thinking'\` past blocks (dim violet, \`💭 \` prefix) instead of silently dropping them.

## Dependencies

- \`@animalabs/agent-framework\`: anima-research/agent-framework#35 — emits the \`inference:content_block\` trace events and the \`blockType\` tag on \`inference:tokens\`.
- \`@animalabs/membrane\`: antra-tess/membrane#19 — fixes the native yielding path so block events actually fire when thinking is on.

This PR is correct on its own (the trace handler is purely additive and a missing event is harmless) but only delivers user-visible behaviour once the two upstream PRs land and the deps bump.

## Test plan

- [x] \`bun test\` — 292/292 pass
- [x] \`npx tsc --noEmit\` — clean
- [x] Manual end-to-end against \`data-evac\`: continued a session with \`recipe.agent.thinking.enabled = true\` against Opus, thinking now streams in dim violet with the \`💭 \` prefix; historical thinking blocks (where Chronicle stored them structurally) replay correctly via \`loadSessionHistory\`.

## Not in scope

- Subagent peek and fleet-child views — they have their own line-merging buffers; can layer the same distinction in later if needed.
- WebUI rendering — the wire protocol would need a new variant carrying \`blockType\`. Separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)