### PR TITLE
fix(reasoning): emit adaptive thinking format (opus-4.x rejects legacy enabled+budget)

### DIFF
--- a/src/logging-adapter.ts
+++ b/src/logging-adapter.ts
@@ -50,9 +50,16 @@ export class LoggingAnthropicAdapter extends AnthropicAdapter {
   private withReasoning(request: ProviderRequest): ProviderRequest {
     const r = this.getReasoning?.();
     if (!r || !r.enabled) return request;
+    // Use ADAPTIVE thinking, not the legacy { type:'enabled', budget_tokens }
+    // form. Current Anthropic models (opus-4-6/4-7/4-8, …) reject the legacy
+    // form with: `"thinking.type.enabled" is not supported for this model.
+    // Use "thinking.type.adaptive"`. Under adaptive the model sizes its own
+    // thinking, so `budgetTokens` is no longer sent (it still shows in
+    // reasoning_status as an informational hint). Membrane forwards
+    // `request.thinking` verbatim, so no provider change is needed.
     return {
       ...request,
-      thinking: { type: 'enabled', budget_tokens: r.budgetTokens },
+      thinking: { type: 'adaptive' } as unknown as ProviderRequest['thinking'],
     } as ProviderRequest;
   }
 


### PR DESCRIPTION
## Problem
Current Anthropic models (opus-4-6 / 4-7 / 4-8) reject the legacy extended-thinking form:
```
"thinking.type.enabled" is not supported for this model. Use "thinking.type.adaptive".
```
`LoggingAnthropicAdapter.withReasoning` injected `thinking:{type:"enabled",budget_tokens}` whenever the `SettingsModule` reasoning toggle was on. So an agent that enabled reasoning made **every** subsequent inference 400 (verified live: Cairn enabled reasoning mid-conversation and went silent — 4 failed retries per turn).

## Fix
Switch `withReasoning()` to `thinking:{type:"adaptive"}`, which all current models accept. Verified against the API directly: adaptive is accepted by opus-4-6/4-7/4-8; the legacy form is rejected by all three. Membrane already forwards `request.thinking` verbatim, so no provider change is needed. Under adaptive the model sizes its own thinking, so `budgetTokens` is now informational only (still shown in `reasoning_status`).

## Notes
- Stacked on `feat/tui-mem-stats-and-strategy-passthrough` — that branch introduces both `SettingsModule` and `logging-adapter.ts` (the file doesn't exist on `main`), so this must target it. Diff is a single commit.
- Verified live: Cairn now infers with `thinking:{type:"adaptive"}`, `stop=end_turn`, reasoning on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)