### PR TITLE
fix: make fleet subscription E2E hermetic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@animalabs/connectome-host",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@animalabs/connectome-host",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "hasInstallScript": true,
       "dependencies": {
         "@animalabs/agent-framework": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@animalabs/connectome-host",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "General-purpose agent TUI host with recipe-based configuration",
   "type": "module",
   "scripts": {

--- a/test/fleet-subscribe-union-e2e.test.ts
+++ b/test/fleet-subscribe-union-e2e.test.ts
@@ -45,8 +45,11 @@ describe('FleetModule subscribe union e2e', () => {
   let tmpDir: string;
   let recipePath: string;
   let fleet: FleetModule;
+  let previousApiKey: string | undefined;
 
   beforeAll(async () => {
+    previousApiKey = process.env.ANTHROPIC_API_KEY;
+    process.env.ANTHROPIC_API_KEY = previousApiKey || 'sk-test-fleet-subscribe-union';
     tmpDir = mkdtempSync(join(tmpdir(), 'fkm-sub-union-'));
     recipePath = join(tmpDir, 'recipe.json');
     writeFileSync(recipePath, JSON.stringify(NARROW_RECIPE), 'utf-8');
@@ -68,6 +71,8 @@ describe('FleetModule subscribe union e2e', () => {
     } catch { /* noop */ }
     await new Promise((r) => setTimeout(r, 500));
     try { rmSync(tmpDir, { recursive: true, force: true }); } catch { /* noop */ }
+    if (previousApiKey === undefined) delete process.env.ANTHROPIC_API_KEY;
+    else process.env.ANTHROPIC_API_KEY = previousApiKey;
   });
 
   test('narrow recipe subscription gets reducer-required events forced in by FleetModule', async () => {


### PR DESCRIPTION
## Summary
- release the host as 0.3.5 after CI exposed an environment-dependent E2E fixture
- give the fleet subscription child a dummy test-only Anthropic key when the environment has none
- restore the caller environment after the test

## Verification
- `env -u ANTHROPIC_API_KEY bun test test/fleet-subscribe-union-e2e.test.ts`
- `env -u ANTHROPIC_API_KEY npm test` (367 pass, 0 fail)