### PR TITLE
feat(recipe): expose per-agent cacheTtl ('5m' | '1h')

### DIFF
--- a/docs/AGENT-ONBOARDING.md
+++ b/docs/AGENT-ONBOARDING.md
@@ -243,6 +243,7 @@ ln -sfn ../../../connectome-local/context-manager/node_modules/@animalabs/chroni
     "maxTokens": 16384,                     // response cap
     "maxStreamTokens": 180000,              // recompile trigger; keep < model window
     "contextBudgetTokens": 160000,          // SEE §11.1 — MUST fit under (window - maxTokens)
+    "cacheTtl": "1h",                       // prompt-cache TTL; '1h' for residents replying slower than 5m (cache re-write premium dominates spend otherwise), omit/'5m' for rapid loops
     "strategy": {
       "type": "autobiographical",
       "headWindowTokens": 4000,

--- a/src/index.ts
+++ b/src/index.ts
@@ -448,6 +448,7 @@ async function createFramework(
         maxTokens: recipe.agent.maxTokens ?? 16384,
         maxStreamTokens: recipe.agent.maxStreamTokens ?? 150000,
         contextBudgetTokens: recipe.agent.contextBudgetTokens,
+        ...(recipe.agent.cacheTtl && { cacheTtl: recipe.agent.cacheTtl }),
         strategy,
         ...(recipe.agent.thinking && { thinking: recipe.agent.thinking }),
         ...(recipe.agent.refusalHandling && { refusalHandling: recipe.agent.refusalHandling }),

--- a/src/recipe.ts
+++ b/src/recipe.ts
@@ -673,6 +673,12 @@ export function validateRecipe(raw: unknown): Recipe {
     throw new Error('Recipe agent.maxStreamTokens must be a positive number.');
   }
 
+  // Recipes are runtime JSON; a typo'd TTL ("1hr", "60m") would otherwise
+  // surface as a 400 from Anthropic at the agent's first inference.
+  if (agent.cacheTtl !== undefined && agent.cacheTtl !== '5m' && agent.cacheTtl !== '1h') {
+    throw new Error(`Recipe agent.cacheTtl must be '5m' or '1h', got ${JSON.stringify(agent.cacheTtl)}.`);
+  }
+
   // Validate agent.thinking if present. Catches typos and constraint
   // violations (notably max_tokens > budget_tokens) at recipe-load time
   // rather than as a 400 from Anthropic at first inference.

--- a/src/recipe.ts
+++ b/src/recipe.ts
@@ -77,6 +77,10 @@ export interface RecipeAgent {
   /** Per-agent context compile budget (input tokens). When unset, the
    *  ContextManager default (100k) applies. Raise for large-context models. */
   contextBudgetTokens?: number;
+  /** Prompt-cache TTL ('5m' | '1h') forwarded to the provider. Set '1h' for
+   *  agents whose reply cadence is slower than 5 minutes — avoids re-writing
+   *  the full context to cache after every gap. Unset: provider default (5m). */
+  cacheTtl?: '5m' | '1h';
   strategy?: RecipeStrategy;
   /**
    * Native extended thinking. When `enabled: true`, the agent's API requests

--- a/test/recipe-cache-ttl.test.ts
+++ b/test/recipe-cache-ttl.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Tests for recipe.agent.cacheTtl: accepted values pass validation and an
+ * invalid TTL fails at recipe-load time (not as a provider 400 at first
+ * inference).
+ */
+import { describe, test, expect } from 'bun:test';
+import { validateRecipe } from '../src/recipe.js';
+
+function recipeWithCacheTtl(cacheTtl?: unknown) {
+  return {
+    name: 'ttl-test',
+    agent: {
+      systemPrompt: 'sys',
+      ...(cacheTtl !== undefined && { cacheTtl }),
+    },
+  };
+}
+
+describe('recipe agent.cacheTtl validation', () => {
+  test('accepts "5m"', () => {
+    expect(validateRecipe(recipeWithCacheTtl('5m')).agent.cacheTtl).toBe('5m');
+  });
+
+  test('accepts "1h"', () => {
+    expect(validateRecipe(recipeWithCacheTtl('1h')).agent.cacheTtl).toBe('1h');
+  });
+
+  test('accepts unset (provider default applies)', () => {
+    expect(validateRecipe(recipeWithCacheTtl()).agent.cacheTtl).toBeUndefined();
+  });
+
+  test('rejects a typo\'d TTL at load time', () => {
+    expect(() => validateRecipe(recipeWithCacheTtl('1hr'))).toThrow(/cacheTtl must be '5m' or '1h'/);
+    expect(() => validateRecipe(recipeWithCacheTtl('60m'))).toThrow(/cacheTtl/);
+    expect(() => validateRecipe(recipeWithCacheTtl(3600))).toThrow(/cacheTtl/);
+  });
+});


### PR DESCRIPTION
Two-line companion to anima-research/agent-framework#53: plumbs `recipe.agent.cacheTtl` → `AgentConfig.cacheTtl`, so a recipe can opt a persistent agent into 1-hour prompt-cache TTL.

Rationale + production measurements are in the framework PR (85% of a chatty resident's day-one spend was 5m-TTL cache re-writes; '1h' cuts an equivalent day to ~¼ cost).

Safe to merge in either order: before agent-framework#53 lands, the extra config field is ignored by the Agent constructor (no-op); after, it types and works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)