### PR TITLE
fix(host): subagent postmortem 2026-05-28 + TUI multi-line input

### DIFF
--- a/src/modules/subagent-module.ts
+++ b/src/modules/subagent-module.ts
@@ -122,12 +122,15 @@ export class SubagentTerminated extends Error {
   }
 }
 
-/** Persisted subagent state (stored in Chronicle module state). */
+/** Persisted subagent state (stored in Chronicle module state).
+ *  'cancelled' = terminal-but-benign (user cancel, zombie reclaim, supersession).
+ *  Postmortem 2026-05-28 P1 #4: separated from 'failed' so the TUI subagent
+ *  list and the web admin tree agree on terminal cause. */
 interface PersistedSubagent {
   name: string;
   type: 'spawn' | 'fork';
   task: string;
-  status: 'running' | 'completed' | 'failed';
+  status: 'running' | 'completed' | 'failed' | 'cancelled';
   startedAt: number;
   /**
    * Last time we saw a trace event addressed to this subagent (token, tool
@@ -145,12 +148,14 @@ interface PersistedSubagent {
   parent?: string;
 }
 
-/** Observable state of an active subagent, for TUI display. */
+/** Observable state of an active subagent, for TUI display. See
+ *  PersistedSubagent.status — 'cancelled' is the same dedicated benign-
+ *  terminal state introduced for the postmortem 2026-05-28 P1 #4 fix. */
 export interface ActiveSubagent {
   name: string;
   type: 'spawn' | 'fork';
   task: string;
-  status: 'running' | 'completed' | 'failed';
+  status: 'running' | 'completed' | 'failed' | 'cancelled';
   startedAt: number;
   /** Last addressed trace event timestamp. See PersistedSubagent.lastActivityAt. */
   lastActivityAt: number;
@@ -170,6 +175,16 @@ interface LiveSubagentState {
   pendingToolCalls: Array<{ name: string; input?: unknown }>;
   /** Track callIds from tool_calls_yielded so we can route tool:* events back. */
   activeCallIds: Set<string>;
+  /** When set, an inference request has been dispatched but no token has
+   *  arrived yet — i.e., the agent is provably alive waiting on the LLM
+   *  provider. Postmortem 2026-05-28 F3: between `inference:started` /
+   *  `inference:stream_resumed` and the first `inference:tokens`, both
+   *  `currentStream` and `pendingToolCalls` are empty even though the
+   *  request is on the wire. The reaper / peek predicates must treat this
+   *  as a protected state, otherwise slow rounds (Opus on 100–165K-token
+   *  contexts routinely exceed 30s TTFT) get reaped mid-request. Cleared
+   *  on first token, completion, failure, or new tool yield. */
+  requestInFlightSince?: number;
 }
 
 /** Streaming event pushed to peek subscribers. */
@@ -192,7 +207,7 @@ export interface SubagentPeekSnapshot {
   name: string;
   type: 'spawn' | 'fork';
   task: string;
-  status: 'running' | 'completed' | 'failed';
+  status: 'running' | 'completed' | 'failed' | 'cancelled';
   startedAt: number;
   elapsedMs: number;
   messageCount: number;
@@ -394,7 +409,14 @@ export class SubagentModule implements Module {
   // demand-driven reap. This interval gives us a steady heartbeat reap
   // independent of spawn activity.
   private reaperTimer: ReturnType<typeof setInterval> | null = null;
-  private static readonly REAPER_INTERVAL_MS = 30_000;
+  // Postmortem 2026-05-28 F3: bumped from 30_000ms. With the in-flight guard
+  // closing the "request on wire" false-positive window, the threshold is
+  // less load-bearing — but 30s was still tight enough that JIT pauses, GC,
+  // or transient hiccups under heavy fleet load could trip the reaper on a
+  // genuinely-progressing-but-pausing agent. 60s sweep cadence is also
+  // friendlier when the fleet is already throttled by 429s (reaping under
+  // throttling is counterproductive — the slot isn't stuck, it's queued).
+  private static readonly REAPER_INTERVAL_MS = 60_000;
 
   // Prompt size guard
   private maxPromptTokens: number;
@@ -469,16 +491,24 @@ export class SubagentModule implements Module {
           return;
         }
 
+        // Postmortem 2026-05-28 F3: track the request-in-flight window.
+        // `inference:started` and `inference:stream_resumed` dispatch a new
+        // LLM request; the first `inference:tokens`, `inference:completed`,
+        // `inference:failed`, or `inference:tool_calls_yielded` signals the
+        // provider has responded. Between those, the reaper / peek predicates
+        // treat `requestInFlightSince` as proof the agent isn't stuck.
         switch (event.type) {
           case 'inference:started':
             live.currentStream = '';
             live.pendingToolCalls = [];
             live.activeCallIds.clear();
+            live.requestInFlightSince = Date.now();
             this.emit(displayName, { type: 'inference:started' });
             break;
           case 'inference:tokens': {
             const content = (event as { content?: string }).content ?? '';
             live.currentStream += content;
+            live.requestInFlightSince = undefined;
             this.emit(displayName, { type: 'tokens', content });
             break;
           }
@@ -486,6 +516,7 @@ export class SubagentModule implements Module {
             const calls = (event as { calls?: Array<{ id: string; name: string; input?: unknown }> }).calls ?? [];
             live.pendingToolCalls = calls.map(c => ({ name: c.name, input: c.input }));
             live.currentStream = '';
+            live.requestInFlightSince = undefined;
             // Index callIds so we can route tool:* events back
             for (const c of calls) {
               live.activeCallIds.add(c.id);
@@ -497,16 +528,19 @@ export class SubagentModule implements Module {
           case 'inference:stream_resumed':
             live.currentStream = '';
             live.pendingToolCalls = [];
+            live.requestInFlightSince = Date.now();
             this.emit(displayName, { type: 'stream_resumed' });
             break;
           case 'inference:completed': {
             const usage = (event as { tokenUsage?: { input?: number } }).tokenUsage;
             if (usage?.input) this.lastInputTokens.set(displayName, usage.input);
+            live.requestInFlightSince = undefined;
             this.emit(displayName, { type: 'inference:completed' });
             break;
           }
           case 'inference:failed': {
             const error = (event as { error?: string }).error ?? 'Unknown error';
+            live.requestInFlightSince = undefined;
             this.emit(displayName, { type: 'inference:failed', error });
             break;
           }
@@ -608,7 +642,9 @@ export class SubagentModule implements Module {
 
   /**
    * Restore activeSubagents + parentMap from Chronicle module state.
-   * Marks any 'running' entries as 'interrupted' since the actual processes are gone.
+   * Marks any 'running' entries as 'cancelled' since the actual processes are gone.
+   * Postmortem 2026-05-28 P1 #4: use 'cancelled' (not 'completed') so the
+   * operator can tell host-interruption from genuine completion in the TUI.
    */
   restoreFromStore(): void {
     if (!this.ctx) return;
@@ -623,7 +659,7 @@ export class SubagentModule implements Module {
         name: pa.name,
         type: pa.type,
         task: pa.task,
-        status: pa.status === 'running' ? 'completed' : pa.status,
+        status: pa.status === 'running' ? 'cancelled' : pa.status,
         startedAt: pa.startedAt,
         // Fallback for records from versions before lastActivityAt was added:
         // treat them as if their last activity was their start time. Affects
@@ -745,7 +781,7 @@ export class SubagentModule implements Module {
       case 'concurrency':
         return this.handleConcurrency(call.input as { maxConcurrent?: number });
       case 'peek':
-        return this.handlePeek(call.input as { name?: string });
+        return this.handlePeek(call.input as { name?: string }, caller);
       case 'return': {
         // Stash the result keyed by the tool call ID. The completion path
         // in runSpawn/runFork will pick it up via the callIdIndex → displayName.
@@ -772,13 +808,21 @@ export class SubagentModule implements Module {
     return {};
   }
 
-  async gatherContext(_agentName: string): Promise<import('@animalabs/context-manager').ContextInjection[]> {
+  async gatherContext(agentName: string): Promise<import('@animalabs/context-manager').ContextInjection[]> {
     if (!this.ctx) return [];
     const persisted = this.ctx.getState<{ hudEnabled?: boolean }>() ?? {};
     if (!persisted.hudEnabled) return [];
 
+    // Postmortem 2026-05-28 P3 #8: scope the Fleet Status HUD to the
+    // calling agent's descendants. Pre-fix the HUD injected the whole
+    // fleet roster every turn, which (a) encouraged peer-coordination
+    // anti-patterns and (b) amplified false zombie/failed flags across
+    // the orchestrator's context.
+    const allowed = this.getDescendantDisplayNames(agentName);
+
     const lines: string[] = [];
     for (const [, sa] of this.activeSubagents) {
+      if (!allowed.has(sa.name)) continue;
       const elapsed = sa.completedAt
         ? Math.floor((sa.completedAt - sa.startedAt) / 1000)
         : Math.floor((Date.now() - sa.startedAt) / 1000);
@@ -788,8 +832,12 @@ export class SubagentModule implements Module {
       lines.push(`  ${sa.name} [${sa.type}] ${sa.status} ${elapsed}s ${sa.toolCallsCount}calls parent:${parentShort} "${task}"`);
     }
 
-    // Also show async handles still running
+    // Also show async handles still running, but only those owned by the
+    // caller (or its descendants — but async handles aren't parent-indexed
+    // separately, so conservatively skip them when scoping is in effect
+    // and the caller has no descendants to begin with).
     for (const [name] of this.asyncHandles) {
+      if (!allowed.has(name)) continue;
       if (!this.activeSubagents.has(name) && !this.activeSubagents.has(`spawn-${name}`)) {
         lines.push(`  ${name} [async] pending`);
       }
@@ -905,7 +953,12 @@ export class SubagentModule implements Module {
    * Returns the number of slots reclaimed.
    */
   private reclaimZombieSlots(): number {
-    const ZOMBIE_THRESHOLD_MS = 30_000;
+    // Postmortem 2026-05-28 F3: bumped from 30_000ms — 30s was too tight for
+    // Opus on 100–165K-token contexts with rate-limited MCP tools; single-
+    // round TTFT routinely exceeds it. The `requestInFlightSince` guard
+    // (below) is the primary defence; the threshold bump is belt-and-braces
+    // for legitimate post-request pauses.
+    const ZOMBIE_THRESHOLD_MS = 120_000;
     let reclaimed = 0;
 
     for (const [displayName, live] of this.liveSubagents) {
@@ -916,9 +969,16 @@ export class SubagentModule implements Module {
       if (!entry || entry.status !== 'running') continue;
 
       const silentMs = Date.now() - entry.lastActivityAt;
+      // Postmortem 2026-05-28 F3: `!live.requestInFlightSince` protects the
+      // "request dispatched, awaiting first token" window. Before this, the
+      // guard `!currentStream && pendingToolCalls.length===0` was true while
+      // the next round's request was on the wire, and the reaper killed
+      // progressing agents mid-request. Forensic signature in production:
+      // last message in store is an unconsumed `tool_result`.
       const isZombie = silentMs > ZOMBIE_THRESHOLD_MS
         && !live.currentStream
-        && live.pendingToolCalls.length === 0;
+        && live.pendingToolCalls.length === 0
+        && !live.requestInFlightSince;
 
       if (isZombie) {
         const elapsedTotal = Date.now() - entry.startedAt;
@@ -947,7 +1007,11 @@ export class SubagentModule implements Module {
           this.cancellationHandles.delete(displayName);
         }
 
-        entry.status = 'failed';
+        // Postmortem 2026-05-28 P1 #4: zombie reclaim is terminal-but-benign,
+        // not a fault. Land on 'cancelled' so the TUI and the reducer-driven
+        // web tree agree (the reducer maps the trace-side `inference:aborted`
+        // emitted by the cancellation handle to 'cancelled' as well).
+        entry.status = 'cancelled';
         entry.completedAt = Date.now();
         entry.statusMessage = 'zombie — slot reclaimed';
 
@@ -1097,6 +1161,32 @@ export class SubagentModule implements Module {
   }
 
   /**
+   * Compute the set of descendant display names rooted at the given framework
+   * agent name. Walks `parentMap` (displayName → callerFrameworkAgentName)
+   * top-down. Excludes the root itself.
+   *
+   * Postmortem 2026-05-28 P3 #8: used by peek() and gatherContext() to
+   * scope observability surfaces to the caller's subtree. Prevents peer
+   * agents from inspecting each other and saturating context with
+   * cross-fleet roster information they have no legitimate use for.
+   */
+  private getDescendantDisplayNames(rootFrameworkAgentName: string): Set<string> {
+    const result = new Set<string>();
+    const queue: string[] = [rootFrameworkAgentName];
+    while (queue.length > 0) {
+      const parentFw = queue.shift()!;
+      for (const [childDisplayName, parentName] of this.parentMap) {
+        if (parentName === parentFw && !result.has(childDisplayName)) {
+          result.add(childDisplayName);
+          const childLive = this.liveSubagents.get(childDisplayName);
+          if (childLive) queue.push(childLive.frameworkAgentName);
+        }
+      }
+    }
+    return result;
+  }
+
+  /**
    * Cancel all children (direct + transitive) of the given display name.
    * Uses the parentMap to find descendants via framework agent names.
    */
@@ -1190,14 +1280,25 @@ export class SubagentModule implements Module {
    * Peek at a running subagent's live state: full context, streaming output,
    * pending tool calls. Returns null if the subagent is not running.
    * If name is omitted, returns snapshots for all running subagents.
+   *
+   * Postmortem 2026-05-28 P3 #8: when a `callerFrameworkAgentName` is
+   * supplied (the normal tool-call path threads it through `handlePeek`),
+   * the result is scoped to the caller's descendants — peers/cousins are
+   * filtered out. Internal callers without a known identity (omit the arg)
+   * keep the global view for backward compatibility.
    */
-  async peek(name?: string): Promise<SubagentPeekSnapshot[]> {
+  async peek(name?: string, callerFrameworkAgentName?: string): Promise<SubagentPeekSnapshot[]> {
+    const allowed = callerFrameworkAgentName
+      ? this.getDescendantDisplayNames(callerFrameworkAgentName)
+      : null;
     if (name) {
+      if (allowed && !allowed.has(name)) return [];
       const snapshot = await this.peekOne(name);
       return snapshot ? [snapshot] : [];
     }
     const results: SubagentPeekSnapshot[] = [];
     for (const displayName of this.liveSubagents.keys()) {
+      if (allowed && !allowed.has(displayName)) continue;
       const snapshot = await this.peekOne(displayName);
       if (snapshot) results.push(snapshot);
     }
@@ -1235,12 +1336,18 @@ export class SubagentModule implements Module {
 
     const elapsedMs = entry ? Date.now() - entry.startedAt : 0;
 
-    // Zombie detection: running for >30s with no active stream and no pending tool calls
-    const ZOMBIE_THRESHOLD_MS = 30_000;
+    // Zombie detection. Postmortem 2026-05-28 F2: this previously keyed off
+    // `startedAt`, which flagged any subagent >30s old as a zombie the moment
+    // it was between tokens — saturating peers' context with false alarms and
+    // driving an orchestrator-level retry storm. Now keyed off `lastActivityAt`
+    // and gated by `!requestInFlightSince` to match the reaper.
+    const ZOMBIE_THRESHOLD_MS = 120_000;
+    const silentMs = entry ? Date.now() - entry.lastActivityAt : 0;
     const isZombie = (entry?.status === 'running')
-      && elapsedMs > ZOMBIE_THRESHOLD_MS
+      && silentMs > ZOMBIE_THRESHOLD_MS
       && !live.currentStream
-      && live.pendingToolCalls.length === 0;
+      && live.pendingToolCalls.length === 0
+      && !live.requestInFlightSince;
 
     return {
       name: displayName,
@@ -1554,8 +1661,8 @@ export class SubagentModule implements Module {
     return { success: true, data: this.getConcurrencyStatus() };
   }
 
-  private async handlePeek(input: { name?: string }): Promise<ToolResult> {
-    const snapshots = await this.peek(input.name);
+  private async handlePeek(input: { name?: string }, caller?: string): Promise<ToolResult> {
+    const snapshots = await this.peek(input.name, caller);
     if (snapshots.length === 0) {
       return {
         success: true,
@@ -1664,9 +1771,12 @@ export class SubagentModule implements Module {
           lastError = err instanceof Error ? err : new Error(String(err));
           this.cancellationHandles.delete(input.name);
 
-          // Non-retryable termination (user cancel, zombie reclaim, etc.)
+          // Non-retryable termination (user cancel, zombie reclaim, etc.).
+          // Postmortem 2026-05-28 P1 #4: terminal-but-benign — 'cancelled',
+          // not 'completed'. Before this, the TUI subagent list rendered these
+          // as "done" while the reducer-driven web tree rendered them red.
           if (lastError instanceof SubagentTerminated) {
-            entry.status = 'completed';
+            entry.status = 'cancelled';
             entry.completedAt = Date.now();
             entry.statusMessage = lastError.reason;
             const notice = this.concurrencyNotice(waitedMs);
@@ -1872,9 +1982,10 @@ export class SubagentModule implements Module {
           lastError = err instanceof Error ? err : new Error(String(err));
           this.cancellationHandles.delete(input.name);
 
-          // Non-retryable termination (user cancel, zombie reclaim, etc.)
+          // Non-retryable termination (user cancel, zombie reclaim, etc.).
+          // See P1 #4 comment in runSpawn — 'cancelled', not 'completed'.
           if (lastError instanceof SubagentTerminated) {
-            entry.status = 'completed';
+            entry.status = 'cancelled';
             entry.completedAt = Date.now();
             entry.statusMessage = lastError.reason;
             const notice = this.concurrencyNotice(waitedMs);

--- a/src/state/agent-tree-reducer.ts
+++ b/src/state/agent-tree-reducer.ts
@@ -36,11 +36,17 @@ export type AgentPhase =
   | 'invoking'
   | 'executing'
   | 'done'
-  | 'failed';
+  | 'failed'
+  // Terminal-but-benign: user cancel, zombie-reclaim, supersession, agent
+  // reboot, budget-restart. Postmortem 2026-05-28 P1 #3: renderers must
+  // treat this as neutral (not red) and terminal (not 'running'). It is the
+  // result of `inference:aborted` and reboot-induced `inference:exhausted`,
+  // both of which are NOT faults.
+  | 'cancelled';
 
 export type AgentKind = 'framework' | 'subagent';
 
-export type AgentStatus = 'running' | 'completed' | 'failed';
+export type AgentStatus = 'running' | 'completed' | 'failed' | 'cancelled';
 
 export interface AgentTokens {
   /** Last-seen input tokens. Represents *current context window size*, not cumulative. */
@@ -175,6 +181,13 @@ const EVENT_HANDLERS: Record<string, EventHandler> = {
     if (!e.agentName) return;
     const node = r._ensureNode(e.agentName);
     node.phase = 'done';
+    // Postmortem 2026-05-28 F1: writing 'completed' here closes a one-way
+    // failed latch. Before this, the only status transitions were
+    // running → failed (via aborted/exhausted/failed) and the only way out
+    // was a fresh inference:started. So a benign abort followed by a clean
+    // completion left the admin UI red forever for that node.
+    node.status = 'completed';
+    node.completedAt = ts;
     node.lastEventAt = ts;
     const usage = e.tokenUsage as { input?: number; output?: number; cacheRead?: number; cacheCreation?: number } | undefined;
     if (usage) r._applyTokenUsage(node, usage);
@@ -189,24 +202,26 @@ const EVENT_HANDLERS: Record<string, EventHandler> = {
     node.lastEventAt = ts;
   },
 
+  // inference:exhausted = budget exhaustion / stream-side cancel / reboot-
+  // induced. Postmortem 2026-05-28 P1 #3: not strictly a fault — flip both
+  // fields to the dedicated 'cancelled' terminal state so the renderer can
+  // distinguish "stopped on purpose" from "errored out".
   'inference:exhausted': (r, e, ts) => {
     if (!e.agentName) return;
     const node = r._ensureNode(e.agentName);
-    node.phase = 'failed';
-    node.status = 'failed';
+    node.phase = 'cancelled';
+    node.status = 'cancelled';
     node.completedAt = ts;
     node.lastEventAt = ts;
   },
 
-  // Aborted = user-initiated cancel. Not strictly a fault, but for tree
-  // rendering the terminal-state semantics match :failed/:exhausted: status
-  // must flip to 'failed' so the renderer's status-keyed RED colouring
-  // doesn't show an aborted agent as still 'running'.
+  // inference:aborted = user cancel / zombie-reclaim / supersession.
+  // Postmortem 2026-05-28 P1 #3: same as exhausted — terminal, but benign.
   'inference:aborted': (r, e, ts) => {
     if (!e.agentName) return;
     const node = r._ensureNode(e.agentName);
-    node.phase = 'failed';
-    node.status = 'failed';
+    node.phase = 'cancelled';
+    node.status = 'cancelled';
     node.completedAt = ts;
     node.lastEventAt = ts;
   },

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -248,15 +248,27 @@ export async function runTui(app: AppContext): Promise<void> {
     placeholder: 'Type a message or /help...',
   });
 
-  // ── Paste handling (CC-style) ───────────────────────────────────────
-  // Large pastes get stored out-of-band; a short placeholder appears in
-  // the input field.  On submit the placeholders are expanded back.
+  // ── Paste handling ─────────────────────────────────────────────────
+  // Short single-line pastes are inlined for visibility. Larger or
+  // multi-line pastes get stored out-of-band; an informative placeholder
+  // — `[paste #N: "head…" Nch, Mlines]` — appears in the input. The
+  // placeholder is expanded back to the original text on submit.
+  const INLINE_PASTE_THRESHOLD = 200;
   const pastedTexts: string[] = [];
+  function formatPastePlaceholder(n: number, text: string): string {
+    const head = text.replace(/\s+/g, ' ').trim().slice(0, 30);
+    const lines = text.split(/\r?\n/).length;
+    const sizeHint = lines > 1 ? `${text.length}ch, ${lines}L` : `${text.length}ch`;
+    return `[paste #${n}: "${head}…" ${sizeHint}]`;
+  }
   (input as any).handlePaste = (event: { bytes: Uint8Array }) => {
     const text = stripAnsiSequences(decodePasteBytes(event.bytes));
+    if (text.length <= INLINE_PASTE_THRESHOLD && !/[\r\n]/.test(text)) {
+      (input as any).insertText(text);
+      return;
+    }
     pastedTexts.push(text);
-    const tag = `[pasted text #${pastedTexts.length}]`;
-    (input as any).insertText(tag);
+    (input as any).insertText(formatPastePlaceholder(pastedTexts.length, text));
   };
 
   const inputBox = new BoxRenderable(renderer, {
@@ -1872,7 +1884,7 @@ export async function runTui(app: AppContext): Promise<void> {
 
     // Expand paste placeholders
     const text = pastedTexts.length > 0
-      ? raw.replace(/\[pasted text #(\d+)\]/g, (m, n) => pastedTexts[parseInt(n, 10) - 1] ?? m)
+      ? raw.replace(/\[paste #(\d+):[^\]]*\]/g, (m, n) => pastedTexts[parseInt(n, 10) - 1] ?? m)
       : raw;
     pastedTexts.length = 0;
 

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -8,7 +8,7 @@
  *   ├─────────────────────────────┤
  *   │  Status bar (1 row)         │  ← [status | tool | N sub]
  *   ├─────────────────────────────┤
- *   │  InputRenderable            │  ← user input
+ *   │  TextareaRenderable         │  ← user input (Enter submits, Alt+Enter newline)
  *   └─────────────────────────────┘
  *
  * Tab toggles between conversation and agent fleet tree view.
@@ -20,8 +20,7 @@ import {
   type CliRenderer,
   BoxRenderable,
   TextRenderable,
-  InputRenderable,
-  InputRenderableEvents,
+  TextareaRenderable,
   ScrollBoxRenderable,
   bold,
   dim,
@@ -243,9 +242,20 @@ export async function runTui(app: AppContext): Promise<void> {
     justifyContent: 'space-between',
   });
 
-  const input = new InputRenderable(renderer, {
+  // Multi-line input. Enter submits; Alt+Enter (meta+return) and Ctrl+J
+  // (linefeed, default Textarea binding) insert a newline. Shift+Enter is
+  // not bound because most terminals don't transmit the shift modifier on
+  // Enter without Kitty Keyboard protocol; users who want it can run their
+  // terminal's equivalent of Claude Code's /terminal-setup.
+  const input = new TextareaRenderable(renderer, {
     id: 'input',
-    placeholder: 'Type a message or /help...',
+    placeholder: 'Type a message or /help — Alt+Enter for newline',
+    wrapMode: 'word',
+    keyBindings: [
+      { name: 'return', action: 'submit' },
+      { name: 'return', meta: true, action: 'newline' },
+    ],
+    onSubmit: () => { handleSubmit(); },
   });
 
   // ── Paste handling ─────────────────────────────────────────────────
@@ -1876,9 +1886,9 @@ export async function runTui(app: AppContext): Promise<void> {
 
   let resolveExit: (() => void) | null = null;
 
-  input.on(InputRenderableEvents.ENTER, () => {
-    const raw = input.value.trim();
-    input.deleteLine();
+  function handleSubmit() {
+    const raw = ((input as any).plainText as string).trim();
+    (input as any).clear();
 
     if (!raw) { pastedTexts.length = 0; return; }
 
@@ -2026,7 +2036,7 @@ export async function runTui(app: AppContext): Promise<void> {
         content: text, metadata: {}, triggerInference: true,
       });
     }
-  });
+  }
 
   // ── Init ───────────────────────────────────────────────────────────
 

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -742,8 +742,12 @@ export async function runTui(app: AppContext): Promise<void> {
     } else {
       // fleet-child-agent
       const rn = node.reducerNode!;
+      // Postmortem 2026-05-28 P1 #3: 'cancelled' = benign termination
+      // (user cancel, zombie-reclaim, supersession, budget restart). Must
+      // not paint red — that was the visible "failed labels" symptom that
+      // drove the operator to file the postmortem.
       if (rn.status === 'failed') nodeColor = RED;
-      else if (rn.phase === 'idle' || rn.phase === 'done') nodeColor = DIM_GRAY;
+      else if (rn.phase === 'idle' || rn.phase === 'done' || rn.phase === 'cancelled') nodeColor = DIM_GRAY;
       else nodeColor = PHASE_COLOR[rn.phase as SubagentPhase] ?? GRAY;
     }
 
@@ -771,7 +775,12 @@ export async function runTui(app: AppContext): Promise<void> {
       const endTime = sa.completedAt ?? Date.now();
       const elapsed = Math.floor((endTime - sa.startedAt) / 1000);
       if (sa.status !== 'running') {
-        statusTag = sa.status === 'completed' ? `done ${elapsed}s` : `failed ${elapsed}s`;
+        // Postmortem 2026-05-28 P1 #4: 'cancelled' is a third terminal state
+        // (zombie reclaim, user cancel). Show it distinctly so the operator
+        // can tell which subagents ended on a benign cancel vs. a fault.
+        statusTag = sa.status === 'completed' ? `done ${elapsed}s`
+          : sa.status === 'cancelled' ? `cancelled ${elapsed}s`
+          : `failed ${elapsed}s`;
       } else {
         const phase = subagentPhase.get(sa.name) ?? 'sending';
         statusTag = `${phase} ${elapsed}s`;

--- a/test/agent-tree-reducer.test.ts
+++ b/test/agent-tree-reducer.test.ts
@@ -67,28 +67,76 @@ describe('AgentTreeReducer', () => {
     expect(node.completedAt).toBe(ts(1));
   });
 
-  test('inference:aborted sets BOTH phase and status to failed (renderer keys colour off status)', () => {
-    // Regression: pre-fix, aborted inferences emerged with phase='failed' but
-    // status='running', so the fleet-child-agent renderer (keyed off status)
-    // showed cancelled agents as still working. The bug was masked when most
-    // recipes didn't subscribe to inference:aborted; the reducer-required-events
-    // floor exposed it on every fleet child.
+  test('inference:aborted produces terminal cancelled state (P1 #3 — distinct from failed)', () => {
+    // Postmortem 2026-05-28 P1 #3: inference:aborted = user cancel /
+    // zombie-reclaim / supersession / agent reboot. Not strictly a fault. The
+    // previous regression guard (pre-2026-05-28) flipped status to 'failed'
+    // because the fleet-child-agent renderer was status-keyed and aborts left
+    // it stuck on 'running'. The right answer is a third terminal state,
+    // 'cancelled' — terminal (renderer must not show as 'running'), but
+    // neutral (renderer must not paint red). Both fields settle to 'cancelled'
+    // so consumers of either status or phase get the same answer.
     const r = new AgentTreeReducer();
     r.applyEvent({ type: 'inference:started', agentName: 'a', timestamp: ts(0) });
     r.applyEvent({ type: 'inference:aborted', agentName: 'a', reason: 'user', timestamp: ts(1) });
     const node = r.getNode('a')!;
-    expect(node.phase).toBe('failed');
-    expect(node.status).toBe('failed');
+    expect(node.phase).toBe('cancelled');
+    expect(node.status).toBe('cancelled');
     expect(node.completedAt).toBe(ts(1));
   });
 
-  test('inference:exhausted also sets status=failed', () => {
+  test('inference:exhausted from in-band stream abort also produces cancelled (P1 #3)', () => {
+    // Postmortem 2026-05-28 F1: framework.ts:2108 emits inference:exhausted
+    // for budget-restart / stream-side cancel paths. Same semantics as
+    // aborted — benign termination, not a fault.
     const r = new AgentTreeReducer();
     r.applyEvent({ type: 'inference:started', agentName: 'a', timestamp: ts(0) });
     r.applyEvent({ type: 'inference:exhausted', agentName: 'a', error: 'budget', timestamp: ts(1) });
     const node = r.getNode('a')!;
-    expect(node.status).toBe('failed');
-    expect(node.phase).toBe('failed');
+    expect(node.phase).toBe('cancelled');
+    expect(node.status).toBe('cancelled');
+  });
+
+  // Postmortem 2026-05-28 F1: the reducer never transitions status to 'completed'.
+  // inference:completed only sets phase='done', leaving status='running' for the
+  // entire lifetime of the agent — which is fine until a later aborted/exhausted/
+  // failed event latches status='failed', at which point only a fresh
+  // inference:started can clear it. For ephemeral subagents whose terminal event
+  // is a benign abort, terminal RED is then permanent.
+  test('inference:completed sets status=completed (F1 — closes one-way failed latch)', () => {
+    const r = new AgentTreeReducer();
+    r.applyEvent({ type: 'inference:started', agentName: 'a', timestamp: ts(0) });
+    r.applyEvent({
+      type: 'inference:completed',
+      agentName: 'a',
+      durationMs: 5,
+      timestamp: ts(1),
+    });
+    const node = r.getNode('a')!;
+    expect(node.phase).toBe('done');
+    expect(node.status).toBe('completed');
+  });
+
+  test('inference:completed after a prior aborted clears the cancelled status (F1 — recovery un-latches)', () => {
+    // The "successful turn clears earlier transient terminal status" behavior.
+    // Without this, the admin UI shows long-running agents non-running for
+    // hours after a single transient cancel even though they have since
+    // completed many turns. Combined with the P1 #3 cancelled-vs-failed split
+    // (the prior aborted now lands as 'cancelled', not 'failed').
+    const r = new AgentTreeReducer();
+    r.applyEvent({ type: 'inference:started', agentName: 'a', timestamp: ts(0) });
+    r.applyEvent({ type: 'inference:aborted', agentName: 'a', reason: 'cancel', timestamp: ts(1) });
+    expect(r.getNode('a')!.status).toBe('cancelled');
+
+    // A subsequent successful round should heal the latch.
+    r.applyEvent({ type: 'inference:started', agentName: 'a', timestamp: ts(2) });
+    r.applyEvent({
+      type: 'inference:completed',
+      agentName: 'a',
+      durationMs: 5,
+      timestamp: ts(3),
+    });
+    expect(r.getNode('a')!.status).toBe('completed');
   });
 
   test('REDUCER_REQUIRED_EVENTS is derived from the dispatch table — every entry actually does something', () => {

--- a/test/subagent-peek-scoping.test.ts
+++ b/test/subagent-peek-scoping.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Postmortem 2026-05-28 P3 #8: scope `peek` and the `gatherContext` HUD to
+ * the caller's descendants only. Today both surfaces show the global roster:
+ *
+ *   - `peek()` (no arg) returns snapshots for every running subagent in the
+ *      fleet, including peers and cousins of the caller.
+ *   - `peek(name)` accepts any name — there's no descendant check.
+ *   - `gatherContext` iterates `activeSubagents` directly with no parent
+ *      filter, so when the HUD is on the caller's context is injected with
+ *      the full fleet roster every turn.
+ *
+ * This invites a "coordinate with peers" anti-pattern (visible in the
+ * production miner's narration: scouts gossiping about siblings being
+ * zombied) and lets one slow scout's status saturate the orchestrator's
+ * context and trigger retry-storm spawn behavior.
+ *
+ * The fix uses `parentMap` (already maintained for cancelChildren) to walk
+ * descendants. A caller sees only its own subtree — peers and ancestors are
+ * filtered out.
+ */
+import { describe, test, expect } from 'bun:test';
+import {
+  SubagentModule,
+  type ActiveSubagent,
+} from '../src/modules/subagent-module.js';
+
+interface FakeLiveState {
+  frameworkAgentName: string;
+  displayName: string;
+  systemPrompt: string;
+  contextManager: { compile: () => Promise<{ messages: unknown[] }> };
+  currentStream: string;
+  pendingToolCalls: Array<{ name: string; input?: unknown }>;
+  activeCallIds: Set<string>;
+  requestInFlightSince?: number;
+}
+
+/** Build a peek-ready SubagentModule with a tree of subagents wired up:
+ *
+ *      root  ('top')
+ *        ├── child-a   (parent: root)
+ *        │     └── grandchild-a1 (parent: child-a)
+ *        ├── child-b   (parent: root)
+ *        └── peer      (parent: 'other-root') — NOT in the tree
+ *
+ * Caller framework agent names: root = 'fw-top', child-a = 'fw-a',
+ * child-b = 'fw-b', grandchild-a1 = 'fw-a1', peer = 'fw-peer'.
+ */
+function makeTree(): SubagentModule {
+  const mod = new SubagentModule();
+  const privateView = mod as unknown as {
+    liveSubagents: Map<string, FakeLiveState>;
+    frameworkNameIndex: Map<string, string>;
+  };
+
+  const installOne = (displayName: string, frameworkAgentName: string, parent?: string): void => {
+    const live: FakeLiveState = {
+      frameworkAgentName,
+      displayName,
+      systemPrompt: 'test',
+      contextManager: { compile: async () => ({ messages: [] }) },
+      currentStream: '',
+      pendingToolCalls: [],
+      activeCallIds: new Set(),
+    };
+    privateView.liveSubagents.set(displayName, live);
+    privateView.frameworkNameIndex.set(frameworkAgentName, displayName);
+    const entry: ActiveSubagent = {
+      name: displayName,
+      type: 'spawn',
+      task: `task-${displayName}`,
+      status: 'running',
+      startedAt: Date.now(),
+      lastActivityAt: Date.now(),
+      toolCallsCount: 0,
+      findingsCount: 0,
+    };
+    mod.activeSubagents.set(`entry-${displayName}`, entry);
+    if (parent !== undefined) mod.parentMap.set(displayName, parent);
+  };
+
+  installOne('child-a', 'fw-a', 'fw-top');
+  installOne('child-b', 'fw-b', 'fw-top');
+  installOne('grandchild-a1', 'fw-a1', 'fw-a');
+  installOne('peer', 'fw-peer', 'fw-other-root');
+
+  return mod;
+}
+
+describe('SubagentModule peek + HUD descendant scoping (P3 #8)', () => {
+  test('peek() with no name and a caller returns only descendants', async () => {
+    const mod = makeTree();
+    // The top-level caller ('fw-top') owns child-a, child-b, grandchild-a1
+    // (transitively). It does NOT own peer.
+    const callerView = mod as unknown as {
+      handlePeek: (input: { name?: string }, caller?: string) => Promise<{ success: boolean; data: unknown }>;
+    };
+    const result = await callerView.handlePeek({}, 'fw-top');
+    const data = result.data as Array<{ name: string }>;
+    const names = new Set(data.map(s => s.name));
+    expect(names.has('child-a')).toBe(true);
+    expect(names.has('child-b')).toBe(true);
+    expect(names.has('grandchild-a1')).toBe(true);
+    expect(names.has('peer')).toBe(false);
+  });
+
+  test('peek() called by a mid-tree caller scopes to that subtree', async () => {
+    const mod = makeTree();
+    const callerView = mod as unknown as {
+      handlePeek: (input: { name?: string }, caller?: string) => Promise<{ success: boolean; data: unknown }>;
+    };
+    // child-a's subtree is just grandchild-a1 — siblings (child-b) and
+    // cousins (peer) and ancestors (root) must be invisible.
+    const result = await callerView.handlePeek({}, 'fw-a');
+    const data = result.data as Array<{ name: string }>;
+    const names = new Set(data.map(s => s.name));
+    expect(names.has('grandchild-a1')).toBe(true);
+    expect(names.has('child-b')).toBe(false);
+    expect(names.has('peer')).toBe(false);
+    expect(names.has('child-a')).toBe(false); // caller doesn't see itself
+  });
+
+  test('peek(name) on a non-descendant returns empty even if the name exists', async () => {
+    const mod = makeTree();
+    const callerView = mod as unknown as {
+      handlePeek: (input: { name?: string }, caller?: string) => Promise<{ success: boolean; data: unknown }>;
+    };
+    // child-a tries to peek peer (which exists fleet-wide but is not a
+    // descendant of child-a). Should return "no such subagent" from
+    // child-a's perspective.
+    const result = await callerView.handlePeek({ name: 'peer' }, 'fw-a');
+    expect(result.data).toEqual({ message: "No running subagent named 'peer'" });
+  });
+
+  test('peek(name) on a descendant works as before', async () => {
+    const mod = makeTree();
+    const callerView = mod as unknown as {
+      handlePeek: (input: { name?: string }, caller?: string) => Promise<{ success: boolean; data: unknown }>;
+    };
+    const result = await callerView.handlePeek({ name: 'grandchild-a1' }, 'fw-a');
+    const data = result.data as Array<{ name: string }>;
+    expect(data.length).toBe(1);
+    expect(data[0].name).toBe('grandchild-a1');
+  });
+
+  test('peek() without a caller (e.g. internal call) still sees everything', async () => {
+    // Backward compat: not all callers thread an identity through (e.g.
+    // internal observability paths, tests). When no caller is provided, the
+    // descendant filter is bypassed.
+    const mod = makeTree();
+    const all = await mod.peek();
+    expect(all.length).toBe(4); // child-a + child-b + grandchild-a1 + peer
+  });
+
+  test('gatherContext HUD is scoped to descendants of the calling agent', async () => {
+    const mod = makeTree();
+    // Force the HUD on by directly setting the persisted flag's source — the
+    // module checks ctx?.getState().hudEnabled, but in this minimal test
+    // there's no ctx, so the early return at the top of gatherContext would
+    // bail. Pre-fix the function returned [] without ctx; post-fix the
+    // descendant filter must still be exercised. To keep the test focused on
+    // scoping (not on persistence wiring), stub ctx with a hudEnabled=true
+    // state-bag and an empty setState.
+    (mod as unknown as { ctx: unknown }).ctx = {
+      getState: () => ({ hudEnabled: true }),
+      setState: () => {},
+    };
+    const injections = await mod.gatherContext('fw-a');
+    expect(injections.length).toBeGreaterThan(0);
+    const text = (injections[0].content[0] as { text: string }).text;
+    // Each HUD line begins with two spaces then the subagent name and ' [type]'.
+    // Anchor on that to avoid substring collisions (grandchild-a1 contains
+    // the literal 'child-a' as a substring, which would make a naïve
+    // includes() check false-positive).
+    expect(text).toMatch(/^\s*grandchild-a1 \[/m);
+    expect(text).not.toMatch(/^\s*child-b \[/m);
+    expect(text).not.toMatch(/^\s*peer \[/m);
+    expect(text).not.toMatch(/^\s*child-a \[/m); // caller's own entry not surfaced
+  });
+});

--- a/test/subagent-peek-zombie.test.ts
+++ b/test/subagent-peek-zombie.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Postmortem 2026-05-28 F2: dual-clock zombie bug in SubagentModule.
+ *
+ * The reaper (reclaimZombieSlots) was correctly updated to use `lastActivityAt`
+ * — the merciful clock that distinguishes "long-running but progressing" from
+ * "silently stuck." The peek observability surface (peekOne / isZombie field)
+ * still uses `startedAt`, which flags ANY subagent older than 30s as a zombie
+ * the moment it's between tokens.
+ *
+ * This false positive saturates orchestrator context: scouts narrate about
+ * peer zombies, the orchestrator re-spawns them as -retryN, abandoned
+ * originals get aborted, the admin UI paints them red. The reap doesn't even
+ * have to happen for the symptom to manifest.
+ *
+ * These tests assert the merciful (lastActivityAt-based) semantics from peek's
+ * point of view. Each test seeds the module's private maps directly to keep
+ * the surface small — `peek()` does not need a full framework / context-manager
+ * stack to exercise the predicate.
+ */
+import { describe, test, expect } from 'bun:test';
+import { SubagentModule, type ActiveSubagent } from '../src/modules/subagent-module.js';
+
+interface FakeLiveState {
+  frameworkAgentName: string;
+  displayName: string;
+  systemPrompt: string;
+  contextManager: { compile: () => Promise<{ messages: unknown[] }> };
+  currentStream: string;
+  pendingToolCalls: Array<{ name: string; input?: unknown }>;
+  activeCallIds: Set<string>;
+}
+
+/** Build a peek-ready SubagentModule with one synthetic subagent installed. */
+function makeModuleWithSubagent(opts: {
+  displayName: string;
+  startedAt: number;
+  lastActivityAt: number;
+  currentStream?: string;
+  pendingToolCalls?: Array<{ name: string; input?: unknown }>;
+  status?: 'running' | 'completed' | 'failed';
+}): SubagentModule {
+  const mod = new SubagentModule();
+  const live: FakeLiveState = {
+    frameworkAgentName: `fw-${opts.displayName}`,
+    displayName: opts.displayName,
+    systemPrompt: 'test',
+    // Minimal stub — peekOne wraps compile() in try/catch and treats failures as
+    // "context manager mid-modification, return what we have," so this is fine.
+    contextManager: { compile: async () => ({ messages: [] }) },
+    currentStream: opts.currentStream ?? '',
+    pendingToolCalls: opts.pendingToolCalls ?? [],
+    activeCallIds: new Set(),
+  };
+  const entry: ActiveSubagent = {
+    name: opts.displayName,
+    type: 'spawn',
+    task: 'test-task',
+    status: opts.status ?? 'running',
+    startedAt: opts.startedAt,
+    lastActivityAt: opts.lastActivityAt,
+    toolCallsCount: 0,
+    findingsCount: 0,
+  };
+
+  // `liveSubagents` is private — go around the visibility modifier. The map is
+  // the canonical source for peek; we keep the test's surface minimal by
+  // skipping the spawn/fork wiring.
+  (mod as unknown as { liveSubagents: Map<string, FakeLiveState> }).liveSubagents.set(
+    opts.displayName,
+    live,
+  );
+  // activeSubagents is `readonly` (re-binding the Map is what's forbidden), so
+  // mutating it directly is fine.
+  mod.activeSubagents.set(`entry-${opts.displayName}`, entry);
+  return mod;
+}
+
+describe('SubagentModule.peek — F2 dual-clock zombie predicate', () => {
+  test('healthy long-running scout is NOT zombie (lastActivityAt fresh)', async () => {
+    // Productive scout 5 minutes in, last bumped activity 5s ago, currently
+    // between an inference round and its first token. Pre-fix: peek reports
+    // isZombie=true because elapsedMs from startedAt is 5min > 30s. Post-fix:
+    // peek consults lastActivityAt, sees fresh activity, reports isZombie=false.
+    const now = Date.now();
+    const mod = makeModuleWithSubagent({
+      displayName: 'scout',
+      startedAt: now - 5 * 60_000,
+      lastActivityAt: now - 5_000,
+    });
+    const [snap] = await mod.peek('scout');
+    expect(snap).toBeDefined();
+    expect(snap!.isZombie).toBe(false);
+  });
+
+  test('genuinely stuck subagent IS zombie (lastActivityAt stale, no stream/tools)', async () => {
+    // Activity stopped 5 minutes ago with no current stream and no pending
+    // tools — the case the reaper exists to catch. Silence picked well above
+    // both 30s (old) and 120s (post-F3) thresholds so the test stays valid
+    // regardless of future threshold tuning.
+    const now = Date.now();
+    const mod = makeModuleWithSubagent({
+      displayName: 'stuck',
+      startedAt: now - 10 * 60_000,
+      lastActivityAt: now - 5 * 60_000,
+    });
+    const [snap] = await mod.peek('stuck');
+    expect(snap!.isZombie).toBe(true);
+  });
+
+  test('subagent currently streaming is NOT zombie even with old lastActivityAt', async () => {
+    // currentStream non-empty short-circuits the predicate regardless of clocks.
+    const now = Date.now();
+    const mod = makeModuleWithSubagent({
+      displayName: 'streaming',
+      startedAt: now - 10 * 60_000,
+      lastActivityAt: now - 5 * 60_000,
+      currentStream: 'tokens flowing',
+    });
+    const [snap] = await mod.peek('streaming');
+    expect(snap!.isZombie).toBe(false);
+  });
+
+  test('subagent with pending tool calls is NOT zombie', async () => {
+    // pendingToolCalls non-empty also short-circuits — agent is awaiting tool
+    // results, not stuck.
+    const now = Date.now();
+    const mod = makeModuleWithSubagent({
+      displayName: 'awaiting-tools',
+      startedAt: now - 10 * 60_000,
+      lastActivityAt: now - 5 * 60_000,
+      pendingToolCalls: [{ name: 'files--read', input: { path: '/x' } }],
+    });
+    const [snap] = await mod.peek('awaiting-tools');
+    expect(snap!.isZombie).toBe(false);
+  });
+
+  test('completed subagent is never reported as zombie', async () => {
+    const now = Date.now();
+    const mod = makeModuleWithSubagent({
+      displayName: 'done',
+      startedAt: now - 10 * 60_000,
+      lastActivityAt: now - 5 * 60_000,
+      status: 'completed',
+    });
+    const [snap] = await mod.peek('done');
+    expect(snap!.isZombie).toBe(false);
+  });
+});

--- a/test/subagent-reaper-in-flight.test.ts
+++ b/test/subagent-reaper-in-flight.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Postmortem 2026-05-28 F3: reaper's guard does not cover the
+ * "request in flight, awaiting first token" window.
+ *
+ * Today's reap guard is `!live.currentStream && pendingToolCalls.length === 0`.
+ * At inference:started and inference:stream_resumed, both are cleared. The
+ * agent then sits with the guard open while the next LLM request is on the
+ * wire. With Opus on 100–165K-token contexts under rate-limited MCP tools,
+ * single-round TTFT routinely exceeds 30s, and the periodic reaper executes
+ * mid-request even though the agent is genuinely progressing.
+ *
+ * Forensic signature in production: every reaped scout's last message in the
+ * Chronicle store is an unconsumed `tool_result` — i.e., tool results came
+ * back, stream_resumed cleared the guards, the next request was dispatched,
+ * the reaper struck before the first token.
+ *
+ * Tests:
+ *   1) reaper does NOT cancel an entry with `requestInFlightSince` set, even
+ *      when lastActivityAt is older than the threshold.
+ *   2) reaper DOES cancel a genuinely silent entry (control — proves the
+ *      threshold path is still alive).
+ *   3) Lifecycle: trace events set/clear `requestInFlightSince` on the live
+ *      subagent state via the module's onTrace handler.
+ */
+import { describe, test, expect } from 'bun:test';
+import {
+  SubagentModule,
+  type ActiveSubagent,
+} from '../src/modules/subagent-module.js';
+import type { TraceEvent } from '@animalabs/agent-framework';
+
+interface FakeLiveState {
+  frameworkAgentName: string;
+  displayName: string;
+  systemPrompt: string;
+  contextManager: { compile: () => Promise<{ messages: unknown[] }> };
+  currentStream: string;
+  pendingToolCalls: Array<{ name: string; input?: unknown }>;
+  activeCallIds: Set<string>;
+  /** Populated when an inference request has been dispatched but no token
+   *  has arrived yet. The reaper must treat this as a protected state. */
+  requestInFlightSince?: number;
+}
+
+function installSubagent(
+  mod: SubagentModule,
+  opts: {
+    displayName: string;
+    frameworkAgentName?: string;
+    startedAt: number;
+    lastActivityAt: number;
+    currentStream?: string;
+    pendingToolCalls?: Array<{ name: string; input?: unknown }>;
+    requestInFlightSince?: number;
+    status?: 'running' | 'completed' | 'failed';
+  },
+): { live: FakeLiveState; entry: ActiveSubagent } {
+  const frameworkAgentName = opts.frameworkAgentName ?? `fw-${opts.displayName}`;
+  const live: FakeLiveState = {
+    frameworkAgentName,
+    displayName: opts.displayName,
+    systemPrompt: 'test',
+    contextManager: { compile: async () => ({ messages: [] }) },
+    currentStream: opts.currentStream ?? '',
+    pendingToolCalls: opts.pendingToolCalls ?? [],
+    activeCallIds: new Set(),
+    requestInFlightSince: opts.requestInFlightSince,
+  };
+  const entry: ActiveSubagent = {
+    name: opts.displayName,
+    type: 'spawn',
+    task: 'test-task',
+    status: opts.status ?? 'running',
+    startedAt: opts.startedAt,
+    lastActivityAt: opts.lastActivityAt,
+    toolCallsCount: 0,
+    findingsCount: 0,
+  };
+  const privateView = mod as unknown as {
+    liveSubagents: Map<string, FakeLiveState>;
+    frameworkNameIndex: Map<string, string>;
+  };
+  privateView.liveSubagents.set(opts.displayName, live);
+  privateView.frameworkNameIndex.set(frameworkAgentName, opts.displayName);
+  mod.activeSubagents.set(`entry-${opts.displayName}`, entry);
+  return { live, entry };
+}
+
+/** Captures the trace handler that SubagentModule.setFramework registers, so
+ *  the lifecycle test can fire events without spinning up the full framework. */
+function makeTraceCapturingFramework(): {
+  framework: { onTrace: (cb: (e: TraceEvent) => void) => void };
+  fire: (event: TraceEvent) => void;
+} {
+  let captured: ((e: TraceEvent) => void) | null = null;
+  return {
+    framework: {
+      onTrace(cb: (e: TraceEvent) => void) {
+        captured = cb;
+      },
+    },
+    fire(event: TraceEvent) {
+      if (!captured) throw new Error('onTrace was never called');
+      captured(event);
+    },
+  };
+}
+
+describe('SubagentModule reaper — F3 request-in-flight protection', () => {
+  test('reaper does NOT cancel an agent with a request in flight', () => {
+    // Postmortem scenario: stream_resumed fired, currentStream + pendingToolCalls
+    // cleared, the next LLM round is on the wire. lastActivityAt is frozen at
+    // the moment of stream_resumed dispatch. TTFT is 45s — pre-fix the reaper
+    // would strike mid-request because all of (!currentStream, no pending tools,
+    // silentMs > threshold) hold. With the in-flight guard, the agent is left
+    // alone.
+    const now = Date.now();
+    const mod = new SubagentModule();
+    const { entry } = installSubagent(mod, {
+      displayName: 'opus-in-flight',
+      startedAt: now - 5 * 60_000,
+      lastActivityAt: now - 3 * 60_000,        // well past any threshold
+      requestInFlightSince: now - 3 * 60_000,  // request dispatched, no token yet
+    });
+
+    const reclaimed = (mod as unknown as { reclaimZombieSlots: () => number })
+      .reclaimZombieSlots();
+
+    expect(reclaimed).toBe(0);
+    expect(entry.status).toBe('running');
+  });
+
+  test('reaper DOES cancel a genuinely silent agent (control)', () => {
+    // Same staleness, but no request in flight — this is the "stuck" case the
+    // reaper exists to clean up. 5 min silence exceeds both the pre- and
+    // post-fix thresholds, so this test stays valid if the threshold is
+    // tuned in either direction.
+    const now = Date.now();
+    const mod = new SubagentModule();
+    const { entry } = installSubagent(mod, {
+      displayName: 'genuinely-stuck',
+      startedAt: now - 10 * 60_000,
+      lastActivityAt: now - 5 * 60_000,
+    });
+
+    const reclaimed = (mod as unknown as { reclaimZombieSlots: () => number })
+      .reclaimZombieSlots();
+
+    expect(reclaimed).toBe(1);
+    // Postmortem 2026-05-28 P1 #4: zombie-reaped subagents land in
+    // 'cancelled' (terminal-but-benign), not 'failed'. Aligns the
+    // SubagentModule's terminal state with the reducer's split between
+    // genuine faults (inference:failed) and benign cancels.
+    expect(entry.status).toBe('cancelled');
+  });
+
+  test('peek.isZombie also respects requestInFlightSince', async () => {
+    // The peek surface drives the orchestrator's perception. Postmortem F2 was
+    // about dual clocks; F3 is the same shape: a healthy in-flight agent must
+    // not report isZombie=true.
+    const now = Date.now();
+    const mod = new SubagentModule();
+    installSubagent(mod, {
+      displayName: 'opus-in-flight',
+      startedAt: now - 5 * 60_000,
+      lastActivityAt: now - 3 * 60_000,
+      requestInFlightSince: now - 3 * 60_000,
+    });
+    const [snap] = await mod.peek('opus-in-flight');
+    expect(snap!.isZombie).toBe(false);
+  });
+
+  test('lifecycle: inference:started sets requestInFlightSince', () => {
+    const now = Date.now();
+    const mod = new SubagentModule();
+    const { live } = installSubagent(mod, {
+      displayName: 'lc',
+      frameworkAgentName: 'fw-lc',
+      startedAt: now - 10_000,
+      lastActivityAt: now - 10_000,
+    });
+    expect(live.requestInFlightSince).toBeUndefined();
+
+    const fake = makeTraceCapturingFramework();
+    // setFramework registers the onTrace handler. Cast: our fake satisfies the
+    // surface SubagentModule uses at registration time.
+    mod.setFramework(fake.framework as never);
+
+    fake.fire({ type: 'inference:started', agentName: 'fw-lc', timestamp: Date.now() } as never);
+    expect(typeof live.requestInFlightSince).toBe('number');
+  });
+
+  test('lifecycle: first inference:tokens clears requestInFlightSince', () => {
+    const now = Date.now();
+    const mod = new SubagentModule();
+    const { live } = installSubagent(mod, {
+      displayName: 'lc2',
+      frameworkAgentName: 'fw-lc2',
+      startedAt: now - 10_000,
+      lastActivityAt: now - 10_000,
+      requestInFlightSince: now - 5_000,
+    });
+
+    const fake = makeTraceCapturingFramework();
+    mod.setFramework(fake.framework as never);
+
+    fake.fire({ type: 'inference:tokens', agentName: 'fw-lc2', content: 'hello', timestamp: Date.now() } as never);
+    expect(live.requestInFlightSince).toBeUndefined();
+  });
+
+  test('lifecycle: inference:stream_resumed sets requestInFlightSince again', () => {
+    // After a tool round, the framework emits stream_resumed and dispatches a
+    // new request. This is the gap the postmortem traced reaps to.
+    const now = Date.now();
+    const mod = new SubagentModule();
+    const { live } = installSubagent(mod, {
+      displayName: 'lc3',
+      frameworkAgentName: 'fw-lc3',
+      startedAt: now - 60_000,
+      lastActivityAt: now - 60_000,
+    });
+
+    const fake = makeTraceCapturingFramework();
+    mod.setFramework(fake.framework as never);
+
+    fake.fire({ type: 'inference:stream_resumed', agentName: 'fw-lc3', timestamp: Date.now() } as never);
+    expect(typeof live.requestInFlightSince).toBe('number');
+  });
+});

--- a/web/src/Tree.tsx
+++ b/web/src/Tree.tsx
@@ -267,6 +267,11 @@ function phaseColor(phase: AgentNode['phase']): string {
     case 'executing': return 'bg-amber-500/30 text-amber-200';
     case 'done': return 'bg-neutral-700 text-neutral-400';
     case 'failed': return 'bg-rose-500/40 text-rose-200';
+    // Postmortem 2026-05-28 P1 #3: 'cancelled' is terminal-but-benign.
+    // A slightly warmer dim than 'done' so the operator can spot which
+    // children ended on a cancel vs. a successful turn, without the
+    // false-alarm RED of 'failed'.
+    case 'cancelled': return 'bg-neutral-700 text-amber-300/70';
     default: return 'bg-neutral-800 text-neutral-400';
   }
 }


### PR DESCRIPTION
Bundles two strands of unpushed work into one PR.

## Subagent / zombies — postmortem 2026-05-28
Closes the three root causes from the Lynx Boter Knowledge Mining Triumvirate run:
- **F1 — reducer status latch.** `inference:completed` now sets `status='completed'` + clears the aborted/exhausted/failed latch, so benign-cancel subagents stop showing permanent RED.
- **F2 — peek dual-clock.** `peek.isZombie` now keys off `lastActivityAt` (matching the reaper) instead of `startedAt` — the dominant driver of the failed-label / retry storm.
- **F3 — reaper in-flight gap.** New `requestInFlightSince` on `LiveSubagentState` so the reaper no longer kills scouts during long TTFT windows; threshold 30s→120s, sweep 30s→60s.
- **cancelled vs failed split.** New `'cancelled'` terminal state across `AgentStatus`/`AgentPhase`/`ActiveSubagent`/`PersistedSubagent`/`SubagentPeekSnapshot`; TUI + `web/src/Tree.tsx` paint it neutral, not red.
- **descendant scoping.** peek / HUD Fleet Status filter to the caller's descendants — peers/cousins no longer visible.

Tests: +19 across three new files (peek-zombie, reaper-in-flight, peek-scoping) plus reducer cases.

## TUI UX — multi-line input
- `TextareaRenderable` replaces the single-line input. Enter submits; Alt+Enter / Ctrl+J insert a newline.
- Informative paste placeholders (`[paste #N: "head…" Nch, Mlines]`); short single-line pastes inlined.

**Note:** the input-box auto-grow experiment was excised — it didn't work reliably. Multi-line input stays; the box is fixed-height for now.

## Verification
- `tsc --noEmit`: 0 errors
- `bun test`: 311 pass / 0 fail
