### PR TITLE
Add billing ledger, OpenAI Responses sessions, and 1h cache default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,10 @@ ANTHROPIC_API_KEY=sk-ant-...
 # Agent-visible wall clock (IANA zone; recipe agent.timezone takes precedence)
 # AGENT_TIMEZONE=America/Los_Angeles
 
+# For recipes with agent.provider="openai-responses":
+# OPENAI_API_KEY=sk-...
+# OPENAI_BASE_URL=https://api.openai.com/v1
+
 # --- Recipe ${VAR} substitutions ---------------------------------------
 # Recipes in recipes/ reference these via ${VAR}.  Unset = that branch of
 # the recipe fails to load; remove the referencing mcpServers block from

--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "@animalabs/agent-framework": "^0.6.0",
         "@animalabs/chronicle": "^0.2.0",
         "@animalabs/context-manager": "^0.5.5",
-        "@animalabs/membrane": "^0.5.68",
+        "@animalabs/membrane": "^0.5.70",
         "@opentui/core": "^0.1.82",
       },
       "devDependencies": {
@@ -25,7 +25,7 @@
 
     "@animalabs/context-manager": ["@animalabs/context-manager@0.5.5", "", { "dependencies": { "@animalabs/chronicle": "^0.2.0", "@animalabs/membrane": "^0.5.64" } }, "sha512-KWTluwU5VIZKIPF/IdfUbkvPNZ5zMxSfZjaxZb81IXe+DBPmjHuUVNIqgXIQ2Mv1pCn1vCNqieZ/iSrc6dFH8w=="],
 
-    "@animalabs/membrane": ["@animalabs/membrane@0.5.68", "", { "dependencies": { "@anthropic-ai/sdk": "^0.52.0" } }, "sha512-MfSERy0ECxdBZ4NelHdZbqsP/ORWJsfeAI6vuyy6gP77aGcdJL8qf4XrUkOox5yZa5MqB50y0K58Ffv79jCnbg=="],
+    "@animalabs/membrane": ["@animalabs/membrane@0.5.70", "", { "dependencies": { "@anthropic-ai/sdk": "^0.52.0" } }, "sha512-AxF9A88Oz6gPJxr6A32nDQ+byQEWDqbAZCDugilaUy6lGZvrKun/k4qU5cAHf9s8xGQl4T3afzTAT8yF69UogA=="],
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.52.0", "", { "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-d4c+fg+xy9e46c8+YnrrgIQR45CZlAi7PwdzIfDXDM6ACxEZli1/fxhURsq30ZpMZy6LvSkr41jGq5aF5TD7rQ=="],
 
@@ -274,6 +274,10 @@
     "yoga-layout": ["yoga-layout@3.2.1", "", {}, "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="],
 
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@animalabs/agent-framework/@animalabs/membrane": ["@animalabs/membrane@0.5.68", "", { "dependencies": { "@anthropic-ai/sdk": "^0.52.0" } }, "sha512-MfSERy0ECxdBZ4NelHdZbqsP/ORWJsfeAI6vuyy6gP77aGcdJL8qf4XrUkOox5yZa5MqB50y0K58Ffv79jCnbg=="],
+
+    "@animalabs/context-manager/@animalabs/membrane": ["@animalabs/membrane@0.5.68", "", { "dependencies": { "@anthropic-ai/sdk": "^0.52.0" } }, "sha512-MfSERy0ECxdBZ4NelHdZbqsP/ORWJsfeAI6vuyy6gP77aGcdJL8qf4XrUkOox5yZa5MqB50y0K58Ffv79jCnbg=="],
 
     "@discordjs/rest/@discordjs/collection": ["@discordjs/collection@2.1.1", "", {}, "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg=="],
 

--- a/docs/AGENT-ONBOARDING.md
+++ b/docs/AGENT-ONBOARDING.md
@@ -244,7 +244,7 @@ ln -sfn ../../../connectome-local/context-manager/node_modules/@animalabs/chroni
     "maxTokens": 16384,                     // response cap
     "maxStreamTokens": 180000,              // recompile trigger; keep < model window
     "contextBudgetTokens": 160000,          // SEE §11.1 — MUST fit under (window - maxTokens)
-    "cacheTtl": "1h",                       // prompt-cache TTL; '1h' for residents replying slower than 5m (cache re-write premium dominates spend otherwise), omit/'5m' for rapid loops
+    "cacheTtl": "1h",                       // prompt-cache TTL; defaults to '1h', set '5m' explicitly for rapid sub-5m loops
     "strategy": {
       "type": "autobiographical",
       "headWindowTokens": 4000,
@@ -266,6 +266,10 @@ ln -sfn ../../../connectome-local/context-manager/node_modules/@animalabs/chroni
   }
 }
 ```
+
+Use `"cacheTtl": "1h"` for Connectome deployments. This is also the runtime
+default when the field is omitted. Set `"5m"` only for intentionally rapid
+workloads whose cache is normally reused within five minutes.
 
 **`.env`** (`chmod 600`). Common vars:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@animalabs/connectome-host",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "General-purpose agent TUI host with recipe-based configuration",
   "type": "module",
   "scripts": {
@@ -14,7 +14,7 @@
     "@animalabs/agent-framework": "^0.6.0",
     "@animalabs/chronicle": "^0.2.0",
     "@animalabs/context-manager": "^0.5.5",
-    "@animalabs/membrane": "^0.5.68",
+    "@animalabs/membrane": "^0.5.70",
     "@opentui/core": "^0.1.82"
   },
   "devDependencies": {

--- a/scripts/import-codex-rollout.ts
+++ b/scripts/import-codex-rollout.ts
@@ -1,0 +1,288 @@
+#!/usr/bin/env bun
+/** Import a Codex rollout JSONL as a KV-stable OpenAI Responses session. */
+
+import {
+  basename,
+  dirname,
+  join,
+  resolve,
+} from 'node:path';
+import {
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs';
+import { JsStore } from '@animalabs/chronicle';
+import { ContextManager } from '@animalabs/context-manager';
+import type { ContentBlock } from '@animalabs/membrane';
+import { SessionManager } from '../src/session-manager.js';
+
+interface RolloutRecord {
+  timestamp?: string;
+  type?: string;
+  payload?: Record<string, unknown>;
+}
+
+interface NativeItem {
+  type?: string;
+  id?: string;
+  role?: string;
+  [key: string]: unknown;
+}
+
+interface EffectiveItem {
+  item: NativeItem;
+  timestamp?: string;
+  sourceLine: number;
+  restoredByCompaction: boolean;
+}
+
+function usage(): never {
+  console.error('Usage: bun scripts/import-codex-rollout.ts <rollout.jsonl> --out <instance-dir> [--agent <name>]');
+  process.exit(1);
+}
+
+function parseArgs(argv: string[]) {
+  const args = argv.slice(2);
+  if (!args[0] || args[0].startsWith('-')) usage();
+  const source = resolve(args[0]);
+  let outDir = '';
+  let agentName = 'Codex';
+  for (let i = 1; i < args.length; i++) {
+    if (args[i] === '--out') outDir = resolve(args[++i] ?? '');
+    else if (args[i] === '--agent') agentName = args[++i] ?? usage();
+    else usage();
+  }
+  if (!outDir) usage();
+  return { source, outDir, agentName };
+}
+
+/** Reconstruct the provider's current input window. A `compacted` record
+ * replaces all prior response-item history with its canonical
+ * `replacement_history`; later response items append normally. */
+export function reconstructEffectiveHistory(records: RolloutRecord[]): EffectiveItem[] {
+  let history: EffectiveItem[] = [];
+  for (const [index, record] of records.entries()) {
+    if (record.type === 'compacted') {
+      const replacement = record.payload?.replacement_history;
+      if (Array.isArray(replacement)) {
+        history = replacement.map(item => ({
+          item: item as NativeItem,
+          timestamp: record.timestamp,
+          sourceLine: index + 1,
+          restoredByCompaction: true,
+        }));
+      }
+      continue;
+    }
+    if (record.type === 'response_item' && record.payload) {
+      history.push({
+        item: record.payload as NativeItem,
+        timestamp: record.timestamp,
+        sourceLine: index + 1,
+        restoredByCompaction: false,
+      });
+    }
+  }
+  return history;
+}
+
+function textFromContent(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  return content
+    .map(part => {
+      if (!part || typeof part !== 'object') return '';
+      const value = part as Record<string, unknown>;
+      return typeof value.text === 'string' ? value.text
+        : typeof value.refusal === 'string' ? value.refusal
+        : '';
+    })
+    .filter(Boolean)
+    .join('\n');
+}
+
+/** A human-readable Chronicle projection. `rawItem` is the load-bearing field:
+ * the Responses formatter emits it verbatim and ignores the projection. */
+export function projectItem(item: NativeItem): ContentBlock[] {
+  const carrier = <T extends ContentBlock>(block: T): ContentBlock =>
+    ({ ...block, rawItem: item } as ContentBlock);
+
+  switch (item.type) {
+    case 'message':
+      return [carrier({ type: 'text', text: textFromContent(item.content) })];
+    case 'reasoning':
+      if (typeof item.encrypted_content === 'string') {
+        return [carrier({ type: 'redacted_thinking', data: item.encrypted_content })];
+      }
+      return [carrier({ type: 'thinking', thinking: textFromContent(item.summary) })];
+    case 'compaction':
+      return [carrier({
+        type: 'redacted_thinking',
+        data: typeof item.encrypted_content === 'string' ? item.encrypted_content : '',
+      })];
+    case 'function_call':
+      return [carrier({
+        type: 'tool_use',
+        id: String(item.call_id ?? item.id ?? ''),
+        name: String(item.name ?? ''),
+        input: (() => {
+          try { return JSON.parse(String(item.arguments ?? '{}')) as Record<string, unknown>; }
+          catch { return { _rawArguments: item.arguments }; }
+        })(),
+      })];
+    case 'function_call_output':
+      return [carrier({
+        type: 'tool_result',
+        toolUseId: String(item.call_id ?? ''),
+        content: typeof item.output === 'string' ? item.output : JSON.stringify(item.output ?? null),
+      })];
+    default:
+      // Custom tool calls/outputs and future item types stay opaque. The
+      // zero-width projection avoids injecting synthetic text into the model.
+      return [carrier({ type: 'text', text: '' })];
+  }
+}
+
+function participantFor(item: NativeItem, agentName: string): string {
+  if (item.type === 'message') return item.role === 'assistant' ? agentName : 'user';
+  if (item.type === 'reasoning' || item.type === 'compaction' ||
+      item.type === 'function_call' || item.type === 'custom_tool_call') return agentName;
+  return 'user';
+}
+
+function writeRecipe(instanceDir: string, agentName: string): string {
+  const recipeDir = join(instanceDir, 'recipes');
+  mkdirSync(recipeDir, { recursive: true });
+  const path = join(recipeDir, 'codex-rollout.json');
+  const recipe = {
+    name: `${agentName} rollout revival`,
+    description: 'Stateless OpenAI Responses continuation imported from a Codex rollout.',
+    version: '1',
+    agent: {
+      name: agentName,
+      provider: 'openai-responses',
+      model: 'gpt-5.6-sol',
+      systemPrompt: 'The native imported Responses history contains the authoritative developer and system instructions.',
+      maxTokens: 128000,
+      maxStreamTokens: 900000,
+      contextBudgetTokens: 1000000,
+      strategy: { type: 'passthrough' },
+      responses: {
+        reasoningEffort: 'high',
+        reasoningContext: 'all_turns',
+        compactThreshold: 850000,
+      },
+    },
+    modules: {
+      subagents: false,
+      lessons: false,
+      retrieval: false,
+      wake: false,
+    },
+  };
+  writeFileSync(path, JSON.stringify(recipe, null, 2) + '\n');
+  return path;
+}
+
+async function main() {
+  const opts = parseArgs(process.argv);
+  const raw = readFileSync(opts.source, 'utf8');
+  const records = raw.trim().split('\n').filter(Boolean).map((line, index) => {
+    try { return JSON.parse(line) as RolloutRecord; }
+    catch (error) { throw new Error(`Invalid JSON at ${opts.source}:${index + 1}: ${String(error)}`); }
+  });
+  const history = reconstructEffectiveHistory(records);
+  if (history.length === 0) throw new Error('Rollout contains no effective response items.');
+
+  const dataDir = join(opts.outDir, 'data');
+  const sourceDir = join(opts.outDir, 'source');
+  mkdirSync(sourceDir, { recursive: true });
+  const snapshotPath = join(sourceDir, basename(opts.source));
+  writeFileSync(snapshotPath, raw);
+
+  const sessionManager = new SessionManager(dataDir);
+  const session = sessionManager.createSession(`Codex ${basename(opts.source).replace(/^rollout-|\.jsonl$/g, '')}`);
+  const storePath = sessionManager.getStorePath(session.id);
+  const store = JsStore.openOrCreate({ path: storePath });
+  try {
+    const cm = await ContextManager.open({ store });
+    try {
+      for (const entry of history) {
+        cm.addMessage(
+          participantFor(entry.item, opts.agentName),
+          projectItem(entry.item),
+          {
+            sourceId: entry.item.id ?? `rollout-line-${entry.sourceLine}`,
+            codexRollout: {
+              sourceLine: entry.sourceLine,
+              sourceTimestamp: entry.timestamp,
+              restoredByCompaction: entry.restoredByCompaction,
+              nativeType: entry.item.type,
+            },
+          },
+        );
+      }
+    } finally {
+      await cm.close?.();
+    }
+  } finally {
+    store.close?.();
+  }
+
+  const meta = records.find(record => record.type === 'session_meta')?.payload ?? {};
+  const turnContexts = records.filter(record => record.type === 'turn_context');
+  const latestTurn = turnContexts.at(-1)?.payload ?? {};
+  const compacted = records.filter(record => record.type === 'compacted');
+  const sidecarPath = join(dirname(storePath), `${session.id}.import-source.json`);
+  writeFileSync(sidecarPath, JSON.stringify({
+    source: opts.source,
+    snapshot: snapshotPath,
+    agentName: opts.agentName,
+    importedAt: new Date().toISOString(),
+    originalRecordCount: records.length,
+    importedMessageCount: history.length,
+    effectiveItemCount: history.length,
+    compactionCount: compacted.length,
+    latestWindowId: compacted.at(-1)?.payload?.window_id ?? null,
+    model: latestTurn.model ?? 'gpt-5.6-sol',
+    sessionMeta: meta,
+  }, null, 2) + '\n');
+
+  const index = sessionManager.load();
+  index.sessions[session.id]!.messageCount = history.length;
+  sessionManager.save(index);
+  const recipePath = writeRecipe(opts.outDir, opts.agentName);
+  writeFileSync(join(opts.outDir, '.env.example'), [
+    `DATA_DIR=${dataDir}`,
+    'OPENAI_API_KEY=',
+    '',
+  ].join('\n'));
+  writeFileSync(join(opts.outDir, 'README.md'), [
+    '# Codex rollout Connectome instance',
+    '',
+    `Imported from \`${opts.source}\`.`,
+    '',
+    'Run from the connectome-host checkout:',
+    '',
+    '```sh',
+    `DATA_DIR=${dataDir} OPENAI_API_KEY=... bun src/index.ts ${recipePath}`,
+    '```',
+    '',
+    'The session uses provider-native Responses items and passthrough context management.',
+    'Do not run the Claude warmup importer; it would normalize the native prefix.',
+    '',
+  ].join('\n'));
+
+  console.log(JSON.stringify({
+    instanceDir: opts.outDir,
+    dataDir,
+    recipePath,
+    sessionId: session.id,
+    importedItems: history.length,
+    compactions: compacted.length,
+    snapshotPath,
+  }, null, 2));
+}
+
+if (import.meta.main) await main();

