### PR TITLE
fix: install Bun for connectome-host release tests

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,11 @@ jobs:
         with:
           node-version: 24
 
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
       - name: Install dependencies
         run: npm install
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@animalabs/connectome-host",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@animalabs/connectome-host",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "hasInstallScript": true,
       "dependencies": {
         "@animalabs/agent-framework": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@animalabs/connectome-host",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "General-purpose agent TUI host with recipe-based configuration",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- release the host as 0.3.4 after v0.3.3 reached the test step but found no Bun executable
- install the pinned Bun 1.3.14 test runner in the build-and-test job
- keep npm 11 / Node 24 as the trusted publishing path

## Verification
- `npm run build:web`
- `npm test` (367 pass, 0 fail)