### PR TITLE
release connectome-host 0.3.2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
 
@@ -46,10 +46,10 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           # node 24 ships npm >= 11.5.1, required for OIDC publishing.
           node-version: 24

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,22 @@
 {
-  "name": "connectome-host",
-  "version": "0.3.0",
+  "name": "@animalabs/connectome-host",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "connectome-host",
-      "version": "0.3.0",
+      "name": "@animalabs/connectome-host",
+      "version": "0.3.2",
+      "hasInstallScript": true,
       "dependencies": {
-        "@animalabs/agent-framework": "^0.2.0",
-        "@animalabs/chronicle": "^0.1.1",
-        "@animalabs/context-manager": "^0.2.0",
-        "@animalabs/membrane": "^0.5.43",
+        "@animalabs/agent-framework": "^0.6.0",
+        "@animalabs/chronicle": "^0.2.0",
+        "@animalabs/context-manager": "^0.5.5",
+        "@animalabs/membrane": "^0.5.68",
         "@opentui/core": "^0.1.82"
       },
       "devDependencies": {
+        "@types/bun": "^1.3.13",
         "@types/node": "^22.0.0",
         "typescript": "^5.7.0"
       }
@@ -92,14 +94,14 @@
       }
     },
     "node_modules/@animalabs/agent-framework": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@animalabs/agent-framework/-/agent-framework-0.2.0.tgz",
-      "integrity": "sha512-gU63Xp2cUSPEJaFZ5HF6Cw4+hZJlWIy4TAuDDurRBZ2Vhv1wQMJ+0Oj5afiHha2K82aAwxkfi4mLtTqUC784NA==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@animalabs/agent-framework/-/agent-framework-0.6.2.tgz",
+      "integrity": "sha512-tgXl+vNgbG3Aj0rTraFuCJI+l+PN2c/LPqB/9mS9EMLU+KwPLdFd3xeHw8oGq+G/7LK/C5PjEBwPfIsa06JBmQ==",
       "license": "MIT",
       "dependencies": {
-        "@animalabs/chronicle": "^0.1.0",
-        "@animalabs/context-manager": "^0.2.0",
-        "@animalabs/membrane": "^0.5.43",
+        "@animalabs/chronicle": "^0.2.2",
+        "@animalabs/context-manager": "^0.5.5",
+        "@animalabs/membrane": "^0.5.64",
         "chokidar": "^4.0.3",
         "discord.js": "^14.25.1",
         "ws": "^8.18.0"
@@ -112,50 +114,35 @@
       }
     },
     "node_modules/@animalabs/chronicle": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@animalabs/chronicle/-/chronicle-0.1.1.tgz",
-      "integrity": "sha512-/yeeUpIkRnPS7s+XbXzveKNBRqMFPWmknwe98vBtFOR1ovp+ENgF0HmfFPC4XDeqO4B3v8S+EZkWkiOw+kwJkQ==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@animalabs/chronicle/-/chronicle-0.2.6.tgz",
+      "integrity": "sha512-+gbt2GR4SP8MnKxeqkJZf6oZn339fLiBtk6GHyBD/gHQ4e4eFqBpTaTd5eKycKBws0xWGcOqyiJFH4IdBkweUA==",
       "license": "MIT",
       "optionalDependencies": {
-        "@animalabs/chronicle-darwin-arm64": "0.1.1",
-        "@animalabs/chronicle-darwin-x64": "0.1.1",
-        "@animalabs/chronicle-linux-arm64-gnu": "0.1.1",
-        "@animalabs/chronicle-linux-x64-gnu": "0.1.1",
-        "@animalabs/chronicle-win32-x64-msvc": "0.1.1"
+        "@animalabs/chronicle-darwin-arm64": "0.2.6",
+        "@animalabs/chronicle-darwin-x64": "0.2.6",
+        "@animalabs/chronicle-linux-arm64-gnu": "0.2.6",
+        "@animalabs/chronicle-linux-x64-gnu": "0.2.6",
+        "@animalabs/chronicle-win32-x64-msvc": "0.2.6"
       }
     },
-    "node_modules/@animalabs/chronicle/node_modules/@animalabs/chronicle-darwin-arm64": {
-      "optional": true
-    },
-    "node_modules/@animalabs/chronicle/node_modules/@animalabs/chronicle-darwin-x64": {
-      "optional": true
-    },
-    "node_modules/@animalabs/chronicle/node_modules/@animalabs/chronicle-linux-arm64-gnu": {
-      "optional": true
-    },
-    "node_modules/@animalabs/chronicle/node_modules/@animalabs/chronicle-linux-x64-gnu": {
-      "optional": true
-    },
-    "node_modules/@animalabs/chronicle/node_modules/@animalabs/chronicle-win32-x64-msvc": {
-      "optional": true
-    },
     "node_modules/@animalabs/context-manager": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@animalabs/context-manager/-/context-manager-0.2.0.tgz",
