### PR TITLE
feat(host): record MCPL connection-lifecycle traces in per-server logs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -347,6 +347,7 @@ async function createFramework(
       if (recipeEntry.disabledTools !== undefined) merged.disabledTools = recipeEntry.disabledTools;
       if (recipeEntry.reconnect !== undefined) merged.reconnect = recipeEntry.reconnect;
       if (recipeEntry.reconnectIntervalMs !== undefined) merged.reconnectIntervalMs = recipeEntry.reconnectIntervalMs;
+      if (recipeEntry.reconnectMaxIntervalMs !== undefined) merged.reconnectMaxIntervalMs = recipeEntry.reconnectMaxIntervalMs;
       // Let a recipe override/adopt WebSocket transport for a file-defined server.
       if (recipeEntry.url !== undefined) merged.url = recipeEntry.url;
       if (recipeEntry.transport !== undefined) merged.transport = recipeEntry.transport;
@@ -526,6 +527,26 @@ function setupSynesthete(app: AppContext): void {
 
 const MCPL_STDERR_LOG_MAX_BYTES = 10 * 1024 * 1024; // 10 MB; rolls to .1 on overflow.
 
+/** Render an mcpl:server-* connection-lifecycle trace as a log line, or null
+ *  for trace types this sink doesn't record. Lifecycle lines are prefixed
+ *  `[host]` to stand apart from the server's own stderr output. */
+function formatMcplLifecycleLine(event: { type: string } & Record<string, unknown>): string | null {
+  switch (event.type) {
+    case 'mcpl:server-stderr':
+      return String(event.line);
+    case 'mcpl:server-connect-failed':
+      return `[host] connect failed (attempt ${event.attempt}, ${event.willRetry ? 'will retry' : 'NO RETRY — server unavailable until restart'}): ${event.error}`;
+    case 'mcpl:server-reconnected':
+      return `[host] reconnected after ${event.attempts} attempt(s)`;
+    case 'mcpl:server-closed':
+      return `[host] connection closed (code=${event.code}, signal=${event.signal}${event.willReconnect ? ', reconnect scheduled' : ''})`;
+    case 'mcpl:server-error':
+      return `[host] connection error: ${event.error}`;
+    default:
+      return null;
+  }
+}
+
 function setupMcplStderrLog(app: AppContext, storePath: string): void {
   const dir = join(storePath, 'mcpl-stderr');
   // Best-effort directory creation — if it fails, per-write attempts will too,
@@ -533,12 +554,14 @@ function setupMcplStderrLog(app: AppContext, storePath: string): void {
   void mkdir(dir, { recursive: true }).catch(() => {});
 
   app.framework.onTrace((event) => {
-    if (event.type !== 'mcpl:server-stderr') return;
-    const e = event as unknown as { serverId: string; line: string; timestamp: number };
+    const e = event as unknown as { type: string; serverId?: string; timestamp: number } & Record<string, unknown>;
+    if (typeof e.serverId !== 'string') return;
+    const line = formatMcplLifecycleLine(e);
+    if (line === null) return;
     const iso = new Date(e.timestamp).toISOString();
     // basename guards against a misconfigured serverId like "../foo" escaping dir.
     const path = join(dir, `${basename(e.serverId)}.log`);
-    const entry = `${iso} ${e.line}\n`;
+    const entry = `${iso} ${line}\n`;
     void rotateIfNeeded(path, entry.length)
       .then(() => appendFile(path, entry))
       .catch(() => {

--- a/src/mcpl-config.ts
+++ b/src/mcpl-config.ts
@@ -20,6 +20,7 @@ export interface ServerFileEntry {
   toolPrefix?: string;
   reconnect?: boolean;
   reconnectIntervalMs?: number;
+  reconnectMaxIntervalMs?: number;
   enabledFeatureSets?: string[];
   disabledFeatureSets?: string[];
   enabledTools?: string[];
@@ -66,6 +67,7 @@ export function loadMcplServers(configPath: string): LoadedServerConfig[] {
       toolPrefix: entry.toolPrefix,
       reconnect: entry.reconnect,
       reconnectIntervalMs: entry.reconnectIntervalMs,
+      reconnectMaxIntervalMs: entry.reconnectMaxIntervalMs,
       enabledFeatureSets: entry.enabledFeatureSets,
       disabledFeatureSets: entry.disabledFeatureSets,
       enabledTools: entry.enabledTools,

--- a/src/recipe.ts
+++ b/src/recipe.ts
@@ -115,7 +115,11 @@ export interface RecipeMcpServer {
    */
   disabledTools?: string[];
   reconnect?: boolean;
+  /** Base reconnect interval; the framework doubles it per consecutive
+   *  failure (with jitter) up to reconnectMaxIntervalMs. */
   reconnectIntervalMs?: number;
+  /** Ceiling for the exponential reconnect backoff. Default: 5 minutes. */
+  reconnectMaxIntervalMs?: number;
   /**
    * Channel auto-open policy. 'auto' (default) opens everything the server
    * registers; 'manual' opens nothing (agent calls channel_open as needed);


### PR DESCRIPTION
## Problem

The `mcpl-stderr` sink only captures each MCPL server's own stderr; connect and reconnect failures live solely on the host process's stderr. A server that loses the boot handshake race (npx cold-cache race, Tengro/connectome-cook#7) just goes missing until someone ssh's in and reads process logs.

## Changes

- `setupMcplStderrLog` now also records the framework's new `mcpl:server-*` connection-lifecycle traces (connect-failed / reconnected / closed / error) in the same `<store>/mcpl-stderr/<serverId>.log`, prefixed `[host]` to stand apart from server output. The web UI receives these traces automatically via the generic `fanOutTrace`, so no UI change is needed.
- Plumbs the new `reconnectMaxIntervalMs` (exponential-backoff ceiling) through `ServerFileEntry`, the recipe `mcpServers` merge, and the recipe type.

Companion to anima-research/agent-framework#52, which adds the trace events, the backoff, and fixes a latent unhandled-'error' crash. This PR is safe to land independently: the sink filters by trace type and payload shape, so against an older AF it simply keeps logging stderr lines only.

## Tests

`bun test`: the 13 failing Fleet/headless e2e tests fail identically on clean main (environment-dependent); no new failures. `tsc`: the 12 pre-existing errors (AF version skew) are unchanged; no new errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)