### PR TITLE
webui: context makeup view (segments + exact tokens)

### DIFF
--- a/src/modules/web-ui-module.ts
+++ b/src/modules/web-ui-module.ts
@@ -692,6 +692,91 @@ export class WebUiModule implements Module {
     return this.serveStatic(requested);
   }
 
+  /**
+   * Context makeup: the segment breakdown of the agent's current compiled
+   * context — head window, raw middle, summaries by level (L1/L2/L3), and the
+   * recent verbatim tail — from the strategy's RenderStats, plus an exact
+   * total token count via the model's count_tokens endpoint. Transparent:
+   * previewActivation + count_tokens only; no inference, no Chronicle writes.
+   *
+   *   GET /debug/context/makeup[?agent=<name>]
+   */
+  private async handleContextMakeup(url: URL): Promise<Response> {
+    const app = sharedServer?.app;
+    if (!app) return new Response('Not ready', { status: 503 });
+    const agentName = url.searchParams.get('agent') || app.recipe.agent.name || 'agent';
+    const agent = app.framework.getAgent(agentName);
+    if (!agent) {
+      return new Response(JSON.stringify({ error: `Agent not found: ${agentName}` }), {
+        status: 404, headers: { 'content-type': 'application/json' },
+      });
+    }
+    try {
+      // Populates the strategy's render stats as a side-effect of compiling.
+      const request = await app.framework.previewActivation(agentName);
+      const cm = (agent as { getContextManager: () => { getRenderStats: () => unknown } }).getContextManager();
+      const stats = cm.getRenderStats();
+
+      // Build an Anthropic-faithful payload for an exact count_tokens: map
+      // participants to roles (the agent's own -> assistant, others -> user
+      // with a "Name:" prefix) and merge consecutive same-role runs, mirroring
+      // what the NativeFormatter sends.
+      const textOf = (c: unknown): string =>
+        Array.isArray(c)
+          ? c.map((b) => (b && typeof b === 'object' && (b as { type?: string }).type === 'text' ? (b as { text: string }).text : '')).join('')
+          : String(c ?? '');
+      const merged: Array<{ role: 'user' | 'assistant'; text: string }> = [];
+      for (const m of ((request as { messages?: Array<{ participant?: string; role?: string; content: unknown }> }).messages ?? [])) {
+        const who = m.participant ?? m.role ?? 'user';
+        const role: 'user' | 'assistant' = who === agentName ? 'assistant' : 'user';
+        let t = textOf(m.content);
+        if (role === 'user' && who && who !== 'user') t = `${who}: ${t}`;
+        const last = merged[merged.length - 1];
+        if (last && last.role === role) last.text += '\n' + t;
+        else merged.push({ role, text: t });
+      }
+      const anthMessages = merged.filter((m) => m.text.trim().length > 0).map((m) => ({ role: m.role, content: m.text }));
+      const sysRaw = (request as { system?: unknown }).system;
+      const systemStr = Array.isArray(sysRaw)
+        ? sysRaw.map((b) => (b && typeof b === 'object' ? (b as { text?: string }).text ?? '' : String(b))).join('\n')
+        : (typeof sysRaw === 'string' ? sysRaw : undefined);
+
+      let exactTotalTokens: number | null = null;
+      const countModel = process.env.COUNT_TOKENS_MODEL || 'anthropic/claude-opus-4.5';
+      let countSource = 'count_tokens';
+      try {
+        const base = (process.env.ANTHROPIC_BASE_URL || 'https://api.anthropic.com').replace(/\/$/, '');
+        const res = await fetch(base + '/v1/messages/count_tokens', {
+          method: 'POST',
+          headers: {
+            'x-api-key': process.env.ANTHROPIC_API_KEY ?? '',
+            'anthropic-version': '2023-06-01',
+            'content-type': 'application/json',
+            'user-agent': 'conhost/1.0',
+          },
+          body: JSON.stringify({ model: countModel, ...(systemStr ? { system: systemStr } : {}), messages: anthMessages }),
+        });
+        if (res.ok) {
+          const j = (await res.json()) as { input_tokens?: number };
+          exactTotalTokens = j.input_tokens ?? null;
+        } else {
+          countSource = `count_tokens_failed_${res.status}`;
+        }
+      } catch {
+        countSource = 'count_tokens_error';
+      }
+
+      return new Response(
+        JSON.stringify({ agent: agentName, stats, exactTotalTokens, countModel, countSource }, null, 2),
+        { headers: { 'content-type': 'application/json' } },
+      );
+    } catch (error) {
+      return new Response(JSON.stringify({ error: error instanceof Error ? error.message : String(error) }), {
+        status: 500, headers: { 'content-type': 'application/json' },
+      });
+    }
+  }
+
   private async serveWorkspaceFile(rest: string): Promise<Response> {
     if (!sharedServer?.app) return new Response('Not ready', { status: 503 });
     const decoded = decodeURIComponent(rest);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -10,6 +10,7 @@ import { UsagePanel } from './Usage';
 import { LessonsPanel, type LessonRow } from './Lessons';
 import { McplPanel, type McplServerRow } from './Mcpl';
 import { FilesPanel, FileViewerModal, type Mount, type FlatEntry, type FileViewer } from './Files';
+import { ContextPanel } from './Context';
 import type {
   WebUiServerMessage,
   WelcomeMessage,
@@ -83,7 +84,7 @@ export function App() {
 
   /** Right-sidebar tab selection. The Tree is the most-used surface so it's
    *  the default; lessons / mcp / files are operator-driven panels. */
-  type SidebarTab = 'tree' | 'lessons' | 'mcp' | 'files';
+  type SidebarTab = 'tree' | 'lessons' | 'mcp' | 'files' | 'context';
   const [sidebarTab, setSidebarTab] = createSignal<SidebarTab>('tree');
 
   /** Scope shared by Lessons / Files / Recipe panels. 'local' means the
@@ -682,6 +683,9 @@ export function App() {
                 onOpenFile={requestFile}
               />
             </Show>
+            <Show when={sidebarTab() === 'context'}>
+              <ContextPanel agent={panelScope() === 'local' ? undefined : panelScope()} />
+            </Show>
           </div>
           <RecipePane welcome={welcome()} scope={panelScope()} />
         </aside>
@@ -1024,14 +1028,15 @@ function CommandSuggestions(props: { draft: string; onPick: (cmd: string) => voi
 }
 
 function SidebarTabs(props: {
-  current: 'tree' | 'lessons' | 'mcp' | 'files';
-  onSelect: (tab: 'tree' | 'lessons' | 'mcp' | 'files') => void;
+  current: 'tree' | 'lessons' | 'mcp' | 'files' | 'context';
+  onSelect: (tab: 'tree' | 'lessons' | 'mcp' | 'files' | 'context') => void;
 }) {
-  const tabs: Array<{ id: 'tree' | 'lessons' | 'mcp' | 'files'; label: string; title: string }> = [
+  const tabs: Array<{ id: 'tree' | 'lessons' | 'mcp' | 'files' | 'context'; label: string; title: string }> = [
     { id: 'tree', label: 'Tree', title: 'Agent + fleet tree' },
     { id: 'lessons', label: 'Lessons', title: 'Lesson library' },
     { id: 'mcp', label: 'MCP', title: 'MCPL servers' },
     { id: 'files', label: 'Files', title: 'Workspace mounts + files' },
+    { id: 'context', label: 'Context', title: 'Compiled context makeup' },
   ];
   return (
     <div class="flex border-b border-neutral-800 bg-neutral-900/40 text-[11px]">

--- a/web/src/Context.tsx
+++ b/web/src/Context.tsx
@@ -1,0 +1,158 @@
+/**
+ * Context panel — the makeup of the agent's current compiled context.
+ *
+ * Reads GET /debug/context/makeup (transparent: previewActivation +
+ * count_tokens, no inference / no writes) and shows the segment breakdown the
+ * autobiographical strategy produced: head window, raw middle, summaries by
+ * level (L1/L2/L3), and the recent verbatim tail — as a proportional bar plus
+ * a per-segment table, with an exact total token count.
+ */
+
+import { createSignal, onMount, For, Show } from 'solid-js';
+
+interface Seg { messages: number; tokens: number }
+interface Stats {
+  head: Seg;
+  tail: Seg;
+  middleRaw: Seg;
+  summaries: { l1: { count: number; tokens: number }; l2: { count: number; tokens: number }; l3: { count: number; tokens: number } };
+  pending: { chunks: number; merges: number };
+  total: Seg;
+}
+interface Makeup {
+  agent: string;
+  stats: Stats | null;
+  exactTotalTokens: number | null;
+  countModel: string;
+  countSource: string;
+  error?: string;
+}
+
+type Row = { key: string; label: string; messages: number; tokens: number; color: string };
+
+const fmt = (n: number) => n.toLocaleString();
+
+function rowsOf(s: Stats): Row[] {
+  return [
+    { key: 'head', label: 'Head (oldest, verbatim)', messages: s.head.messages, tokens: s.head.tokens, color: '#64748b' },
+    { key: 'l1', label: 'Summaries · L1', messages: s.summaries.l1.count, tokens: s.summaries.l1.tokens, color: '#06b6d4' },
+    { key: 'l2', label: 'Summaries · L2', messages: s.summaries.l2.count, tokens: s.summaries.l2.tokens, color: '#3b82f6' },
+    { key: 'l3', label: 'Summaries · L3', messages: s.summaries.l3.count, tokens: s.summaries.l3.tokens, color: '#6366f1' },
+    { key: 'middleRaw', label: 'Middle (raw, verbatim)', messages: s.middleRaw.messages, tokens: s.middleRaw.tokens, color: '#f59e0b' },
+    { key: 'tail', label: 'Recent tail (verbatim)', messages: s.tail.messages, tokens: s.tail.tokens, color: '#10b981' },
+  ].filter((r) => r.tokens > 0 || r.messages > 0);
+}
+
+export function ContextPanel(props: { agent?: string }) {
+  const [data, setData] = createSignal<Makeup | null>(null);
+  const [loading, setLoading] = createSignal(false);
+  const [err, setErr] = createSignal<string | null>(null);
+
+  const load = async () => {
+    setLoading(true);
+    setErr(null);
+    try {
+      const q = props.agent ? `?agent=${encodeURIComponent(props.agent)}` : '';
+      const res = await fetch(`/debug/context/makeup${q}`, { credentials: 'same-origin' });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const j = (await res.json()) as Makeup;
+      if (j.error) throw new Error(j.error);
+      setData(j);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  onMount(load);
+
+  const estTotal = () => data()?.stats?.total.tokens ?? 0;
+  const rows = () => {
+    const s = data()?.stats;
+    return s ? rowsOf(s) : [];
+  };
+
+  return (
+    <div class="p-2 text-[11px] font-mono text-neutral-300 space-y-3">
+      <div class="flex items-center justify-between">
+        <span class="text-neutral-400">Context makeup{data()?.agent ? ` · ${data()!.agent}` : ''}</span>
+        <button
+          type="button"
+          class="px-2 py-0.5 text-neutral-400 hover:text-neutral-100 border border-neutral-700 rounded"
+          onClick={load}
+          disabled={loading()}
+        >
+          {loading() ? '…' : 'refresh'}
+        </button>
+      </div>
+
+      <Show when={err()}>
+        <div class="text-rose-400">error: {err()}</div>
+      </Show>
+
+      <Show when={data()?.stats} fallback={<Show when={!err()}><div class="text-neutral-500">loading…</div></Show>}>
+        {/* headline totals */}
+        <div class="flex gap-4">
+          <div>
+            <div class="text-2xl text-neutral-100">{fmt(data()!.exactTotalTokens ?? estTotal())}</div>
+            <div class="text-neutral-500">
+              {data()!.exactTotalTokens != null ? 'tokens (exact)' : 'tokens (est)'}
+            </div>
+          </div>
+          <div class="self-end text-neutral-500">
+            {fmt(data()!.stats!.total.messages)} msgs · est {fmt(estTotal())}
+          </div>
+        </div>
+
+        {/* proportional bar */}
+        <div class="flex h-4 w-full overflow-hidden rounded border border-neutral-800">
+          <For each={rows()}>
+            {(r) => (
+              <div
+                style={{ width: `${(r.tokens / Math.max(1, estTotal())) * 100}%`, background: r.color }}
+                title={`${r.label}: ${fmt(r.tokens)} tok`}
+              />
+            )}
+          </For>
+        </div>
+
+        {/* per-segment table */}
+        <table class="w-full">
+          <thead>
+            <tr class="text-neutral-500 text-left">
+              <th class="font-normal py-1">segment</th>
+              <th class="font-normal text-right">msgs</th>
+              <th class="font-normal text-right">tokens</th>
+              <th class="font-normal text-right">%</th>
+            </tr>
+          </thead>
+          <tbody>
+            <For each={rows()}>
+              {(r) => (
+                <tr class="border-t border-neutral-900">
+                  <td class="py-1">
+                    <span class="inline-block w-2 h-2 mr-2 rounded-sm align-middle" style={{ background: r.color }} />
+                    {r.label}
+                  </td>
+                  <td class="text-right text-neutral-400">{fmt(r.messages)}</td>
+                  <td class="text-right text-neutral-200">{fmt(r.tokens)}</td>
+                  <td class="text-right text-neutral-500">{((r.tokens / Math.max(1, estTotal())) * 100).toFixed(1)}%</td>
+                </tr>
+              )}
+            </For>
+          </tbody>
+        </table>
+
+        <div class="text-neutral-500 space-y-0.5">
+          <div>
+            pending compression: {data()!.stats!.pending.chunks} chunk(s), {data()!.stats!.pending.merges} merge(s)
+          </div>
+          <div>
+            exact via count_tokens ({data()!.countModel}; same tokenizer) · per-segment tokens are strategy estimates
+          </div>
+        </div>
+      </Show>
+    </div>
+  );
+}


### PR DESCRIPTION
Adds a **Context** tab to the webui showing the makeup of the agent's current compiled context.

- **Backend:** `GET /debug/context/makeup` returns the strategy's `RenderStats` (head / middle-raw / summaries L1–L3 / recent tail, each with message + token counts) plus an **exact total** via `count_tokens` (uses a live Claude model id — shared tokenizer, so the count is exact even when the agent's own model is gateway-routed/deprecated). Transparent: `previewActivation` + `count_tokens` only.
- **Frontend:** new SolidJS `ContextPanel` — proportional segment bar + per-segment table + exact total.

Came out of needing to see how much of a long-running agent's context is summarized memory vs raw recent (e.g. ~half L1 summaries at 120k tokens).

🤖 Generated with [Claude Code](https://claude.com/claude-code)