--- a/src/call-ledger.ts
+++ b/src/call-ledger.ts
@@ -1,0 +1,371 @@
+/**
+ * Recent provider-call ledger for the WebUI.
+ *
+ * The provider adapter feeds this tracker compact, content-free call records.
+ * It reconstructs the cache verdict operators actually need (hit, first
+ * write, expired rewrite, uncached auxiliary call) and retains a bounded
+ * window. Older process logs are replayed on startup so a host restart does
+ * not leave the dashboard blank.
+ */
+
+import { closeSync, openSync, readSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import type {
+  CallLedgerRow,
+  CallLedgerSnapshot,
+  CallLedgerVerdict,
+} from './web/protocol.js';
+import { ANTHROPIC_PRICING_VERSION, priceAnthropicCall } from './call-pricing.js';
+
+export interface ProviderCallRecord {
+  timestamp: string;
+  kind: 'complete' | 'stream';
+  durationMs: number;
+  model: string;
+  messages: number;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+  /** Provider-reported cache creation buckets. These remain separate because
+   *  Anthropic charges different multipliers for 5m and 1h writes. */
+  cacheWrite5mTokens?: number;
+  cacheWrite1hTokens?: number;
+  /** True only when the split came from the response usage object. */
+  cacheWriteBucketsAuthoritative?: boolean;
+  inferenceGeo?: string;
+  serviceTier?: string;
+  /** Undefined for historical compact logs written before cache summaries. */
+  cacheBreakpoints?: number;
+  /** TTLs found on cache_control blocks. `default` means provider default. */
+  cacheTtls?: string[];
+  stopReason?: string;
+  error?: string;
+}
+
+export interface CallLedgerOptions {
+  dataDir?: string;
+  defaultTtl?: '5m' | '1h';
+  maxRows?: number;
+  hydrate?: boolean;
+}
+
+type Listener = (snapshot: CallLedgerSnapshot) => void;
+
+export class CallLedger {
+  private readonly rows: CallLedgerRow[] = [];
+  private readonly maxRows: number;
+  private readonly defaultTtl: '5m' | '1h';
+  private readonly listeners = new Set<Listener>();
+  private lastCacheActivityAt: number | null = null;
+  private sequence = 0;
+
+  constructor(opts: CallLedgerOptions = {}) {
+    this.maxRows = opts.maxRows ?? 200;
+    this.defaultTtl = opts.defaultTtl ?? '5m';
+    if (opts.hydrate !== false && opts.dataDir) this.hydrate(opts.dataDir);
+  }
+
+  record(call: ProviderCallRecord): void {
+    this.append(call, true);
+  }
+
+  onUpdate(listener: Listener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  snapshot(): CallLedgerSnapshot {
+    const rows = this.rows.map((r) => ({
+      ...r,
+      tokens: { ...r.tokens },
+      cache: { ...r.cache, ttls: [...r.cache.ttls] },
+      ...(r.cost ? { cost: { ...r.cost, rates: { ...r.cost.rates } } } : {}),
+    }));
+    const byVerdict: Partial<Record<CallLedgerVerdict, number>> = {};
+    let input = 0;
+    let output = 0;
+    let cacheRead = 0;
+    let cacheWrite = 0;
+    let totalCost = 0;
+    let pricedCalls = 0;
+    for (const row of rows) {
+      byVerdict[row.verdict] = (byVerdict[row.verdict] ?? 0) + 1;
+      input += row.tokens.input;
+      output += row.tokens.output;
+      cacheRead += row.tokens.cacheRead;
+      cacheWrite += row.tokens.cacheWrite;
+      if (row.cost) {
+        totalCost += row.cost.total;
+        pricedCalls++;
+      }
+    }
+    const cacheDenominator = input + cacheRead + cacheWrite;
+    return {
+      rows,
+      summary: {
+        calls: rows.length,
+        input,
+        output,
+        cacheRead,
+        cacheWrite,
+        cacheHitRatio: cacheDenominator > 0 ? cacheRead / cacheDenominator : 0,
+        cost: {
+          total: totalCost,
+          currency: 'USD',
+          pricedCalls,
+          unpricedCalls: rows.length - pricedCalls,
+          pricingVersion: ANTHROPIC_PRICING_VERSION,
+        },
+        byVerdict,
+      },
+    };
+  }
+
+  private append(call: ProviderCallRecord, notify: boolean): void {
+    const at = Date.parse(call.timestamp);
+    const ttl = effectiveTtl(call.cacheTtls, this.defaultTtl);
+    const ttlSeconds = ttl === '1h' ? 3600 : 300;
+    const hasKnownFlags = call.cacheBreakpoints !== undefined;
+    const hasCacheControls = (call.cacheBreakpoints ?? 0) > 0;
+    const cacheActivity = call.cacheReadTokens > 0 || call.cacheWriteTokens > 0;
+    const priorCacheAt = this.lastCacheActivityAt;
+    const gapSeconds = priorCacheAt !== null && Number.isFinite(at)
+      ? Math.max(0, Math.round((at - priorCacheAt) / 1000))
+      : undefined;
+
+    const { verdict, cause } = classifyCall({
+      call,
+      hasKnownFlags,
+      hasCacheControls,
+      ttlSeconds,
+      gapSeconds,
+    });
+
+    const write5m = call.cacheWrite5mTokens ?? 0;
+    const write1h = call.cacheWrite1hTokens ?? 0;
+    const reportedSplit = write5m + write1h;
+    const splitMismatch = call.cacheWriteTokens > 0 && (
+      !call.cacheWriteBucketsAuthoritative || reportedSplit !== call.cacheWriteTokens
+    );
+    const cost = call.error ? undefined : priceAnthropicCall(call.model, call.timestamp, {
+      inputTokens: call.inputTokens,
+      outputTokens: call.outputTokens,
+      cacheReadTokens: call.cacheReadTokens,
+      cacheWrite5mTokens: write5m,
+      cacheWrite1hTokens: write1h,
+      unclassifiedCacheWriteTokens: splitMismatch
+        ? Math.max(1, Math.abs(call.cacheWriteTokens - reportedSplit))
+        : 0,
+      inferenceGeo: call.inferenceGeo,
+      serviceTier: call.serviceTier,
+    });
+
+    const row: CallLedgerRow = {
+      id: `${call.timestamp}:${++this.sequence}`,
+      timestamp: call.timestamp,
+      kind: call.kind,
+      originEstimate: call.kind === 'stream' ? 'turn~' : 'aux~',
+      model: call.model,
+      messages: call.messages,
+      durationMs: call.durationMs,
+      tokens: {
+        input: call.inputTokens,
+        output: call.outputTokens,
+        cacheRead: call.cacheReadTokens,
+        cacheWrite: call.cacheWriteTokens,
+      },
+      ...(cost ? { cost } : {}),
+      cache: {
+        breakpoints: call.cacheBreakpoints,
+        ttls: call.cacheTtls?.length ? [...new Set(call.cacheTtls)] : [],
+        effectiveTtl: ttl,
+      },
+      verdict,
+      cause,
+      ...(call.stopReason ? { stopReason: call.stopReason } : {}),
+      ...(call.error ? { error: call.error } : {}),
+    };
+
+    this.rows.push(row);
+    if (this.rows.length > this.maxRows) this.rows.splice(0, this.rows.length - this.maxRows);
+    if (cacheActivity && Number.isFinite(at)) this.lastCacheActivityAt = at;
+
+    if (notify) {
+      const snapshot = this.snapshot();
+      for (const listener of this.listeners) {
+        try { listener(snapshot); } catch { /* observability must not break inference */ }
+      }
+    }
+  }
+
+  private hydrate(dataDir: string): void {
+    let files: string[];
+    try {
+      files = readdirSync(dataDir)
+        .filter((name) => /^llm-calls\..*\.jsonl$/.test(name))
+        .map((name) => join(dataDir, name))
+        .sort((a, b) => statSync(a).mtimeMs - statSync(b).mtimeMs)
+        .slice(-4);
+    } catch {
+      return;
+    }
+
+    const calls: ProviderCallRecord[] = [];
+    for (const file of files) {
+      for (const line of readTailLines(file, 16 * 1024 * 1024)) {
+        try {
+          const parsed = parseLoggedCall(JSON.parse(line) as Record<string, unknown>);
+          if (parsed) calls.push(parsed);
+        } catch {
+          // Partial/legacy/oversized forensic lines are skipped individually.
+        }
+      }
+    }
+    calls.sort((a, b) => Date.parse(a.timestamp) - Date.parse(b.timestamp));
+    for (const call of calls.slice(-this.maxRows)) this.append(call, false);
+  }
+}
+
+function classifyCall(opts: {
+  call: ProviderCallRecord;
+  hasKnownFlags: boolean;
+  hasCacheControls: boolean;
+  ttlSeconds: number;
+  gapSeconds?: number;
+}): { verdict: CallLedgerVerdict; cause: string } {
+  const { call, hasKnownFlags, hasCacheControls, ttlSeconds, gapSeconds } = opts;
+  if (call.error) return { verdict: 'ERROR', cause: call.error };
+  if (hasKnownFlags && !hasCacheControls) {
+    return { verdict: 'uncached', cause: 'no cache_control flags in request' };
+  }
+  if (call.cacheReadTokens > 0 && call.cacheWriteTokens > 0) {
+    const pct = cachePercent(call);
+    return { verdict: 'hit+extend', cause: `${pct}% from cache; wrote ${formatTokens(call.cacheWriteTokens)} more` };
+  }
+  if (call.cacheReadTokens > 0) {
+    return { verdict: 'HIT', cause: `${cachePercent(call)}% from cache` };
+  }
+  if (call.cacheWriteTokens > 0) {
+    if (gapSeconds === undefined) {
+      return { verdict: 'first-write', cause: `created ${formatTokens(call.cacheWriteTokens)} cache tokens` };
+    }
+    if (gapSeconds > ttlSeconds) {
+      return { verdict: 'rewrite:expired', cause: `gap ${gapSeconds}s > ttl ${ttlSeconds}s` };
+    }
+    return {
+      verdict: 'rewrite:unexplained',
+      cause: `cache miss inside ttl (${gapSeconds}s <= ${ttlSeconds}s); prefix changed or was truncated`,
+    };
+  }
+  if (!hasKnownFlags) {
+    return { verdict: 'unknown', cause: 'older log has no cache_control summary' };
+  }
+  return { verdict: 'empty', cause: 'cache flags present; provider reported no cache activity' };
+}
+
+function cachePercent(call: ProviderCallRecord): number {
+  const total = call.inputTokens + call.cacheReadTokens + call.cacheWriteTokens;
+  return total > 0 ? Math.round(call.cacheReadTokens / total * 100) : 0;
+}
+
+function effectiveTtl(ttls: string[] | undefined, fallback: '5m' | '1h'): '5m' | '1h' {
+  if (ttls?.includes('1h')) return '1h';
+  if (ttls?.includes('5m') || ttls?.includes('default')) return '5m';
+  return fallback;
+}
+
+function formatTokens(n: number): string {
+  if (n < 1000) return String(n);
+  if (n < 1_000_000) return `${(n / 1000).toFixed(1)}k`;
+  return `${(n / 1_000_000).toFixed(2)}M`;
+}
+
+function parseLoggedCall(record: Record<string, unknown>): ProviderCallRecord | null {
+  const kind = record.kind;
+  const timestamp = record.timestamp;
+  const summary = record.requestSummary as Record<string, unknown> | undefined;
+  if ((kind !== 'complete' && kind !== 'stream') || typeof timestamp !== 'string' || !summary) return null;
+  const rawResponse = record.rawResponse as Record<string, unknown> | null | undefined;
+  const usage = rawResponse?.usage as Record<string, unknown> | undefined;
+  const cacheCreation = usage?.cache_creation as Record<string, unknown> | undefined;
+  const rawRequest = record.rawRequest;
+  const summarized = rawRequest ? summarizeCacheControls(rawRequest) : undefined;
+  const error = record.error as Record<string, unknown> | string | undefined;
+  return {
+    timestamp,
+    kind,
+    durationMs: number(record.durationMs),
+    model: string(summary.model),
+    messages: number(summary.messages),
+    inputTokens: number(usage?.input_tokens),
+    outputTokens: number(usage?.output_tokens),
+    cacheReadTokens: number(usage?.cache_read_input_tokens),
+    cacheWriteTokens: number(usage?.cache_creation_input_tokens),
+    cacheWrite5mTokens: optionalNumber(cacheCreation?.ephemeral_5m_input_tokens),
+    cacheWrite1hTokens: optionalNumber(cacheCreation?.ephemeral_1h_input_tokens),
+    cacheWriteBucketsAuthoritative: cacheCreation !== undefined,
+    inferenceGeo: optionalString(usage?.inference_geo) ?? optionalString(rawResponse?.inference_geo),
+    serviceTier: optionalString(usage?.service_tier) ?? optionalString(rawResponse?.service_tier),
+    cacheBreakpoints: optionalNumber(summary.cacheBreakpoints) ?? summarized?.count,
+    cacheTtls: stringArray(summary.cacheTtls) ?? summarized?.ttls,
+    stopReason: typeof rawResponse?.stop_reason === 'string' ? rawResponse.stop_reason : undefined,
+    error: typeof error === 'string'
+      ? error
+      : typeof error?.message === 'string' ? error.message : undefined,
+  };
+}
+
+/** Content-free cache_control inventory from an actual provider payload. */
+export function summarizeCacheControls(raw: unknown): { count: number; ttls: string[] } {
+  let count = 0;
+  const ttls: string[] = [];
+  const visit = (value: unknown): void => {
+    if (!value || typeof value !== 'object') return;
+    if (Array.isArray(value)) {
+      for (const item of value) visit(item);
+      return;
+    }
+    const obj = value as Record<string, unknown>;
+    if (obj.cache_control && typeof obj.cache_control === 'object') {
+      count++;
+      const ttl = (obj.cache_control as Record<string, unknown>).ttl;
+      ttls.push(typeof ttl === 'string' ? ttl : 'default');
+    }
+    for (const [key, child] of Object.entries(obj)) {
+      if (key !== 'cache_control') visit(child);
+    }
+  };
+  visit(raw);
+  return { count, ttls };
+}
+
+function readTailLines(path: string, maxBytes: number): string[] {
+  let fd: number | undefined;
+  try {
+    const size = statSync(path).size;
+    const start = Math.max(0, size - maxBytes);
+    const length = size - start;
+    if (length <= 0) return [];
+    fd = openSync(path, 'r');
+    const buffer = Buffer.allocUnsafe(length);
+    readSync(fd, buffer, 0, length, start);
+    let text = buffer.toString('utf8');
+    if (start > 0) {
+      const firstNewline = text.indexOf('\n');
+      text = firstNewline >= 0 ? text.slice(firstNewline + 1) : '';
+    }
+    return text.split('\n').filter(Boolean);
+  } catch {
+    return [];
+  } finally {
+    if (fd !== undefined) closeSync(fd);
+  }
+}
+
+const number = (v: unknown): number => typeof v === 'number' && Number.isFinite(v) ? v : 0;
+const string = (v: unknown): string => typeof v === 'string' ? v : '';
+const optionalNumber = (v: unknown): number | undefined => typeof v === 'number' && Number.isFinite(v) ? v : undefined;
+const optionalString = (v: unknown): string | undefined => typeof v === 'string' && v.length > 0 ? v : undefined;
+const stringArray = (v: unknown): string[] | undefined =>
+  Array.isArray(v) && v.every((x) => typeof x === 'string') ? v as string[] : undefined;

--- a/src/call-pricing.ts
+++ b/src/call-pricing.ts
@@ -1,0 +1,119 @@
+/**
+ * Provider-call pricing used by the operator ledger.
+ *
+ * Rates are USD per million tokens and are applied to the provider's
+ * authoritative usage buckets. Cache creation MUST remain split by TTL:
+ * Anthropic bills 5m writes at 1.25x input and 1h writes at 2x input.
+ *
+ * Source: https://platform.claude.com/docs/en/about-claude/pricing
+ * Snapshot: 2026-07-13. Keep the version string/date auditable; silently
+ * changing historical prices would make old JSONL replay disagree with bills.
+ */
+
+import type { CallCostBreakdown } from './web/protocol.js';
+
+export const ANTHROPIC_PRICING_VERSION = 'anthropic-public-2026-07-13';
+
+interface BaseRate {
+  inputPerMillion: number;
+  outputPerMillion: number;
+}
+
+export interface PriceableCallUsage {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheWrite5mTokens: number;
+  cacheWrite1hTokens: number;
+  /** Non-zero means the provider reported creation tokens we could not place
+   *  in an authoritative TTL bucket. Such a call is deliberately unpriced. */
+  unclassifiedCacheWriteTokens: number;
+  inferenceGeo?: string;
+  serviceTier?: string;
+}
+
+export function priceAnthropicCall(
+  model: string,
+  timestamp: string,
+  usage: PriceableCallUsage,
+): CallCostBreakdown | undefined {
+  const rate = anthropicBaseRate(model, timestamp);
+  if (!rate || usage.unclassifiedCacheWriteTokens > 0) return undefined;
+
+  // Public list pricing covers standard service. Priority Tier is contract
+  // priced; returning no figure is safer than presenting a plausible lie.
+  const tier = usage.serviceTier?.toLowerCase();
+  if (tier && tier !== 'standard') return undefined;
+
+  const geo = usage.inferenceGeo?.toLowerCase();
+  const geoMultiplier = !geo || geo === 'global'
+    ? 1
+    : (geo === 'us' || geo === 'us-only' || geo === 'us_only') ? 1.1 : undefined;
+  if (geoMultiplier === undefined) return undefined;
+
+  const input = usage.inputTokens * rate.inputPerMillion / 1_000_000 * geoMultiplier;
+  const cacheWrite5m = usage.cacheWrite5mTokens * rate.inputPerMillion * 1.25 / 1_000_000 * geoMultiplier;
+  const cacheWrite1h = usage.cacheWrite1hTokens * rate.inputPerMillion * 2 / 1_000_000 * geoMultiplier;
+  const cacheRead = usage.cacheReadTokens * rate.inputPerMillion * 0.1 / 1_000_000 * geoMultiplier;
+  const output = usage.outputTokens * rate.outputPerMillion / 1_000_000 * geoMultiplier;
+
+  return {
+    input,
+    cacheWrite5m,
+    cacheWrite1h,
+    cacheRead,
+    output,
+    total: input + cacheWrite5m + cacheWrite1h + cacheRead + output,
+    currency: 'USD',
+    grade: 'billing',
+    pricingVersion: ANTHROPIC_PRICING_VERSION,
+    rates: {
+      inputPerMillion: rate.inputPerMillion * geoMultiplier,
+      outputPerMillion: rate.outputPerMillion * geoMultiplier,
+      cacheWrite5mPerMillion: rate.inputPerMillion * 1.25 * geoMultiplier,
+      cacheWrite1hPerMillion: rate.inputPerMillion * 2 * geoMultiplier,
+      cacheReadPerMillion: rate.inputPerMillion * 0.1 * geoMultiplier,
+    },
+  };
+}
+
+function anthropicBaseRate(model: string, timestamp: string): BaseRate | undefined {
+  // Fable 5 and Mythos 5 share pricing.
+  if (starts(model, 'claude-fable-5', 'claude-mythos-5')) return rate(10, 50);
+
+  if (starts(model,
+    'claude-opus-4-8',
+    'claude-opus-4-7',
+    'claude-opus-4-6',
+    'claude-opus-4-5',
+  )) return rate(5, 25);
+
+  // Sonnet 5 launch pricing is promotional through 2026-08-31 inclusive.
+  if (starts(model, 'claude-sonnet-5')) {
+    const at = Date.parse(timestamp);
+    const promoEnd = Date.parse('2026-09-01T00:00:00Z');
+    return Number.isFinite(at) && at < promoEnd ? rate(2, 10) : rate(3, 15);
+  }
+
+  if (starts(model,
+    'claude-sonnet-4-6',
+    'claude-sonnet-4-5',
+    'claude-sonnet-4-',
+    'claude-3-7-sonnet',
+    'claude-3-5-sonnet',
+  )) return rate(3, 15);
+
+  if (starts(model, 'claude-haiku-4-5')) return rate(1, 5);
+  if (starts(model, 'claude-3-5-haiku')) return rate(0.8, 4);
+
+  if (starts(model, 'claude-opus-4-1', 'claude-opus-4-')) return rate(15, 75);
+  return undefined;
+}
+
+function starts(model: string, ...prefixes: string[]): boolean {
+  return prefixes.some((prefix) => model.startsWith(prefix));
+}
+
+function rate(inputPerMillion: number, outputPerMillion: number): BaseRate {
+  return { inputPerMillion, outputPerMillion };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,12 @@
  *   DATA_DIR            - Data directory for sessions (default: ./data)
  */
 
-import { Membrane, NativeFormatter } from '@animalabs/membrane';
+import {
+  Membrane,
+  NativeFormatter,
+  OpenAIResponsesAPIAdapter,
+  OpenAIResponsesFormatter,
+} from '@animalabs/membrane';
 import { LoggingAnthropicAdapter } from './logging-adapter.js';
 import { CallLedger } from './call-ledger.js';
 import { SettingsModule } from './modules/settings-module.js';
@@ -62,14 +67,10 @@ const config = {
   // OAuth/Bearer token (e.g. a Claude subscription token). When set, it takes
   // precedence over the API key so requests never carry both auth schemes.
   authToken: process.env.ANTHROPIC_AUTH_TOKEN,
+  openaiApiKey: process.env.OPENAI_API_KEY,
   model: process.env.MODEL,
   dataDir: process.env.DATA_DIR || './data',
 };
-
-if (!config.apiKey && !config.authToken) {
-  console.error('Missing ANTHROPIC_API_KEY (or ANTHROPIC_AUTH_TOKEN). Set one in .env or environment.');
-  process.exit(1);
-}
 
 // ---------------------------------------------------------------------------
 // AppContext — mutable container for session switching
@@ -139,7 +140,7 @@ async function createFramework(
   recipe: Recipe,
   agentName: string,
   settingsModule: SettingsModule,
-  callLedger: CallLedger,
+  callLedger: CallLedger | null,
 ): Promise<AgentFramework> {
   const model = config.model || recipe.agent.model || 'claude-opus-4-6';
   const modules = recipe.modules ?? {};
@@ -334,7 +335,7 @@ async function createFramework(
       basicAuth: webuiConfig.basicAuth,
       allowedOrigins: webuiConfig.allowedOrigins,
       observersPath,
-      callLedger,
+      ...(callLedger ? { callLedger } : {}),
     });
     moduleInstances.push(webUiModule);
     moduleInstances.push(new ObserversModule({ path: observersPath }));
@@ -476,6 +477,20 @@ async function createFramework(
         maxStreamTokens: recipe.agent.maxStreamTokens ?? 150000,
         contextBudgetTokens: recipe.agent.contextBudgetTokens,
         ...(recipe.agent.cacheTtl && { cacheTtl: recipe.agent.cacheTtl }),
+        ...(recipe.agent.provider === 'openai-responses' && {
+          providerParams: {
+            reasoning: {
+              effort: recipe.agent.responses?.reasoningEffort ?? 'high',
+              context: recipe.agent.responses?.reasoningContext ?? 'all_turns',
+            },
+            ...(recipe.agent.responses?.compactThreshold ? {
+              context_management: [{
+                type: 'compaction',
+                compact_threshold: recipe.agent.responses.compactThreshold,
+              }],
+            } : {}),
+          },
+        }),
         strategy,
         ...(recipe.agent.thinking && { thinking: recipe.agent.thinking }),
         ...(recipe.agent.refusalHandling && { refusalHandling: recipe.agent.refusalHandling }),
@@ -764,6 +779,16 @@ function countLines(path: string): number {
 
 async function main() {
   const recipe = await resolveRecipe();
+  const provider = recipe.agent.provider ?? 'anthropic';
+
+  if (provider === 'openai-responses' && !config.openaiApiKey) {
+    console.error('Missing OPENAI_API_KEY for recipe provider "openai-responses".');
+    process.exit(1);
+  }
+  if (provider === 'anthropic' && !config.apiKey && !config.authToken) {
+    console.error('Missing ANTHROPIC_API_KEY (or ANTHROPIC_AUTH_TOKEN). Set one in .env or environment.');
+    process.exit(1);
+  }
 
   // SettingsModule constructed early so the adapter can read its state for
   // cross-cutting concerns (currently: reasoning). It's wired into the
@@ -778,27 +803,34 @@ async function main() {
     config.dataDir,
     `llm-calls.${new Date().toISOString().replace(/[:.]/g, '-')}.jsonl`,
   );
-  const callLedger = new CallLedger({
-    dataDir: config.dataDir,
-    defaultTtl: recipe.agent.cacheTtl ?? '5m',
-  });
+  const callLedger = provider === 'anthropic'
+    ? new CallLedger({
+        dataDir: config.dataDir,
+        defaultTtl: recipe.agent.cacheTtl ?? '5m',
+      })
+    : null;
   // OAuth (subscription) auth wins over API-key auth when both are present.
   // Subscription tokens (sk-ant-oat…) additionally require the oauth beta
   // header on every request.
-  const adapter = new LoggingAnthropicAdapter(
-    {
-      ...(config.authToken
-        ? {
-            authToken: config.authToken,
-            defaultHeaders: { 'anthropic-beta': 'oauth-2025-04-20' },
-          }
-        : { apiKey: config.apiKey! }),
-      baseURL: process.env.ANTHROPIC_BASE_URL || undefined,
-    },
-    llmLogPath,
-    () => settingsModule.getReasoning(),
-    (record) => callLedger.record(record),
-  );
+  const adapter = provider === 'openai-responses'
+    ? new OpenAIResponsesAPIAdapter({
+        apiKey: config.openaiApiKey!,
+        baseURL: process.env.OPENAI_BASE_URL || undefined,
+      })
+    : new LoggingAnthropicAdapter(
+        {
+          ...(config.authToken
+            ? {
+                authToken: config.authToken,
+                defaultHeaders: { 'anthropic-beta': 'oauth-2025-04-20' },
+              }
+            : { apiKey: config.apiKey! }),
+          baseURL: process.env.ANTHROPIC_BASE_URL || undefined,
+        },
+        llmLogPath,
+        () => settingsModule.getReasoning(),
+        (record) => callLedger!.record(record),
+      );
 
   // Session management — resolved before Membrane construction so the
   // active session's import-source sidecar can contribute to agent-name
@@ -831,7 +863,9 @@ async function main() {
   const agentName = resolved.name;
 
   const membrane = new Membrane(adapter, {
-    formatter: new NativeFormatter(),
+    formatter: provider === 'openai-responses'
+      ? new OpenAIResponsesFormatter()
+      : new NativeFormatter(),
     // Anchor the assistant role for internal callers that don't set
     // request.assistantParticipant themselves (autobio compression,
     // executeMerge). Mismatch here flips stored assistant turns to

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@
 
 import { Membrane, NativeFormatter } from '@animalabs/membrane';
 import { LoggingAnthropicAdapter } from './logging-adapter.js';
+import { CallLedger } from './call-ledger.js';
 import { SettingsModule } from './modules/settings-module.js';
 import { AgentFramework, AutobiographicalStrategy, PassthroughStrategy, WorkspaceModule, resolveTimeZone, type Module, type MountConfig } from '@animalabs/agent-framework';
 import { resolve, join, basename } from 'node:path';
@@ -138,6 +139,7 @@ async function createFramework(
   recipe: Recipe,
   agentName: string,
   settingsModule: SettingsModule,
+  callLedger: CallLedger,
 ): Promise<AgentFramework> {
   const model = config.model || recipe.agent.model || 'claude-opus-4-6';
   const modules = recipe.modules ?? {};
@@ -332,6 +334,7 @@ async function createFramework(
       basicAuth: webuiConfig.basicAuth,
       allowedOrigins: webuiConfig.allowedOrigins,
       observersPath,
+      callLedger,
     });
     moduleInstances.push(webUiModule);
     moduleInstances.push(new ObserversModule({ path: observersPath }));
@@ -775,6 +778,10 @@ async function main() {
     config.dataDir,
     `llm-calls.${new Date().toISOString().replace(/[:.]/g, '-')}.jsonl`,
   );
+  const callLedger = new CallLedger({
+    dataDir: config.dataDir,
+    defaultTtl: recipe.agent.cacheTtl ?? '5m',
+  });
   // OAuth (subscription) auth wins over API-key auth when both are present.
   // Subscription tokens (sk-ant-oat…) additionally require the oauth beta
   // header on every request.
@@ -790,6 +797,7 @@ async function main() {
     },
     llmLogPath,
     () => settingsModule.getReasoning(),
+    (record) => callLedger.record(record),
   );
 
   // Session management — resolved before Membrane construction so the
@@ -832,7 +840,7 @@ async function main() {
   });
 
   const storePath = sessionManager.getStorePath(activeSession.id);
-  const framework = await createFramework(membrane, storePath, recipe, agentName, settingsModule);
+  const framework = await createFramework(membrane, storePath, recipe, agentName, settingsModule, callLedger);
 
   // Build app context
   const app: AppContext = {
@@ -853,7 +861,7 @@ async function main() {
       // re-resolution would matter only if recipe.agent.name is absent
       // AND the user switches between imports that used different
       // --agent values; not the canonical flow.
-      this.framework = await createFramework(membrane, newStorePath, recipe, this.agentName, settingsModule);
+      this.framework = await createFramework(membrane, newStorePath, recipe, this.agentName, settingsModule, callLedger);
       this.framework.start();
       this.userMessageCount = 0;
       resetBranchState(this.branchState);

--- a/src/logging-adapter.ts
+++ b/src/logging-adapter.ts
@@ -27,11 +27,13 @@ import type {
   StreamCallbacks,
 } from '@animalabs/membrane';
 import { appendFileSync } from 'node:fs';
+import { summarizeCacheControls, type ProviderCallRecord } from './call-ledger.js';
 
 /** Live read of the current reasoning setting. The host wires this to
  *  `SettingsModule.getReasoning()` so toggles via the `settings--reasoning_*`
  *  tools take effect on the next call without restart. */
 export type ReasoningGetter = () => { enabled: boolean; budgetTokens: number };
+export type ProviderCallObserver = (record: ProviderCallRecord) => void;
 
 /** Exact first-system-block identity Anthropic requires on subscription
  *  (sk-ant-oat…) OAuth traffic. Verified 2026-07-09: any other first block —
@@ -44,6 +46,7 @@ const OAUTH_SYSTEM_IDENTITY = "You are Claude Code, Anthropic's official CLI for
 export class LoggingAnthropicAdapter extends AnthropicAdapter {
   private readonly logPath: string;
   private readonly getReasoning?: ReasoningGetter;
+  private readonly onCall?: ProviderCallObserver;
   /** True when authenticated with an OAuth/Bearer token instead of an API
    *  key; requests then need the identity block prepended (see above). */
   private readonly oauthMode: boolean;
@@ -52,10 +55,12 @@ export class LoggingAnthropicAdapter extends AnthropicAdapter {
     config: ConstructorParameters<typeof AnthropicAdapter>[0],
     logPath: string,
     getReasoning?: ReasoningGetter,
+    onCall?: ProviderCallObserver,
   ) {
     super(config);
     this.logPath = logPath;
     this.getReasoning = getReasoning;
+    this.onCall = onCall;
     this.oauthMode = Boolean(config?.authToken);
   }
 
@@ -115,13 +120,59 @@ export class LoggingAnthropicAdapter extends AnthropicAdapter {
     }
   }
 
-  private requestSummary(request: ProviderRequest): Record<string, unknown> {
+  private requestSummary(request: ProviderRequest, rawRequest?: unknown): Record<string, unknown> {
+    const cache = rawRequest ? summarizeCacheControls(rawRequest) : undefined;
     return {
       model: request.model,
       maxTokens: request.maxTokens,
       messages: request.messages.length,
       tools: request.tools?.length ?? 0,
+      ...(cache ? { cacheBreakpoints: cache.count, cacheTtls: cache.ttls } : {}),
     };
+  }
+
+  private observeCall(
+    kind: 'complete' | 'stream',
+    timestamp: string,
+    durationMs: number,
+    request: ProviderRequest,
+    rawRequest: unknown,
+    response?: ProviderResponse,
+    error?: unknown,
+  ): void {
+    if (!this.onCall) return;
+    const cache = summarizeCacheControls(rawRequest);
+    const raw = (response as { raw?: Record<string, unknown> } | undefined)?.raw;
+    const rawUsage = raw?.usage as Record<string, unknown> | undefined;
+    const cacheCreation = rawUsage?.cache_creation as Record<string, unknown> | undefined;
+    const finite = (value: unknown): number | undefined =>
+      typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+    const text = (value: unknown): string | undefined =>
+      typeof value === 'string' && value.length > 0 ? value : undefined;
+    try {
+      this.onCall({
+        timestamp,
+        kind,
+        durationMs,
+        model: request.model,
+        messages: request.messages.length,
+        inputTokens: response?.usage.inputTokens ?? 0,
+        outputTokens: response?.usage.outputTokens ?? 0,
+        cacheReadTokens: response?.usage.cacheReadTokens ?? 0,
+        cacheWriteTokens: response?.usage.cacheCreationTokens ?? 0,
+        cacheWrite5mTokens: finite(cacheCreation?.ephemeral_5m_input_tokens),
+        cacheWrite1hTokens: finite(cacheCreation?.ephemeral_1h_input_tokens),
+        cacheWriteBucketsAuthoritative: cacheCreation !== undefined,
+        inferenceGeo: text(rawUsage?.inference_geo) ?? text(raw?.inference_geo),
+        serviceTier: text(rawUsage?.service_tier) ?? text(raw?.service_tier),
+        cacheBreakpoints: cache.count,
+        cacheTtls: cache.ttls,
+        stopReason: response?.stopReason,
+        error: error instanceof Error ? error.message : error ? String(error) : undefined,
+      });
+    } catch {
+      // A dashboard observer is never allowed to affect provider traffic.
+    }
   }
 
   private refusalRawRequest(response: ProviderResponse, rawRequest: unknown): unknown {
@@ -155,22 +206,28 @@ export class LoggingAnthropicAdapter extends AnthropicAdapter {
     const wrapped = this.captureRawRequest(options, sink);
     try {
       const response = await super.complete(effective, wrapped);
+      const timestamp = new Date().toISOString();
+      const durationMs = Date.now() - t0;
       this.log({
         type: 'call', kind: 'complete',
-        timestamp: new Date().toISOString(), durationMs: Date.now() - t0,
-        requestSummary: this.requestSummary(request),
+        timestamp, durationMs,
+        requestSummary: this.requestSummary(request, sink.rawRequest),
         rawRequest: this.refusalRawRequest(response, sink.rawRequest),
         rawResponse: (response as { raw?: unknown }).raw ?? null,
       });
+      this.observeCall('complete', timestamp, durationMs, request, sink.rawRequest, response);
       return response;
     } catch (err) {
+      const timestamp = new Date().toISOString();
+      const durationMs = Date.now() - t0;
       this.log({
         type: 'error', kind: 'complete',
-        timestamp: new Date().toISOString(), durationMs: Date.now() - t0,
-        requestSummary: this.requestSummary(request),
+        timestamp, durationMs,
+        requestSummary: this.requestSummary(request, sink.rawRequest),
         rawRequest: sink.rawRequest,
         error: err instanceof Error ? { name: err.name, message: err.message, stack: err.stack } : String(err),
       });
+      this.observeCall('complete', timestamp, durationMs, request, sink.rawRequest, undefined, err);
       throw err;
     }
   }
@@ -186,22 +243,28 @@ export class LoggingAnthropicAdapter extends AnthropicAdapter {
     const wrapped = this.captureRawRequest(options, sink);
     try {
       const response = await super.stream(effective, callbacks, wrapped);
+      const timestamp = new Date().toISOString();
+      const durationMs = Date.now() - t0;
       this.log({
         type: 'call', kind: 'stream',
-        timestamp: new Date().toISOString(), durationMs: Date.now() - t0,
-        requestSummary: this.requestSummary(request),
+        timestamp, durationMs,
+        requestSummary: this.requestSummary(request, sink.rawRequest),
         rawRequest: this.refusalRawRequest(response, sink.rawRequest),
         rawResponse: (response as { raw?: unknown }).raw ?? null,
       });
+      this.observeCall('stream', timestamp, durationMs, request, sink.rawRequest, response);
       return response;
     } catch (err) {
+      const timestamp = new Date().toISOString();
+      const durationMs = Date.now() - t0;
       this.log({
         type: 'error', kind: 'stream',
-        timestamp: new Date().toISOString(), durationMs: Date.now() - t0,
-        requestSummary: this.requestSummary(request),
+        timestamp, durationMs,
+        requestSummary: this.requestSummary(request, sink.rawRequest),
         rawRequest: sink.rawRequest,
         error: err instanceof Error ? { name: err.name, message: err.message, stack: err.stack } : String(err),
       });
+      this.observeCall('stream', timestamp, durationMs, request, sink.rawRequest, undefined, err);
       throw err;
     }
   }

--- a/src/modules/web-ui-module.ts
+++ b/src/modules/web-ui-module.ts
@@ -41,6 +41,7 @@ import { createHash, timingSafeEqual } from 'node:crypto';
 import type { Recipe } from '../recipe.js';
 import type { SessionManager } from '../session-manager.js';
 import type { BranchState } from '../commands.js';
+import type { CallLedger } from '../call-ledger.js';
 import { handleCommand } from '../commands.js';
 import { AgentTreeReducer, type AgentTreeSnapshot } from '../state/agent-tree-reducer.js';
 import { FleetTreeAggregator } from '../state/fleet-tree-aggregator.js';
@@ -54,6 +55,7 @@ import {
   type WelcomeMessageEntry,
   type RequestHistoryMessage,
   type TokenUsage,
+  type CallLedgerSnapshot,
   type McplListMessage,
   type LessonsListMessage,
 } from '../web/protocol.js';
@@ -128,6 +130,8 @@ export interface WebUiModuleConfig {
    * scope mask. With no grants the webui behaves exactly as before.
    */
   observersPath?: string;
+  /** Content-free recent provider-call ledger for spend/cache diagnostics. */
+  callLedger?: CallLedger;
 }
 
 /** Data stashed on the Bun WS upgrade. */
@@ -389,6 +393,9 @@ interface SharedServerState {
    *  every usage:updated event so the welcome and live UsageMessage frames
    *  carry consistent values. */
   latestPerAgentCost: import('../web/protocol.js').PerAgentCost[];
+  /** Recent per-call cache diagnostics, updated directly by the adapter. */
+  latestCallLedger?: CallLedgerSnapshot;
+  callLedgerDetacher: (() => void) | null;
   /** Currently-bound app, refreshed on every setApp() call. WS handlers read
    *  from here so the singleton always points at the live framework regardless
    *  of which WebUiModule instance is "active". */
@@ -464,6 +471,8 @@ export class WebUiModule implements Module {
       parentUsage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
       childUsage: new Map(),
       latestPerAgentCost: [],
+      latestCallLedger: this.config.callLedger?.snapshot(),
+      callLedgerDetacher: null,
       pendingFleetRequests: new Map(),
       childRecipeCache: new Map(),
       app: null,
@@ -494,6 +503,19 @@ export class WebUiModule implements Module {
       state.allowedOrigins = defaultAllowedOrigins(boundPort);
     }
     sharedServer = state;
+
+    // Provider calls include auxiliary compression requests that never emit a
+    // framework usage trace, so subscribe at the adapter ledger itself. This
+    // keeps the panel live for both conversational and memory-maintenance
+    // calls without polling the JSONL log.
+    state.callLedgerDetacher = this.config.callLedger?.onUpdate((ledger) => {
+      state.latestCallLedger = ledger;
+      const msg: WebUiServerMessage = { type: 'call-ledger', ledger };
+      for (const client of state.clients.values()) {
+        if (!client.welcomed) continue;
+        if (client.scopes === null || client.scopes.has('health')) this.send(client, msg);
+      }
+    }) ?? null;
 
     console.log(`[webui] listening on http://${host}:${boundPort}`);
   }
@@ -2485,6 +2507,9 @@ export class WebUiModule implements Module {
       usage: sharedServer!.latestUsage,
       ...(sharedServer!.latestPerAgentCost.length > 0
         ? { perAgentCost: sharedServer!.latestPerAgentCost }
+        : {}),
+      ...(sharedServer!.latestCallLedger
+        ? { callLedger: sharedServer!.latestCallLedger }
         : {}),
     };
   }

--- a/src/recipe.ts
+++ b/src/recipe.ts
@@ -77,6 +77,8 @@ export interface RecipeAgent {
   model?: string;
   /** IANA zone used when rendering wall-clock times to the agent. */
   timezone?: string;
+  /** Provider transport. Omitted preserves the historical Anthropic default. */
+  provider?: 'anthropic' | 'openai-responses';
   systemPrompt: string;
   maxTokens?: number;
   /**
@@ -101,6 +103,13 @@ export interface RecipeAgent {
   thinking?: {
     enabled: boolean;
     budgetTokens?: number;
+  };
+  /** Stateless OpenAI Responses settings. Only used with
+   * `provider: "openai-responses"`. */
+  responses?: {
+    reasoningEffort?: 'none' | 'low' | 'medium' | 'high' | 'xhigh' | 'max';
+    reasoningContext?: 'current_turn' | 'all_turns';
+    compactThreshold?: number;
   };
   /**
    * Content-refusal handling. When `autoRewind` is on, a `stop_reason: refusal`
@@ -680,6 +689,10 @@ export function validateRecipe(raw: unknown): Recipe {
     throw new Error('Recipe agent must have a "systemPrompt" string');
   }
 
+  if (agent.provider !== undefined && agent.provider !== 'anthropic' && agent.provider !== 'openai-responses') {
+    throw new Error(`Recipe agent.provider must be 'anthropic' or 'openai-responses', got ${JSON.stringify(agent.provider)}.`);
+  }
+
   if (agent.timezone !== undefined) {
     if (typeof agent.timezone !== 'string' || !agent.timezone.trim()) {
       throw new Error('Recipe agent.timezone must be a non-empty IANA time zone string.');
@@ -688,6 +701,24 @@ export function validateRecipe(raw: unknown): Recipe {
       new Intl.DateTimeFormat('en-US', { timeZone: agent.timezone }).format(new Date(0));
     } catch {
       throw new Error(`Recipe agent.timezone is not a valid IANA time zone: ${JSON.stringify(agent.timezone)}.`);
+    }
+  }
+
+  if (agent.responses !== undefined) {
+    if (!agent.responses || typeof agent.responses !== 'object' || Array.isArray(agent.responses)) {
+      throw new Error('Recipe agent.responses must be an object.');
+    }
+    const responses = agent.responses as Record<string, unknown>;
+    const efforts = ['none', 'low', 'medium', 'high', 'xhigh', 'max'];
+    if (responses.reasoningEffort !== undefined && !efforts.includes(String(responses.reasoningEffort))) {
+      throw new Error(`Invalid agent.responses.reasoningEffort ${JSON.stringify(responses.reasoningEffort)}.`);
+    }
+    if (responses.reasoningContext !== undefined && responses.reasoningContext !== 'current_turn' && responses.reasoningContext !== 'all_turns') {
+      throw new Error(`Invalid agent.responses.reasoningContext ${JSON.stringify(responses.reasoningContext)}.`);
+    }
+    if (responses.compactThreshold !== undefined &&
+        (typeof responses.compactThreshold !== 'number' || responses.compactThreshold <= 0)) {
+      throw new Error('Recipe agent.responses.compactThreshold must be a positive number.');
     }
   }
 

--- a/src/recipe.ts
+++ b/src/recipe.ts
@@ -90,9 +90,8 @@ export interface RecipeAgent {
   /** Per-agent context compile budget (input tokens). When unset, the
    *  ContextManager default (100k) applies. Raise for large-context models. */
   contextBudgetTokens?: number;
-  /** Prompt-cache TTL ('5m' | '1h') forwarded to the provider. Set '1h' for
-   *  agents whose reply cadence is slower than 5 minutes — avoids re-writing
-   *  the full context to cache after every gap. Unset: provider default (5m). */
+  /** Prompt-cache TTL ('5m' | '1h') forwarded to the provider. Defaults to
+   *  '1h'; set '5m' explicitly for high-frequency, sub-5-minute workloads. */
   cacheTtl?: '5m' | '1h';
   strategy?: RecipeStrategy;
   /**
@@ -511,6 +510,7 @@ export const DEFAULT_RECIPE: Recipe = {
   description: 'General-purpose assistant with tool access',
   agent: {
     name: 'agent',
+    cacheTtl: '1h',
     systemPrompt: [
       'You are a helpful assistant. You have access to tools provided by connected MCP servers.',
       'Use them to help the user with their tasks.',
@@ -731,6 +731,7 @@ export function validateRecipe(raw: unknown): Recipe {
   if (agent.cacheTtl !== undefined && agent.cacheTtl !== '5m' && agent.cacheTtl !== '1h') {
     throw new Error(`Recipe agent.cacheTtl must be '5m' or '1h', got ${JSON.stringify(agent.cacheTtl)}.`);
   }
+  agent.cacheTtl ??= '1h';
 
   // Validate agent.thinking if present. Catches typos and constraint
   // violations (notably max_tokens > budget_tokens) at recipe-load time

--- a/src/web/protocol.ts
+++ b/src/web/protocol.ts
@@ -93,6 +93,9 @@ export interface WelcomeMessage {
   /** Per-agent cost breakdown for the parent process, present when the
    *  framework's usage tracker has data. Empty during cold start. */
   perAgentCost?: PerAgentCost[];
+  /** Recent provider calls with cache verdicts. Present when the host's
+   *  provider adapter exposes the call ledger. */
+  callLedger?: CallLedgerSnapshot;
 }
 
 /**
@@ -162,6 +165,91 @@ export interface UsageMessage {
   type: 'usage';
   usage: TokenUsage;
   perAgentCost?: PerAgentCost[];
+}
+
+/** Live replacement snapshot emitted after each provider call. */
+export interface CallLedgerMessage {
+  type: 'call-ledger';
+  ledger: CallLedgerSnapshot;
+}
+
+export type CallLedgerVerdict =
+  | 'HIT'
+  | 'hit+extend'
+  | 'uncached'
+  | 'rewrite:expired'
+  | 'rewrite:prefix-mutated'
+  | 'rewrite:prefix-truncated'
+  | 'rewrite:unexplained'
+  | 'first-write'
+  | 'ERROR'
+  | 'empty'
+  | 'unknown';
+
+export interface CallLedgerRow {
+  id: string;
+  timestamp: string;
+  kind: 'complete' | 'stream';
+  /** Honest call-class estimate; `~` means the trigger plumbing did not
+   *  provide a definitive origin. */
+  originEstimate: 'turn~' | 'aux~';
+  model: string;
+  messages: number;
+  durationMs: number;
+  tokens: { input: number; output: number; cacheRead: number; cacheWrite: number };
+  cost?: CallCostBreakdown;
+  cache: {
+    /** Undefined for older compact logs that predate marker summaries. */
+    breakpoints?: number;
+    ttls: string[];
+    effectiveTtl: '5m' | '1h';
+  };
+  verdict: CallLedgerVerdict;
+  cause: string;
+  stopReason?: string;
+  error?: string;
+}
+
+export interface CallCostBreakdown {
+  input: number;
+  cacheWrite5m: number;
+  cacheWrite1h: number;
+  cacheRead: number;
+  output: number;
+  total: number;
+  currency: 'USD';
+  /** `billing` means every charged usage bucket and pricing modifier was
+   *  known. Unknown/mixed buckets are left unpriced rather than estimated. */
+  grade: 'billing';
+  pricingVersion: string;
+  rates: {
+    inputPerMillion: number;
+    outputPerMillion: number;
+    cacheWrite5mPerMillion: number;
+    cacheWrite1hPerMillion: number;
+    cacheReadPerMillion: number;
+  };
+}
+
+export interface CallLedgerSnapshot {
+  /** Oldest to newest; clients may reverse for display. */
+  rows: CallLedgerRow[];
+  summary: {
+    calls: number;
+    input: number;
+    output: number;
+    cacheRead: number;
+    cacheWrite: number;
+    cacheHitRatio: number;
+    cost?: {
+      total: number;
+      currency: 'USD';
+      pricedCalls: number;
+      unpricedCalls: number;
+      pricingVersion: string;
+    };
+    byVerdict: Partial<Record<CallLedgerVerdict, number>>;
+  };
 }
 
 export interface TokenUsage {
@@ -352,6 +440,7 @@ export type WebUiServerMessage =
   | ChildEventMessage
   | CommandResultMessage
   | UsageMessage
+  | CallLedgerMessage
   | BranchChangedMessage
   | SessionChangedMessage
   | PeekMessage

--- a/test/call-ledger.test.ts
+++ b/test/call-ledger.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from 'bun:test';
+import { CallLedger, summarizeCacheControls, type ProviderCallRecord } from '../src/call-ledger.js';
+
+const at = (seconds: number): string => new Date(Date.UTC(2026, 0, 1, 0, 0, seconds)).toISOString();
+
+function call(overrides: Partial<ProviderCallRecord> = {}): ProviderCallRecord {
+  return {
+    timestamp: at(0),
+    kind: 'stream',
+    durationMs: 1000,
+    model: 'claude-fable-5',
+    messages: 10,
+    inputTokens: 2,
+    outputTokens: 100,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    cacheBreakpoints: 4,
+    cacheTtls: ['1h', '1h', '1h', '1h'],
+    stopReason: 'end_turn',
+    ...overrides,
+  };
+}
+
+describe('CallLedger cache verdicts', () => {
+  test('distinguishes first write, hit, and expired rewrite using the effective TTL', () => {
+    const ledger = new CallLedger({ hydrate: false, defaultTtl: '1h' });
+    ledger.record(call({ timestamp: at(0), cacheWriteTokens: 100_000 }));
+    ledger.record(call({ timestamp: at(1800), cacheReadTokens: 100_000 }));
+    ledger.record(call({ timestamp: at(5500), cacheWriteTokens: 101_000 }));
+
+    const rows = ledger.snapshot().rows;
+    expect(rows.map((r) => r.verdict)).toEqual(['first-write', 'HIT', 'rewrite:expired']);
+    expect(rows[2]!.cause).toContain('gap 3700s > ttl 3600s');
+  });
+
+  test('calls without cache flags are visibly uncached', () => {
+    const ledger = new CallLedger({ hydrate: false });
+    ledger.record(call({ kind: 'complete', cacheBreakpoints: 0, cacheTtls: [], inputTokens: 48_000 }));
+    expect(ledger.snapshot().rows[0]).toMatchObject({
+      verdict: 'uncached',
+      cause: 'no cache_control flags in request',
+    });
+  });
+
+  test('reports hit+extend and an aggregate cache ratio', () => {
+    const ledger = new CallLedger({ hydrate: false });
+    ledger.record(call({ inputTokens: 100, cacheReadTokens: 900, cacheWriteTokens: 100 }));
+    const snap = ledger.snapshot();
+    expect(snap.rows[0]!.verdict).toBe('hit+extend');
+    expect(snap.summary.cacheHitRatio).toBeCloseTo(900 / 1100);
+  });
+
+  test('allocates an auditable per-call cost and reconciles the retained total', () => {
+    const ledger = new CallLedger({ hydrate: false });
+    ledger.record(call({
+      cacheWriteTokens: 336_010,
+      cacheWrite5mTokens: 336_010,
+      cacheWrite1hTokens: 0,
+      cacheWriteBucketsAuthoritative: true,
+      cacheTtls: ['5m'],
+      outputTokens: 639,
+      serviceTier: 'standard',
+      inferenceGeo: 'global',
+    }));
+    ledger.record(call({ model: 'unknown-model' }));
+
+    const snap = ledger.snapshot();
+    expect(snap.rows[0]!.cost?.total).toBeCloseTo(4.232095, 9);
+    expect(snap.rows[1]!.cost).toBeUndefined();
+    expect(snap.summary.cost).toMatchObject({
+      total: 4.232095,
+      pricedCalls: 1,
+      unpricedCalls: 1,
+      currency: 'USD',
+    });
+  });
+
+  test('does not guess a cache-write TTL bucket from request flags', () => {
+    const ledger = new CallLedger({ hydrate: false });
+    ledger.record(call({ cacheWriteTokens: 100_000, cacheTtls: ['1h'] }));
+    expect(ledger.snapshot().rows[0]!.cost).toBeUndefined();
+  });
+});
+
+test('summarizeCacheControls inventories markers without retaining content', () => {
+  const raw = {
+    system: [{ type: 'text', text: 'secret', cache_control: { type: 'ephemeral', ttl: '1h' } }],
+    messages: [{ role: 'user', content: [{ type: 'text', text: 'private', cache_control: { type: 'ephemeral' } }] }],
+  };
+  expect(summarizeCacheControls(raw)).toEqual({ count: 2, ttls: ['1h', 'default'] });
+});

--- a/test/call-pricing.test.ts
+++ b/test/call-pricing.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from 'bun:test';
+import { ANTHROPIC_PRICING_VERSION, priceAnthropicCall } from '../src/call-pricing.js';
+
+const timestamp = '2026-07-13T12:00:00.000Z';
+
+function usage(overrides: Partial<Parameters<typeof priceAnthropicCall>[2]> = {}) {
+  return {
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadTokens: 0,
+    cacheWrite5mTokens: 0,
+    cacheWrite1hTokens: 0,
+    unclassifiedCacheWriteTokens: 0,
+    serviceTier: 'standard',
+    inferenceGeo: 'global',
+    ...overrides,
+  };
+}
+
+describe('Anthropic per-call pricing', () => {
+  test('reproduces the ledger-dashboard Fable/Mythos 5m sample exactly', () => {
+    const cost = priceAnthropicCall('claude-fable-5', timestamp, usage({
+      inputTokens: 2,
+      cacheWrite5mTokens: 336_010,
+      outputTokens: 639,
+    }));
+
+    expect(cost?.total).toBeCloseTo(4.232095, 9);
+    expect(cost).toMatchObject({
+      cacheWrite5m: 4.200125,
+      cacheWrite1h: 0,
+      currency: 'USD',
+      grade: 'billing',
+      pricingVersion: ANTHROPIC_PRICING_VERSION,
+    });
+  });
+
+  test('prices 1h writes at 2x base input and cache reads at 0.1x', () => {
+    const write = priceAnthropicCall('claude-mythos-5', timestamp, usage({ cacheWrite1hTokens: 336_010 }));
+    const read = priceAnthropicCall('claude-mythos-5', timestamp, usage({ cacheReadTokens: 336_010 }));
+    expect(write?.cacheWrite1h).toBeCloseTo(6.7202, 9);
+    expect(read?.cacheRead).toBeCloseTo(0.33601, 9);
+  });
+
+  test('applies the US-only inference multiplier to every token category', () => {
+    const global = priceAnthropicCall('claude-fable-5', timestamp, usage({ inputTokens: 1_000_000 }));
+    const us = priceAnthropicCall('claude-fable-5', timestamp, usage({
+      inputTokens: 1_000_000,
+      inferenceGeo: 'us',
+    }));
+    expect(global?.total).toBe(10);
+    expect(us?.total).toBeCloseTo(11, 9);
+  });
+
+  test('leaves unknown rates, custom tiers, and unclassified writes unpriced', () => {
+    expect(priceAnthropicCall('unknown-model', timestamp, usage())).toBeUndefined();
+    expect(priceAnthropicCall('claude-fable-5', timestamp, usage({ serviceTier: 'priority' }))).toBeUndefined();
+    expect(priceAnthropicCall('claude-fable-5', timestamp, usage({
+      unclassifiedCacheWriteTokens: 1,
+    }))).toBeUndefined();
+  });
+
+  test('honors the published Sonnet 5 promotional cutoff', () => {
+    const promo = priceAnthropicCall('claude-sonnet-5', '2026-08-31T23:59:59Z', usage({ inputTokens: 1_000_000 }));
+    const standard = priceAnthropicCall('claude-sonnet-5', '2026-09-01T00:00:00Z', usage({ inputTokens: 1_000_000 }));
+    expect(promo?.total).toBe(2);
+    expect(standard?.total).toBe(3);
+  });
+});

--- a/test/import-codex-rollout.test.ts
+++ b/test/import-codex-rollout.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  projectItem,
+  reconstructEffectiveHistory,
+} from '../scripts/import-codex-rollout.js';
+
+describe('Codex rollout import', () => {
+  test('uses replacement_history as the authoritative compaction boundary', () => {
+    const history = reconstructEffectiveHistory([
+      { type: 'response_item', payload: { type: 'message', id: 'discarded' } },
+      {
+        type: 'compacted', timestamp: '2026-07-13T00:00:00Z',
+        payload: { replacement_history: [
+          { type: 'message', role: 'user', content: 'kept' },
+          { type: 'compaction', id: 'cmp_1', encrypted_content: 'opaque' },
+        ] },
+      },
+      { type: 'response_item', payload: { type: 'reasoning', id: 'rs_2', encrypted_content: 'tail' } },
+    ]);
+
+    expect(history.map(entry => entry.item.id ?? entry.item.type)).toEqual([
+      'message', 'cmp_1', 'rs_2',
+    ]);
+    expect(history[0]!.restoredByCompaction).toBe(true);
+    expect(history[2]!.restoredByCompaction).toBe(false);
+  });
+
+  test('keeps the exact native item on the Chronicle projection block', () => {
+    const item = {
+      type: 'message', id: 'msg_1', role: 'assistant', phase: 'commentary',
+      content: [{ type: 'output_text', text: 'hello' }],
+    };
+    const [block] = projectItem(item);
+    expect(block).toMatchObject({ type: 'text', text: 'hello', rawItem: item });
+  });
+});

--- a/test/logging-adapter.test.ts
+++ b/test/logging-adapter.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from 'bun:test';
 import { LoggingAnthropicAdapter } from '../src/logging-adapter.js';
+import type { ProviderCallRecord } from '../src/call-ledger.js';
 import type { ProviderRequest, ProviderResponse } from '@animalabs/membrane';
 
 // Regression guard for the reasoning passthrough. `withReasoning` injects
@@ -57,7 +58,7 @@ describe('LoggingAnthropicAdapter.withReasoning', () => {
 describe('LoggingAnthropicAdapter request logging', () => {
   const adapter = new LoggingAnthropicAdapter({ apiKey: 'test' }, '/dev/null');
   const internals = adapter as unknown as {
-    requestSummary(r: ProviderRequest): Record<string, unknown>;
+    requestSummary(r: ProviderRequest, raw?: unknown): Record<string, unknown>;
     refusalRawRequest(r: ProviderResponse, raw: unknown): unknown;
   };
 
@@ -76,6 +77,20 @@ describe('LoggingAnthropicAdapter request logging', () => {
     });
   });
 
+  test('summarizes provider cache markers without retaining prompt content', () => {
+    const raw = {
+      messages: [{
+        role: 'user',
+        content: [{ type: 'text', text: 'do not log me', cache_control: { type: 'ephemeral', ttl: '1h' } }],
+      }],
+    };
+    expect(internals.requestSummary(baseRequest, raw)).toMatchObject({
+      cacheBreakpoints: 1,
+      cacheTtls: ['1h'],
+    });
+    expect(JSON.stringify(internals.requestSummary(baseRequest, raw))).not.toContain('do not log me');
+  });
+
   test('retains the raw request only for refusals', () => {
     const rawRequest = { messages: ['forensic context'] };
     const success = { raw: { stop_reason: 'end_turn' } } as unknown as ProviderResponse;
@@ -83,5 +98,47 @@ describe('LoggingAnthropicAdapter request logging', () => {
 
     expect(internals.refusalRawRequest(success, rawRequest)).toBeUndefined();
     expect(internals.refusalRawRequest(refusal, rawRequest)).toBe(rawRequest);
+  });
+
+  test('forwards authoritative billing buckets from the provider response', () => {
+    const calls: ProviderCallRecord[] = [];
+    const observed = new LoggingAnthropicAdapter(
+      { apiKey: 'test' },
+      '/dev/null',
+      undefined,
+      (call) => calls.push(call),
+    ) as unknown as {
+      observeCall(
+        kind: 'complete' | 'stream',
+        timestamp: string,
+        durationMs: number,
+        request: ProviderRequest,
+        rawRequest: unknown,
+        response: ProviderResponse,
+      ): void;
+    };
+    const response = {
+      usage: { inputTokens: 2, outputTokens: 10, cacheCreationTokens: 100, cacheReadTokens: 50 },
+      raw: {
+        usage: {
+          cache_creation: {
+            ephemeral_5m_input_tokens: 25,
+            ephemeral_1h_input_tokens: 75,
+          },
+          service_tier: 'standard',
+          inference_geo: 'global',
+        },
+      },
+    } as unknown as ProviderResponse;
+
+    observed.observeCall('stream', '2026-07-13T00:00:00Z', 10, baseRequest, {}, response);
+    expect(calls[0]).toMatchObject({
+      cacheWriteTokens: 100,
+      cacheWrite5mTokens: 25,
+      cacheWrite1hTokens: 75,
+      cacheWriteBucketsAuthoritative: true,
+      serviceTier: 'standard',
+      inferenceGeo: 'global',
+    });
   });
 });

--- a/test/recipe-cache-ttl.test.ts
+++ b/test/recipe-cache-ttl.test.ts
@@ -4,7 +4,7 @@
  * inference).
  */
 import { describe, test, expect } from 'bun:test';
-import { validateRecipe } from '../src/recipe.js';
+import { DEFAULT_RECIPE, validateRecipe } from '../src/recipe.js';
 
 function recipeWithCacheTtl(cacheTtl?: unknown) {
   return {
@@ -17,6 +17,10 @@ function recipeWithCacheTtl(cacheTtl?: unknown) {
 }
 
 describe('recipe agent.cacheTtl validation', () => {
+  test('the shipped default recipe explicitly uses "1h"', () => {
+    expect(DEFAULT_RECIPE.agent.cacheTtl).toBe('1h');
+  });
+
   test('accepts "5m"', () => {
     expect(validateRecipe(recipeWithCacheTtl('5m')).agent.cacheTtl).toBe('5m');
   });
@@ -25,8 +29,8 @@ describe('recipe agent.cacheTtl validation', () => {
     expect(validateRecipe(recipeWithCacheTtl('1h')).agent.cacheTtl).toBe('1h');
   });
 
-  test('accepts unset (provider default applies)', () => {
-    expect(validateRecipe(recipeWithCacheTtl()).agent.cacheTtl).toBeUndefined();
+  test('defaults unset cacheTtl to "1h"', () => {
+    expect(validateRecipe(recipeWithCacheTtl()).agent.cacheTtl).toBe('1h');
   });
 
   test('rejects a typo\'d TTL at load time', () => {

--- a/test/recipe-provider.test.ts
+++ b/test/recipe-provider.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from 'bun:test';
+import { validateRecipe } from '../src/recipe.js';
+
+function recipe(agent: Record<string, unknown> = {}) {
+  return { name: 'provider-test', agent: { systemPrompt: 'sys', ...agent } };
+}
+
+describe('recipe provider validation', () => {
+  test('preserves Anthropic as the omitted provider and accepts Responses', () => {
+    expect(validateRecipe(recipe()).agent.provider).toBeUndefined();
+    expect(validateRecipe(recipe({ provider: 'openai-responses' })).agent.provider)
+      .toBe('openai-responses');
+  });
+
+  test('accepts Responses reasoning and compaction settings', () => {
+    expect(validateRecipe(recipe({
+      provider: 'openai-responses',
+      responses: {
+        reasoningEffort: 'xhigh',
+        reasoningContext: 'all_turns',
+        compactThreshold: 100_000,
+      },
+    })).agent.responses).toEqual({
+      reasoningEffort: 'xhigh',
+      reasoningContext: 'all_turns',
+      compactThreshold: 100_000,
+    });
+  });
+
+  test('rejects unknown providers and malformed Responses settings', () => {
+    expect(() => validateRecipe(recipe({ provider: 'openai-chat' }))).toThrow(/agent.provider/);
+    expect(() => validateRecipe(recipe({ responses: { reasoningEffort: 'ultra' } }))).toThrow(/reasoningEffort/);
+    expect(() => validateRecipe(recipe({ responses: { reasoningContext: 'previous_turn' } }))).toThrow(/reasoningContext/);
+    expect(() => validateRecipe(recipe({ responses: { compactThreshold: 0 } }))).toThrow(/compactThreshold/);
+  });
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -22,6 +22,7 @@ import {
   type MessageBlock,
   type TokenUsage,
   type PerAgentCost,
+  type CallLedgerSnapshot,
 } from '@conhost/web/protocol';
 
 /** Client-side block: the wire MessageBlock plus live-stream bookkeeping. */
@@ -116,6 +117,7 @@ export function App() {
   let pendingHistoryTimer: number | undefined;
   const [usage, setUsage] = createSignal<TokenUsage>({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
   const [perAgentCost, setPerAgentCost] = createSignal<PerAgentCost[]>([]);
+  const [callLedger, setCallLedger] = createSignal<CallLedgerSnapshot | null>(null);
   const [draft, setDraft] = createSignal('');
   /** Currently-focused tree node + the panel mode rendered on its behalf.
    *  `mode` decides whether the side panel shows live stream events or a
@@ -705,6 +707,7 @@ export function App() {
         appendMessage: (m) => setMessages(produce(arr => arr.push(m))),
         setUsage,
         setPerAgentCost,
+        setCallLedger,
         appendStreamToken,
         appendToolUseBlocks,
         updateToolStatus,
@@ -967,6 +970,7 @@ export function App() {
               node={focusedNode()!}
               sessionUsage={usage()}
               perAgentCost={perAgentCost()}
+              callLedger={callLedger()}
               onClose={closePanel}
             />
           )}
@@ -1066,6 +1070,7 @@ interface HandlerHooks {
   appendMessage: (msg: Message) => void;
   setUsage: (u: TokenUsage) => void;
   setPerAgentCost: (c: PerAgentCost[]) => void;
+  setCallLedger: (ledger: CallLedgerSnapshot | null) => void;
   appendStreamToken: (token: string, blockType?: string) => void;
   /** Attach yielded tool calls to the streaming assistant message. */
   appendToolUseBlocks: (calls: Array<{ id: string; name: string; input?: unknown }>) => void;
@@ -1099,6 +1104,7 @@ function handleServerMessage(
       hooks.applyWelcome(msg);
       hooks.setUsage(msg.usage);
       hooks.setPerAgentCost(msg.perAgentCost ?? []);
+      hooks.setCallLedger(msg.callLedger ?? null);
       return;
     }
     case 'message-appended':
@@ -1110,6 +1116,9 @@ function handleServerMessage(
     case 'usage':
       hooks.setUsage(msg.usage);
       if (msg.perAgentCost) hooks.setPerAgentCost(msg.perAgentCost);
+      return;
+    case 'call-ledger':
+      hooks.setCallLedger(msg.ledger);
       return;
     case 'trace': {
       const e = msg.event;

--- a/web/src/Usage.tsx
+++ b/web/src/Usage.tsx
@@ -14,7 +14,13 @@
 import { For, Show } from 'solid-js';
 import type { UiNode } from './tree';
 import { aggregateTokens } from './tree';
-import type { TokenUsage, PerAgentCost } from '@conhost/web/protocol';
+import type {
+  TokenUsage,
+  PerAgentCost,
+  CallLedgerSnapshot,
+  CallLedgerRow,
+  CallLedgerVerdict,
+} from '@conhost/web/protocol';
 
 export function UsagePanel(props: {
   node: UiNode;
@@ -24,6 +30,10 @@ export function UsagePanel(props: {
   /** Per-agent cost slice (parent-process agents only). Used to label
    *  per-agent cost in process / per-agent breakdown views. */
   perAgentCost: PerAgentCost[];
+  /** Recent provider calls. The ledger is process-local, so it is shown on
+   *  the process usage view rather than pretending it can be split across
+   *  fleet children. */
+  callLedger: CallLedgerSnapshot | null;
   onClose(): void;
 }) {
   const costFor = (agentName: string): { total: number; currency: string } | undefined => {
@@ -70,7 +80,7 @@ export function UsagePanel(props: {
   };
 
   return (
-    <div class="border-l border-neutral-800 w-96 shrink-0 bg-neutral-950 flex flex-col h-full">
+    <div class="border-l border-neutral-800 w-[52rem] max-w-[68vw] shrink-0 bg-neutral-950 flex flex-col h-full">
       <div class="border-b border-neutral-800 px-3 py-2 flex items-center gap-2">
         <span class="text-[10px] uppercase tracking-wider text-neutral-500 font-semibold">usage</span>
         <span class="font-mono text-sm text-neutral-200 truncate">{props.node.label}</span>
@@ -99,6 +109,8 @@ export function UsagePanel(props: {
         </Show>
 
         <Show when={props.node.kind === 'process'}>
+          <CallLedgerSection ledger={props.callLedger} />
+
           <section class="text-[10px] text-neutral-600 italic leading-snug">
             Session total comes from the membrane's per-call usage stream.
             "By node" is the per-agent ledger from the tree reducer; the two
@@ -108,6 +120,108 @@ export function UsagePanel(props: {
       </div>
     </div>
   );
+}
+
+function CallLedgerSection(props: { ledger: CallLedgerSnapshot | null }) {
+  const rows = (): CallLedgerRow[] => [...(props.ledger?.rows ?? [])].slice(-30).reverse();
+  return (
+    <section>
+      <div class="flex items-baseline gap-2 mb-1">
+        <div class="text-neutral-500 uppercase tracking-wider text-[10px]">recent calls · cache ledger</div>
+        <Show when={props.ledger}>
+          {(ledger) => (
+            <span class="ml-auto text-[10px] text-neutral-500">
+              ${fmtCost(ledger().summary.cost?.total ?? 0)} retained · {Math.round(ledger().summary.cacheHitRatio * 100)}% cached
+              <Show when={(ledger().summary.cost?.unpricedCalls ?? 0) > 0}>
+                {' '}· <span class="text-amber-400">{ledger().summary.cost!.unpricedCalls} unpriced</span>
+              </Show>
+            </span>
+          )}
+        </Show>
+      </div>
+
+      <Show
+        when={rows().length > 0}
+        fallback={<div class="border border-neutral-800 rounded px-2 py-2 text-neutral-600">No provider calls recorded yet.</div>}
+      >
+        <div class="border border-neutral-800 rounded overflow-hidden">
+          <div class="grid grid-cols-[4.7rem_3.5rem_3rem_4rem_4rem_4rem_4rem_4.7rem_minmax(8rem,1fr)] gap-x-2 px-2 py-1 bg-neutral-900 text-[9px] uppercase tracking-wider text-neutral-600">
+            <span>time</span><span>origin</span><span>msgs</span><span class="text-right">in</span>
+            <span class="text-right">read</span><span class="text-right">write</span><span class="text-right">out</span>
+            <span class="text-right">cost</span><span>verdict / cause</span>
+          </div>
+          <div class="max-h-80 overflow-y-auto divide-y divide-neutral-900">
+            <For each={rows()}>{(row) => <CallLedgerRowView row={row} />}</For>
+          </div>
+        </div>
+        <div class="mt-1 text-[9px] text-neutral-600">
+          Costs marked in USD use provider-reported token buckets and the versioned public rate card. Calls missing an exact cache-write split or known rate stay explicitly unpriced. origin~ remains an estimated call class.
+        </div>
+      </Show>
+    </section>
+  );
+}
+
+function CallLedgerRowView(props: { row: CallLedgerRow }) {
+  const time = (): string => {
+    const d = new Date(props.row.timestamp);
+    return Number.isNaN(d.getTime()) ? '?' : d.toLocaleTimeString([], { hour12: false });
+  };
+  const flags = (): string => {
+    const bp = props.row.cache.breakpoints;
+    if (bp === undefined) return 'flags unknown';
+    if (bp === 0) return 'no cache flags';
+    return `${bp}bp:${props.row.cache.effectiveTtl}`;
+  };
+  const costTitle = (): string => {
+    const c = props.row.cost;
+    if (!c) return 'Unpriced: an authoritative usage bucket or public rate was unavailable';
+    return [
+      `billing-grade ${c.currency} · ${c.pricingVersion}`,
+      `input $${c.input.toFixed(6)}`,
+      `read $${c.cacheRead.toFixed(6)}`,
+      `write 5m $${c.cacheWrite5m.toFixed(6)}`,
+      `write 1h $${c.cacheWrite1h.toFixed(6)}`,
+      `output $${c.output.toFixed(6)}`,
+    ].join(' · ');
+  };
+  return (
+    <div class="grid grid-cols-[4.7rem_3.5rem_3rem_4rem_4rem_4rem_4rem_4.7rem_minmax(8rem,1fr)] gap-x-2 px-2 py-1.5 items-start hover:bg-neutral-900/60">
+      <span class="text-neutral-400" title={`${props.row.timestamp} · ${Math.round(props.row.durationMs / 1000)}s`}>{time()}</span>
+      <span class="text-neutral-500">{props.row.originEstimate}</span>
+      <span class="text-neutral-400">{props.row.messages}</span>
+      <span class="text-right text-neutral-400">{fmt(props.row.tokens.input)}</span>
+      <span class="text-right text-sky-300">{fmt(props.row.tokens.cacheRead)}</span>
+      <span class="text-right text-amber-300">{fmt(props.row.tokens.cacheWrite)}</span>
+      <span class="text-right text-neutral-400">{fmt(props.row.tokens.output)}</span>
+      <span
+        class={`text-right ${props.row.cost ? 'text-emerald-300' : 'text-amber-500'}`}
+        title={costTitle()}
+      >
+        {props.row.cost ? `$${fmtCost(props.row.cost.total)}` : 'unpriced'}
+      </span>
+      <span class="min-w-0">
+        <span class={`font-semibold ${verdictColor(props.row.verdict)}`}>{props.row.verdict}</span>
+        <span class="ml-1 text-[9px] text-neutral-600">{flags()}</span>
+        <span class="block text-[9px] leading-snug text-neutral-500 break-words">{props.row.cause}</span>
+      </span>
+    </div>
+  );
+}
+
+function verdictColor(verdict: CallLedgerVerdict): string {
+  switch (verdict) {
+    case 'HIT': return 'text-emerald-300';
+    case 'hit+extend': return 'text-lime-300';
+    case 'rewrite:expired': return 'text-orange-300';
+    case 'rewrite:prefix-mutated':
+    case 'rewrite:prefix-truncated': return 'text-red-300';
+    case 'rewrite:unexplained': return 'text-violet-300';
+    case 'ERROR': return 'text-red-400';
+    case 'first-write': return 'text-slate-300';
+    case 'uncached': return 'text-stone-400';
+    default: return 'text-neutral-400';
+  }
 }
 
 function TotalsBlock(props: { totals: { input: number; output: number; cacheRead: number; cacheWrite: number; cost?: { total: number; currency: string } } }) {


### PR DESCRIPTION
## What changed

- adds the normal WebUI provider-call ledger with billing-grade per-call USD allocation and cache verdicts
- adds stateless OpenAI Responses provider selection, reasoning/compaction recipe settings, and Codex rollout import
- changes the omitted prompt-cache TTL default to one hour while preserving explicit five-minute configuration
- updates the host to `@animalabs/membrane` 0.5.70 and bumps `@animalabs/connectome-host` to 0.3.6

## Why

Operators need call-level cost and cache behavior in the normal WebUI. OpenAI Responses sessions also need provider-native history replay so encrypted reasoning and compaction state survive import. Resident Connectome agents generally have turn gaps longer than five minutes, making one hour the safer cache default.

## Validation

- `ANTHROPIC_API_KEY=sk-test bun test` — 391 tests passed
- `bunx tsc --noEmit`
- `npm run build:web`
- `@animalabs/membrane` 0.5.70 was published successfully before updating the host dependency
