### PR TITLE
fix(miner): re-pin scribe to upstream dariakroshka/scribe-mcp (post-#1 merge)

### DIFF
--- a/recipes/knowledge-miner.json
+++ b/recipes/knowledge-miner.json
@@ -76,8 +76,8 @@
         "SCRIBE_GLOSSARY_URL": "${SCRIBE_GLOSSARY_URL:-}"
       },
       "source": {
-        "url": "https://github.com/Tengro/scribe-mcp.git",
-        "ref": "c0deddc73581a4d8be6e28d7e1db00170ebc60cd",
+        "url": "https://github.com/dariakroshka/scribe-mcp.git",
+        "ref": "828ae8ba6ea83ce439ce6ba020ed0223cf096f82",
         "install": {
           "runtime": "bun",
           "run": "bun install --frozen-lockfile"


### PR DESCRIPTION
## Why

#41 merged with the scribe source pinned at the **`Tengro/scribe-mcp` fork @ `c0deddc`**, because the self-contained-binaries change ([dariakroshka/scribe-mcp#1](https://github.com/dariakroshka/scribe-mcp/pull/1)) was still in review at the time. That PR has now **merged** (`dariakroshka/scribe-mcp` main @ `828ae8b`), so this points the recipe back at the canonical repo.

## Change

`recipes/knowledge-miner.json` → `mcpServers.scribe.source`:
- `url`: `Tengro/scribe-mcp.git` → `dariakroshka/scribe-mcp.git`
- `ref`: `c0deddc…` → `828ae8b…` (the merge commit; includes the review fixes — smoke script, stderr fallback, supply-chain docs)

No other changes. The bundled ffmpeg/ffprobe + `fetch`-based download mean no `systemPackages` / apt deps are needed (already the case since #41).

🤖 Generated with [Claude Code](https://claude.com/claude-code)