### PR TITLE
Host: ANTHROPIC_BASE_URL passthrough to the adapter

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -626,7 +626,7 @@ function countLines(path: string): number {
 async function main() {
   const recipe = await resolveRecipe();
 
-  const adapter = new AnthropicAdapter({ apiKey: config.apiKey! });
+  const adapter = new AnthropicAdapter({ apiKey: config.apiKey!, baseURL: process.env.ANTHROPIC_BASE_URL || undefined });
 
   // LLM call log: appends one JSON line per request to {dataDir}/llm-calls.jsonl.
   // Useful for post-mortem debugging when the TUI/headless flashes errors past.


### PR DESCRIPTION
Passes `process.env.ANTHROPIC_BASE_URL` into the Anthropic adapter so the host can target an alternate gateway (e.g. Vercel AI Gateway) via env alone.

**Why it matters:** when a model is deprecated on the direct Anthropic API but still served through a gateway, this is the lifeline — point `ANTHROPIC_BASE_URL` at the gateway, set the gateway model id, and the agent keeps running on its real model and native format. Verified live (the adapter's `x-api-key` auth works against Vercel's `/v1/messages`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)