### PR TITLE
Configure agent-visible timezones

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 ANTHROPIC_API_KEY=sk-ant-...
 # MODEL=claude-opus-4-6
+# Agent-visible wall clock (IANA zone; recipe agent.timezone takes precedence)
+# AGENT_TIMEZONE=America/Los_Angeles
 
 # --- Recipe ${VAR} substitutions ---------------------------------------
 # Recipes in recipes/ reference these via ${VAR}.  Unset = that branch of

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ A recipe is a JSON file that configures everything domain-specific:
   "agent": {
     "name": "researcher",
     "model": "claude-opus-4-6",
+    "timezone": "America/Los_Angeles",
     "systemPrompt": "You are a ...",
     "maxTokens": 16384,
     "strategy": {
@@ -54,6 +55,10 @@ A recipe is a JSON file that configures everything domain-specific:
   }
 }
 ```
+
+`agent.timezone` is an IANA zone used only for times rendered to the agent.
+Chronicle and MCPL protocol timestamps remain epoch/UTC. If the recipe omits
+it, `AGENT_TIMEZONE` is used, then the process timezone.
 
 ### Recipe loading
 

--- a/docs/AGENT-ONBOARDING.md
+++ b/docs/AGENT-ONBOARDING.md
@@ -239,6 +239,7 @@ ln -sfn ../../../connectome-local/context-manager/node_modules/@animalabs/chroni
   "agent": {
     "name": "<agent>",                      // = chronicle "self" participant
     "model": "<model-id>",                  // or gateway-prefixed, e.g. anthropic/claude-opus-4
+    "timezone": "America/Los_Angeles",      // agent-visible wall clock only; storage stays UTC
     "systemPrompt": "<persona / or minimal>",
     "maxTokens": 16384,                     // response cap
     "maxStreamTokens": 180000,              // recompile trigger; keep < model window

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@
 import { Membrane, NativeFormatter } from '@animalabs/membrane';
 import { LoggingAnthropicAdapter } from './logging-adapter.js';
 import { SettingsModule } from './modules/settings-module.js';
-import { AgentFramework, AutobiographicalStrategy, PassthroughStrategy, WorkspaceModule, type Module, type MountConfig } from '@animalabs/agent-framework';
+import { AgentFramework, AutobiographicalStrategy, PassthroughStrategy, WorkspaceModule, resolveTimeZone, type Module, type MountConfig } from '@animalabs/agent-framework';
 import { resolve, join, basename } from 'node:path';
 import { appendFile, mkdir, stat, rename } from 'node:fs/promises';
 import { readFileSync, existsSync } from 'node:fs';
@@ -141,11 +141,12 @@ async function createFramework(
 ): Promise<AgentFramework> {
   const model = config.model || recipe.agent.model || 'claude-opus-4-6';
   const modules = recipe.modules ?? {};
+  const timeZone = resolveTimeZone(recipe.agent.timezone);
 
   // -- Build module list --
   // SettingsModule is constructed in main() (before the adapter, so the
   // adapter can read its state for cross-cutting concerns like reasoning).
-  const moduleInstances: Module[] = [new TuiModule(), new TimeModule(), settingsModule];
+  const moduleInstances: Module[] = [new TuiModule(), new TimeModule(timeZone), settingsModule];
 
   // Subagents
   let subagentModule: SubagentModule | null = null;
@@ -169,10 +170,11 @@ async function createFramework(
 
   // Fleet (cross-process child orchestration). Opt-in via recipe.
   if (modules.fleet === true) {
-    moduleInstances.push(new FleetModule());
+    moduleInstances.push(new FleetModule({ timeZone }));
   } else if (modules.fleet && typeof modules.fleet === 'object') {
     const fleetCfg = modules.fleet;
     const fleetModuleConfig: FleetModuleConfig = {};
+    fleetModuleConfig.timeZone = timeZone;
     if (fleetCfg.children) {
       fleetModuleConfig.autoStart = fleetCfg.children.map((c) => {
         const entry: NonNullable<FleetModuleConfig['autoStart']>[number] = {
@@ -310,7 +312,7 @@ async function createFramework(
   // ability to spawn arbitrary commands via mcpl_deploy; see recipe.ts).
   let mcplAdminModule: McplAdminModule | null = null;
   if (modules.mcplAdmin === true) {
-    mcplAdminModule = new McplAdminModule();
+    mcplAdminModule = new McplAdminModule({ timeZone });
     moduleInstances.push(mcplAdminModule);
   }
 
@@ -384,7 +386,12 @@ async function createFramework(
   // Apply the agent overlay (mcpl-servers.agent.json): servers the agent
   // deployed for itself load unconditionally (no recipe opt-in), and
   // tombstones suppress recipe/file servers the agent unloaded.
-  const finalServers = applyAgentOverlay(allServers, DEFAULT_AGENT_OVERLAY_PATH);
+  const finalServers = applyAgentOverlay(allServers, DEFAULT_AGENT_OVERLAY_PATH).map((server) => ({
+    ...server,
+    // Stdio MCPL children inherit a single agent-facing wall clock. Protocol
+    // timestamps remain UTC; only their rendered text uses this setting.
+    env: { ...(server.env ?? {}), AGENT_TIMEZONE: timeZone },
+  }));
 
   // No server augmentation needed — gate is wired via FrameworkConfig.gate
 
@@ -405,6 +412,7 @@ async function createFramework(
     compressionModel: strategyConfig?.compressionModel ?? model,
     autoTickOnNewMessage: true,
     maxMessageTokens: strategyConfig?.maxMessageTokens ?? 10000,
+    ...(strategyType === 'frontdesk' ? { timeZone } : {}),
   };
   // Forward optional tuning fields when set. The key list is typed
   // against `RecipeStrategy`, so an unknown field name is a compile
@@ -473,6 +481,7 @@ async function createFramework(
     modules: moduleInstances,
     mcplServers: finalServers,
     gate: gateOptions,
+    timeZone,
   });
 
   // Wire post-creation hooks

--- a/src/modules/fleet-module.ts
+++ b/src/modules/fleet-module.ts
@@ -29,6 +29,7 @@ import type {
   ToolCall,
   ToolResult,
 } from '@animalabs/agent-framework';
+import { formatZonedDateTime, resolveTimeZone } from '@animalabs/agent-framework';
 import { spawn as spawnProcess, type ChildProcess } from 'node:child_process';
 import { connect as netConnect, type Socket } from 'node:net';
 import { existsSync, mkdirSync, unlinkSync, openSync, closeSync, appendFileSync } from 'node:fs';
@@ -81,6 +82,8 @@ interface FleetEventSubscription {
 // ---------------------------------------------------------------------------
 
 export interface FleetModuleConfig {
+  /** IANA zone for wall-clock timestamps returned by fleet tools. */
+  timeZone?: string;
   /** Default subscription sent to children at handshake (default: ['*']). */
   defaultSubscription?: string[];
   /** Max events to retain per child for peek (default: 500). */
@@ -255,6 +258,7 @@ export class FleetModule implements Module {
       sigtermEscalationMs: config.sigtermEscalationMs ?? 5_000,
       childIndexPath: config.childIndexPath ?? process.argv[1] ?? '',
       childRuntimePath: config.childRuntimePath ?? process.execPath,
+      timeZone: resolveTimeZone(config.timeZone),
     };
 
     this.autoStartChildren = config.autoStart ?? [];
@@ -1014,7 +1018,12 @@ export class FleetModule implements Module {
       {
         detached: true,
         stdio: startupFd !== null ? ['ignore', startupFd, startupFd] : 'ignore',
-        env: { ...process.env, ...input.env, DATA_DIR: dataDir },
+        env: {
+          ...process.env,
+          ...input.env,
+          AGENT_TIMEZONE: this.config.timeZone,
+          DATA_DIR: dataDir,
+        },
       },
     );
     proc.unref();
@@ -1095,9 +1104,9 @@ export class FleetModule implements Module {
       name: c.name,
       status: c.status,
       pid: c.pid,
-      startedAt: c.startedAt,
-      exitedAt: c.exitedAt,
-      lastEventAt: c.lastEventAt,
+      startedAt: formatZonedDateTime(c.startedAt, this.config.timeZone),
+      exitedAt: c.exitedAt === null ? null : formatZonedDateTime(c.exitedAt, this.config.timeZone),
+      lastEventAt: c.lastEventAt === null ? null : formatZonedDateTime(c.lastEventAt, this.config.timeZone),
       eventCount: c.events.length,
     }));
     return { success: true, data: list };
@@ -1120,9 +1129,10 @@ export class FleetModule implements Module {
       socketPath: c.socketPath,
       pid: c.pid,
       status: c.status,
-      startedAt: c.startedAt,
-      exitedAt: c.exitedAt,
-      lastEventAt: c.lastEventAt,
+      startedAt: formatZonedDateTime(c.startedAt, this.config.timeZone),
+      exitedAt: c.exitedAt === null ? null : formatZonedDateTime(c.exitedAt, this.config.timeZone),
+      lastEventAt: c.lastEventAt === null ? null : formatZonedDateTime(c.lastEventAt, this.config.timeZone),
+      timeZone: this.config.timeZone,
       exitCode: c.exitCode,
       exitReason: c.exitReason,
       eventCount: c.events.length,

--- a/src/modules/mcpl-admin-module.ts
+++ b/src/modules/mcpl-admin-module.ts
@@ -33,6 +33,7 @@ import type {
   AgentFramework,
   McplServerConfig,
 } from '@animalabs/agent-framework';
+import { resolveTimeZone } from '@animalabs/agent-framework';
 import {
   DEFAULT_CONFIG_PATH,
   DEFAULT_AGENT_OVERLAY_PATH,
@@ -44,6 +45,8 @@ import {
 } from '../mcpl-config.js';
 
 export interface McplAdminModuleConfig {
+  /** IANA zone propagated to newly deployed stdio servers. */
+  timeZone?: string;
   /** Path to the agent overlay file. Default: `mcpl-servers.agent.json` in cwd. */
   overlayPath?: string;
   /** Path to the human-owned server config file (read-only here). */
@@ -64,10 +67,12 @@ export class McplAdminModule implements Module {
   private framework: AgentFramework | null = null;
   private overlayPath: string;
   private configPath: string;
+  private timeZone: string;
 
   constructor(config?: McplAdminModuleConfig) {
     this.overlayPath = config?.overlayPath ?? DEFAULT_AGENT_OVERLAY_PATH;
     this.configPath = config?.configPath ?? DEFAULT_CONFIG_PATH;
+    this.timeZone = resolveTimeZone(config?.timeZone);
   }
 
   /** Post-creation wiring (called from index.ts, mirrors ActivityModule.setFramework). */
@@ -275,6 +280,7 @@ export class McplAdminModule implements Module {
     saveAgentOverlay(this.overlayPath, overlay);
 
     const config = resolveOverlayEntry(id, entry, this.overlayPath) as unknown as McplServerConfig;
+    config.env = { ...(config.env ?? {}), AGENT_TIMEZONE: this.timeZone };
 
     const alreadyLoaded = framework.listMcplServers().some(s => s.id === id);
     try {

--- a/src/modules/time-module.ts
+++ b/src/modules/time-module.ts
@@ -15,21 +15,23 @@ import type {
   ToolCall,
   ToolResult,
 } from '@animalabs/agent-framework';
+import { formatZonedDateTime, resolveTimeZone } from '@animalabs/agent-framework';
 
 interface TimeState {
   sessionStartAnnounced?: boolean;
 }
 
-function formatNow(date: Date = new Date()): {
+export function formatNow(date: Date = new Date(), configuredTimeZone?: string): {
   iso: string;
   local: string;
   timezone: string;
   unixMs: number;
 } {
-  const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const timezone = resolveTimeZone(configuredTimeZone);
+  const local = formatZonedDateTime(date, timezone);
   return {
-    iso: date.toISOString(),
-    local: date.toString(),
+    iso: local.slice(0, local.indexOf(' [')),
+    local,
     timezone,
     unixMs: date.getTime(),
   };
@@ -39,6 +41,11 @@ export class TimeModule implements Module {
   readonly name = 'time';
 
   private ctx: ModuleContext | null = null;
+  private readonly timeZone: string;
+
+  constructor(timeZone?: string) {
+    this.timeZone = resolveTimeZone(timeZone);
+  }
 
   async start(ctx: ModuleContext): Promise<void> {
     this.ctx = ctx;
@@ -46,10 +53,9 @@ export class TimeModule implements Module {
     const state = ctx.getState<TimeState>() ?? {};
     if (state.sessionStartAnnounced) return;
 
-    const now = formatNow();
+    const now = formatNow(new Date(), this.timeZone);
     const text =
-      `The time at the start of this session is: ${now.iso} ` +
-      `(local: ${now.local}, timezone: ${now.timezone}).`;
+      `The local time at the start of this session is ${now.local}.`;
 
     ctx.addMessage('user', [{ type: 'text', text }]);
     ctx.setState<TimeState>({ ...state, sessionStartAnnounced: true });
@@ -67,7 +73,7 @@ export class TimeModule implements Module {
     return [
       {
         name: 'now',
-        description: 'Return the current wall-clock time as ISO 8601, local string, timezone, and unix milliseconds.',
+        description: 'Return the current wall-clock time in the agent-configured timezone, plus unix milliseconds.',
         inputSchema: {
           type: 'object',
           properties: {},
@@ -78,7 +84,7 @@ export class TimeModule implements Module {
 
   async handleToolCall(call: ToolCall): Promise<ToolResult> {
     if (call.name === 'now') {
-      return { success: true, data: formatNow() };
+      return { success: true, data: formatNow(new Date(), this.timeZone) };
     }
     return { success: false, isError: true, error: `Unknown tool: ${call.name}` };
   }

--- a/src/recipe.ts
+++ b/src/recipe.ts
@@ -75,6 +75,8 @@ export interface RecipeStrategy {
 export interface RecipeAgent {
   name?: string;
   model?: string;
+  /** IANA zone used when rendering wall-clock times to the agent. */
+  timezone?: string;
   systemPrompt: string;
   maxTokens?: number;
   /**
@@ -676,6 +678,17 @@ export function validateRecipe(raw: unknown): Recipe {
   const agent = obj.agent as Record<string, unknown>;
   if (typeof agent.systemPrompt !== 'string' || !agent.systemPrompt) {
     throw new Error('Recipe agent must have a "systemPrompt" string');
+  }
+
+  if (agent.timezone !== undefined) {
+    if (typeof agent.timezone !== 'string' || !agent.timezone.trim()) {
+      throw new Error('Recipe agent.timezone must be a non-empty IANA time zone string.');
+    }
+    try {
+      new Intl.DateTimeFormat('en-US', { timeZone: agent.timezone }).format(new Date(0));
+    } catch {
+      throw new Error(`Recipe agent.timezone is not a valid IANA time zone: ${JSON.stringify(agent.timezone)}.`);
+    }
   }
 
   if (agent.maxStreamTokens !== undefined && (typeof agent.maxStreamTokens !== 'number' || agent.maxStreamTokens <= 0)) {

--- a/src/strategies/frontdesk-strategy.ts
+++ b/src/strategies/frontdesk-strategy.ts
@@ -9,6 +9,7 @@ import type {
   SummaryEntry,
 } from '@animalabs/context-manager';
 import type { ContentBlock } from '@animalabs/membrane';
+import { formatZonedTime, resolveTimeZone } from '@animalabs/agent-framework';
 
 // Structural mirror of AutobiographicalStrategy's internal Chunk.
 // Kept inline because @animalabs/context-manager does not currently export it.
@@ -24,7 +25,7 @@ interface Chunk {
   phaseType?: string;
 }
 
-export type FrontdeskStrategyOptions = Partial<AutobiographicalConfig>;
+export type FrontdeskStrategyOptions = Partial<AutobiographicalConfig> & { timeZone?: string };
 
 /**
  * Chatbot-flavoured context strategy for agents that receive messages via
@@ -43,6 +44,13 @@ export class FrontdeskStrategy extends AutobiographicalStrategy {
   override readonly name: string = 'frontdesk';
 
   private salientSourceIds: Set<string> = new Set();
+  private readonly timeZone: string;
+
+  constructor(options: FrontdeskStrategyOptions = {}) {
+    const { timeZone, ...strategyOptions } = options;
+    super(strategyOptions);
+    this.timeZone = resolveTimeZone(timeZone);
+  }
 
   override select(
     store: MessageStoreView,
@@ -146,9 +154,7 @@ export class FrontdeskStrategy extends AutobiographicalStrategy {
     }
     if (!d && msgTs instanceof Date && !isNaN(msgTs.getTime())) d = msgTs;
     if (!d) return null;
-    const hh = String(d.getHours()).padStart(2, '0');
-    const mm = String(d.getMinutes()).padStart(2, '0');
-    return `${hh}:${mm}`;
+    return formatZonedTime(d, this.timeZone);
   }
 
   // ==========================================================================

--- a/test/frontdesk-strategy.test.ts
+++ b/test/frontdesk-strategy.test.ts
@@ -81,6 +81,7 @@ function makeStrategy(): TestFrontdesk {
     targetChunkTokens: 50,
     autoTickOnNewMessage: false,
     maxMessageTokens: 0,
+    timeZone: 'UTC',
   });
 }
 
@@ -108,6 +109,15 @@ describe('provenance wrapping', () => {
     expect(header).toContain('14:32');
     expect(header).toContain('msg M987654');
     expect(header!.endsWith('\n')).toBe(true);
+  });
+
+  test('renders provenance time in the configured zone', () => {
+    const s = new TestFrontdesk({ timeZone: 'America/Los_Angeles' });
+    const m = msg('User', 'hello', {
+      serverId: 'zulip',
+      timestamp: '2026-07-17T14:32:00Z',
+    });
+    expect(s.pub_buildHeader(m)).toContain('07:32');
   });
 
   test('wrapProvenance prepends header into the first text block', () => {

--- a/test/recipe-timezone.test.ts
+++ b/test/recipe-timezone.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from 'bun:test';
+import { validateRecipe } from '../src/recipe.js';
+
+function recipe(timezone?: unknown) {
+  return { name: 'tz', agent: { systemPrompt: 'test', ...(timezone === undefined ? {} : { timezone }) } };
+}
+
+describe('recipe agent.timezone validation', () => {
+  test('accepts an IANA timezone', () => {
+    expect(validateRecipe(recipe('America/Los_Angeles')).agent.timezone).toBe('America/Los_Angeles');
+  });
+
+  test('allows the setting to be omitted', () => {
+    expect(validateRecipe(recipe()).agent.timezone).toBeUndefined();
+  });
+
+  test('rejects invalid timezone names', () => {
+    expect(() => validateRecipe(recipe('Pacific/Definitely_Not'))).toThrow(/valid IANA time zone/);
+  });
+});

--- a/test/time-module.test.ts
+++ b/test/time-module.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from 'bun:test';
+import { formatNow } from '../src/modules/time-module.js';
+
+describe('TimeModule presentation timezone', () => {
+  test('formats current time independently of the host timezone', () => {
+    expect(formatNow(new Date('2026-07-15T12:34:56.789Z'), 'America/Los_Angeles')).toEqual({
+      iso: '2026-07-15T05:34:56.789-07:00',
+      local: '2026-07-15T05:34:56.789-07:00 [America/Los_Angeles]',
+      timezone: 'America/Los_Angeles',
+      unixMs: 1_784_118_896_789,
+    });
+  });
+});


### PR DESCRIPTION
## What changed

- Added `agent.timezone` recipe validation with `AGENT_TIMEZONE` fallback.
- Applied the zone to session time, frontdesk provenance, and fleet status.
- Propagated the zone to initial, fleet-spawned, and runtime-deployed MCPL processes.
- Kept Chronicle and MCPL protocol timestamps in epoch/UTC form.

## Why

Agents should share one configurable wall clock even when it differs from the system locale.

## Validation

- `bunx tsc --noEmit`
- Focused timezone, recipe, frontdesk, fleet, and MCPL-admin tests: 32 passed
- Full suite: 373 passed; two pre-existing environment/harness failures remain unrelated
