### PR TITLE
Recipe passthrough for productionBudgetTokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- **Standing autobiographical production target.** Recipes may set `agent.strategy.productionBudgetTokens` to keep the summary forest deep enough for a later live context-budget descent without a fold storm. This is a context-token target passed through to Context Manager, not a provider-spend ceiling; omission preserves Context Manager defaults.
+
 - **`BEDROCK_BASE_URL` env hook** for the bedrock provider — mirrors
   `ANTHROPIC_BASE_URL`, routing bedrock-runtime calls through an inference
   gateway (gate.animalabs.ai/bedrock/<credSet>). The gate reads the agent

--- a/src/framework-strategy.ts
+++ b/src/framework-strategy.ts
@@ -17,6 +17,7 @@ const PASSTHROUGH_KEYS: ReadonlyArray<keyof RecipeStrategy> = [
   'targetChunkTokens',
   'mergeThreshold',
   'summaryTargetTokens',
+  'productionBudgetTokens',
   'l1BudgetTokens',
   'l2BudgetTokens',
   'l3BudgetTokens',

--- a/src/recipe.ts
+++ b/src/recipe.ts
@@ -55,6 +55,10 @@ export interface RecipeStrategy {
   targetChunkTokens?: number;
   mergeThreshold?: number;
   summaryTargetTokens?: number;
+  /** Standing production target: keep the summary forest deep enough to fit
+   *  this budget, enabling a later live-budget descent with no fold-storm and
+   *  a single KV invalidation (see context-manager productionBudgetTokens). */
+  productionBudgetTokens?: number;
   l1BudgetTokens?: number;
   l2BudgetTokens?: number;
   l3BudgetTokens?: number;

--- a/test/framework-strategy-defaults.test.ts
+++ b/test/framework-strategy-defaults.test.ts
@@ -61,6 +61,25 @@ describe('standard-recipe memory defaults', () => {
     expect(config.foldingStrategy).toBeUndefined();
   });
 
+  test('productionBudgetTokens is passed through exactly and omission stays omitted', () => {
+    const configured = buildFrameworkStrategy(
+      recipe({
+        name: 'Mira',
+        strategy: { type: 'autobiographical', productionBudgetTokens: 123_456 },
+      }),
+      'some-model',
+      'America/Los_Angeles',
+    );
+    expect(configView(configured).productionBudgetTokens).toBe(123_456);
+
+    const omitted = buildFrameworkStrategy(
+      recipe({ name: 'Mira', strategy: { type: 'autobiographical' } }),
+      'some-model',
+      'America/Los_Angeles',
+    );
+    expect(configView(omitted).productionBudgetTokens).toBeUndefined();
+  });
+
   test('explicit recipe values override the defaults', () => {
     const strategy = buildFrameworkStrategy(
       recipe({


### PR DESCRIPTION
Expose Context Manager's standing `productionBudgetTokens` target through current Connectome Host recipe composition.

This is a **context-token production target**, not a provider-spend ceiling: it asks autobiographical maintenance to keep the summary forest deep enough for a later live-budget descent without a fold storm.

## Changes

- add `productionBudgetTokens?: number` to `RecipeStrategy`;
- pass an explicitly configured value through `buildFrameworkStrategy`;
- preserve omission as omission;
- focused test pins both configured and omitted behavior.

## Verification

Current-main rebase at head `a2d1160`:

- 604 passed
- 0 failed
- 1,942 assertions
- 68 files

Local Bun 1.3.14 proposed a lock rewrite during independent setup, but the PR's authoritative Ubuntu and macOS CI both completed their frozen install and full test path successfully; no lockfile change was needed for this feature.

