### PR TITLE
Wire sleep-tool privileged-users file into the gate

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -202,6 +202,11 @@ async function createFramework(
     if (typeof modules.wake === 'object' && 'policies' in modules.wake) {
       gateOptions.config = modules.wake as import('@animalabs/agent-framework').GateConfig;
     }
+    // Privileged-users file for the `sleep` tool — users who may wake the agent
+    // through a sleep window. Stable across sessions (install-dir relative);
+    // override with SLEEP_PRIVILEGED_FILE. Edit the file to change the list.
+    gateOptions.privilegedUsersPath =
+      process.env.SLEEP_PRIVILEGED_FILE || resolve('./sleep-privileged.json');
   }
 
   // Workspace (replaces FilesModule + LocalFilesModule)


### PR DESCRIPTION
Adds `gateOptions.privilegedUsersPath` (env `SLEEP_PRIVILEGED_FILE`, default install-dir-relative `./sleep-privileged.json`) so the EventGate's `sleep` tool can let listed users wake the agent through a sleep window.

**Cross-repo dependency:** the `GateOptions.privilegedUsersPath` field lands in agent-framework (on `consolidate/adaptive-default`). This is a 4-line wiring change; no behavior unless that field is consumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)