-      "integrity": "sha512-v9FF7a5a7D8rfX534n7v0h+DithihjkJNV8L9mI27nfi2qDdhllcpM1ecPVGGTFIkOHGKecum9C3jXwWxylNhQ==",
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/@animalabs/context-manager/-/context-manager-0.5.9.tgz",
+      "integrity": "sha512-G0bsOidBU9jWacSxKP27S41rj1d4G3XfGzmapgRL5Xfo5PgnOh6cZ6gZTQ+f81xfmyWH7IGThEejwWTyt8NYgg==",
       "license": "MIT",
       "dependencies": {
-        "@animalabs/chronicle": "^0.1.0",
-        "@animalabs/membrane": "^0.5.40"
+        "@animalabs/chronicle": "^0.2.6",
+        "@animalabs/membrane": "^0.5.69"
       },
       "engines": {
         "node": ">=20.0.0"
       }
     },
     "node_modules/@animalabs/membrane": {
-      "version": "0.5.43",
-      "resolved": "https://registry.npmjs.org/@animalabs/membrane/-/membrane-0.5.43.tgz",
-      "integrity": "sha512-FXIuBO7unpIanMvA2Hmy89TwZQyooOKQ9Q+AT3JWODHrKmx7EoeA53DGI+Ks3/4etDX/2Ug2S6NKaY8pujN4HQ==",
+      "version": "0.5.69",
+      "resolved": "https://registry.npmjs.org/@animalabs/membrane/-/membrane-0.5.69.tgz",
+      "integrity": "sha512-IjoL130eBlh2EsI16jjQesLKuEsFTTdh97FiDFix5FpMEKp+dJu6nH8ukrewjGid9wSspHNmyNnmgZf4AjKPzg==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.52.0"
@@ -877,6 +864,16 @@
       "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
       "license": "MIT"
     },
+    "node_modules/@types/bun": {
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/@types/bun/-/bun-1.3.14.tgz",
+      "integrity": "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bun-types": "1.3.14"
+      }
+    },
     "node_modules/@types/node": {
       "version": "22.19.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.11.tgz",
@@ -996,6 +993,16 @@
       "license": "MIT",
       "peerDependencies": {
         "typescript": "^5"
+      }
+    },
+    "node_modules/bun-types": {
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/bun-types/-/bun-types-1.3.14.tgz",
+      "integrity": "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/bun-webgpu": {
@@ -1483,6 +1490,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.12.2"
+      }
+    },
+    "node_modules/stage-js": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stage-js/-/stage-js-1.0.1.tgz",
+      "integrity": "sha512-cz14aPp/wY0s3bkb/B93BPP5ZAEhgBbRmAT3CCDqert8eCAqIpQ0RB2zpK8Ksxf+Pisl5oTzvPHtL4CVzzeHcw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=18.0"
       }
     },
     "node_modules/string_decoder": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@animalabs/connectome-host",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "General-purpose agent TUI host with recipe-based configuration",
   "type": "module",
   "scripts": {

--- a/src/modules/fleet-module.ts
+++ b/src/modules/fleet-module.ts
@@ -31,7 +31,7 @@ import type {
 } from '@animalabs/agent-framework';
 import { spawn as spawnProcess, type ChildProcess } from 'node:child_process';
 import { connect as netConnect, type Socket } from 'node:net';
-import { existsSync, mkdirSync, unlinkSync, openSync, closeSync, appendFileSync } from 'node:fs';
+import { existsSync, mkdirSync, unlinkSync, openSync, closeSync, appendFileSync, realpathSync } from 'node:fs';
 import { join, resolve, isAbsolute } from 'node:path';
 import { type IncomingCommand, type WireEvent, matchesSubscription } from './fleet-types.js';
 import { loadRecipe } from '../recipe.js';
@@ -1202,9 +1202,11 @@ export class FleetModule implements Module {
    * entries derived from `children[]`, which are absolute post-load).
    */
   private matchesAllowlist(recipe: string, resolved: string): boolean {
+    const canonicalResolved = existsSync(resolved) ? realpathSync(resolved) : resolved;
     for (const entry of this.allowlist) {
       if (entry === '*') return true;
-      if (entry === recipe || entry === resolved) return true;
+      const canonicalEntry = !entry.includes('*') && existsSync(entry) ? realpathSync(entry) : entry;
+      if (entry === recipe || entry === resolved || canonicalEntry === canonicalResolved) return true;
       if (entry.endsWith('*') && !entry.slice(0, -1).includes('*')) {
         const prefix = entry.slice(0, -1);
         if (recipe.startsWith(prefix) || resolved.startsWith(prefix)) return true;

--- a/test/fleet-tree-aggregator-e2e.test.ts
+++ b/test/fleet-tree-aggregator-e2e.test.ts
@@ -51,6 +51,8 @@ describe('FleetTreeAggregator — e2e against headless child', () => {
   let aggregator: FleetTreeAggregator;
 
   beforeAll(async () => {
+    // Children validate credentials during startup but never infer in this test.
+    process.env.ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY || 'sk-test-fleet-aggregator';
     tmpDir = mkdtempSync(join(tmpdir(), 'fkm-agg-e2e-'));
     recipePath = join(tmpDir, 'recipe.json');
     writeFileSync(recipePath, JSON.stringify(CHILD_RECIPE), 'utf-8');


### PR DESCRIPTION
## What changed

Bumps the host to 0.3.2, refreshes the lockfile and release actions, and fixes fleet startup tests/path canonicalization found during release validation.

## Why

Publish the connectome-host stack through npm trusted publishing with reproducible registry dependencies.

## Validation

npm run build:web; npm test (352 passing)