### PR TITLE
Release connectome-host 0.3.7 with published runtime dependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,10 +5,10 @@
     "": {
       "name": "connectome-host",
       "dependencies": {
-        "@animalabs/agent-framework": "^0.6.0",
+        "@animalabs/agent-framework": "^0.6.4",
         "@animalabs/chronicle": "^0.2.0",
         "@animalabs/context-manager": "^0.5.5",
-        "@animalabs/membrane": "^0.5.70",
+        "@animalabs/membrane": "^0.5.71",
         "@opentui/core": "^0.1.82",
       },
       "devDependencies": {
@@ -19,13 +19,13 @@
     },
   },
   "packages": {
-    "@animalabs/agent-framework": ["@animalabs/agent-framework@0.6.0", "", { "dependencies": { "@animalabs/chronicle": "^0.2.0", "@animalabs/context-manager": "^0.5.5", "@animalabs/membrane": "^0.5.64", "chokidar": "^4.0.3", "discord.js": "^14.25.1", "ws": "^8.18.0" }, "bin": { "agent-framework-mcp": "dist/src/api/mcp-server.js" } }, "sha512-LsR2eYveMkC+aZTq0a58bEYoi8+Iq3XQSrSCZ1fbcg+mf9YNOk8ooBRUl0VM03fyPymdOf/fkVx2tdMZM7HjSQ=="],
+    "@animalabs/agent-framework": ["@animalabs/agent-framework@0.6.4", "", { "dependencies": { "@animalabs/chronicle": "^0.2.2", "@animalabs/context-manager": "^0.5.5", "@animalabs/membrane": "^0.5.64", "chokidar": "^4.0.3", "discord.js": "^14.25.1", "ws": "^8.18.0" }, "bin": { "agent-framework-mcp": "dist/src/api/mcp-server.js" } }, "sha512-jLDNNrE7rEI017loFwIx2zTxTBQDwXgo5taqGBrG84Ve0Kaiykj5Cm8pnGm8Mlidl2FtXp5v1NqpRntwZT2idA=="],
 
     "@animalabs/chronicle": ["@animalabs/chronicle@0.2.1", "", { "optionalDependencies": { "@animalabs/chronicle-darwin-arm64": "0.2.1", "@animalabs/chronicle-darwin-x64": "0.2.1", "@animalabs/chronicle-linux-arm64-gnu": "0.2.1", "@animalabs/chronicle-linux-x64-gnu": "0.2.1", "@animalabs/chronicle-win32-x64-msvc": "0.2.1" } }, "sha512-rDFc069yfi7BQUusgsXBwBdqljUWLByXSYaTF40AP+tonBh0No3eF9VzKTSy1I8DYg/jAUHIKtVdKDGsVMVubw=="],
 
     "@animalabs/context-manager": ["@animalabs/context-manager@0.5.5", "", { "dependencies": { "@animalabs/chronicle": "^0.2.0", "@animalabs/membrane": "^0.5.64" } }, "sha512-KWTluwU5VIZKIPF/IdfUbkvPNZ5zMxSfZjaxZb81IXe+DBPmjHuUVNIqgXIQ2Mv1pCn1vCNqieZ/iSrc6dFH8w=="],
 
-    "@animalabs/membrane": ["@animalabs/membrane@0.5.70", "", { "dependencies": { "@anthropic-ai/sdk": "^0.52.0" } }, "sha512-AxF9A88Oz6gPJxr6A32nDQ+byQEWDqbAZCDugilaUy6lGZvrKun/k4qU5cAHf9s8xGQl4T3afzTAT8yF69UogA=="],
+    "@animalabs/membrane": ["@animalabs/membrane@0.5.71", "", { "dependencies": { "@anthropic-ai/sdk": "^0.52.0" } }, "sha512-Jos4Fh/kIbpOiJ43LKIFpmaCmWIzE6ly1x/4c5iHaMw8n6D8OJ2f4va7xo3vNdvfKWBbln4QghmNg4NWo3oFGA=="],
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.52.0", "", { "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-d4c+fg+xy9e46c8+YnrrgIQR45CZlAi7PwdzIfDXDM6ACxEZli1/fxhURsq30ZpMZy6LvSkr41jGq5aF5TD7rQ=="],
 
@@ -275,7 +275,7 @@
 
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
-    "@animalabs/agent-framework/@animalabs/membrane": ["@animalabs/membrane@0.5.68", "", { "dependencies": { "@anthropic-ai/sdk": "^0.52.0" } }, "sha512-MfSERy0ECxdBZ4NelHdZbqsP/ORWJsfeAI6vuyy6gP77aGcdJL8qf4XrUkOox5yZa5MqB50y0K58Ffv79jCnbg=="],
+    "@animalabs/agent-framework/@animalabs/chronicle": ["@animalabs/chronicle@0.2.6", "", { "optionalDependencies": { "@animalabs/chronicle-darwin-arm64": "0.2.6", "@animalabs/chronicle-darwin-x64": "0.2.6", "@animalabs/chronicle-linux-arm64-gnu": "0.2.6", "@animalabs/chronicle-linux-x64-gnu": "0.2.6", "@animalabs/chronicle-win32-x64-msvc": "0.2.6" } }, "sha512-+gbt2GR4SP8MnKxeqkJZf6oZn339fLiBtk6GHyBD/gHQ4e4eFqBpTaTd5eKycKBws0xWGcOqyiJFH4IdBkweUA=="],
 
     "@animalabs/context-manager/@animalabs/membrane": ["@animalabs/membrane@0.5.68", "", { "dependencies": { "@anthropic-ai/sdk": "^0.52.0" } }, "sha512-MfSERy0ECxdBZ4NelHdZbqsP/ORWJsfeAI6vuyy6gP77aGcdJL8qf4XrUkOox5yZa5MqB50y0K58Ffv79jCnbg=="],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@animalabs/connectome-host",
-  "version": "0.3.5",
+  "version": "0.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@animalabs/connectome-host",
-      "version": "0.3.5",
+      "version": "0.3.7",
       "hasInstallScript": true,
       "dependencies": {
-        "@animalabs/agent-framework": "^0.6.0",
+        "@animalabs/agent-framework": "^0.6.4",
         "@animalabs/chronicle": "^0.2.0",
         "@animalabs/context-manager": "^0.5.5",
-        "@animalabs/membrane": "^0.5.68",
+        "@animalabs/membrane": "^0.5.71",
         "@opentui/core": "^0.1.82"
       },
       "devDependencies": {
@@ -94,9 +94,9 @@
       }
     },
     "node_modules/@animalabs/agent-framework": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@animalabs/agent-framework/-/agent-framework-0.6.2.tgz",
-      "integrity": "sha512-tgXl+vNgbG3Aj0rTraFuCJI+l+PN2c/LPqB/9mS9EMLU+KwPLdFd3xeHw8oGq+G/7LK/C5PjEBwPfIsa06JBmQ==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@animalabs/agent-framework/-/agent-framework-0.6.4.tgz",
+      "integrity": "sha512-jLDNNrE7rEI017loFwIx2zTxTBQDwXgo5taqGBrG84Ve0Kaiykj5Cm8pnGm8Mlidl2FtXp5v1NqpRntwZT2idA==",
       "license": "MIT",
       "dependencies": {
         "@animalabs/chronicle": "^0.2.2",
@@ -140,9 +140,9 @@
       }
     },
     "node_modules/@animalabs/membrane": {
-      "version": "0.5.69",
-      "resolved": "https://registry.npmjs.org/@animalabs/membrane/-/membrane-0.5.69.tgz",
-      "integrity": "sha512-IjoL130eBlh2EsI16jjQesLKuEsFTTdh97FiDFix5FpMEKp+dJu6nH8ukrewjGid9wSspHNmyNnmgZf4AjKPzg==",
+      "version": "0.5.71",
+      "resolved": "https://registry.npmjs.org/@animalabs/membrane/-/membrane-0.5.71.tgz",
+      "integrity": "sha512-Jos4Fh/kIbpOiJ43LKIFpmaCmWIzE6ly1x/4c5iHaMw8n6D8OJ2f4va7xo3vNdvfKWBbln4QghmNg4NWo3oFGA==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.52.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@animalabs/connectome-host",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "General-purpose agent TUI host with recipe-based configuration",
   "type": "module",
   "scripts": {
@@ -11,10 +11,10 @@
     "postinstall": "test -d web && npm --prefix web install && npm --prefix web run build || true"
   },
   "dependencies": {
-    "@animalabs/agent-framework": "^0.6.0",
+    "@animalabs/agent-framework": "^0.6.4",
     "@animalabs/chronicle": "^0.2.0",
     "@animalabs/context-manager": "^0.5.5",
-    "@animalabs/membrane": "^0.5.70",
+    "@animalabs/membrane": "^0.5.71",
     "@opentui/core": "^0.1.82"
   },
   "devDependencies": {


### PR DESCRIPTION
## What changed

- bumps `@animalabs/agent-framework` from 0.6.0 to 0.6.4
- bumps `@animalabs/membrane` from 0.5.70 to 0.5.71
- regenerates both Bun and npm lockfiles from the published registry packages
- bumps `@animalabs/connectome-host` to 0.3.7

## Root cause

The 0.3.6 tag still locked Agent Framework 0.6.0. That package did not export the timezone helpers used by the merged host, so the tag workflow failed during test discovery and skipped npm publication.

## Validation

Validation ran from a detached clean worktree with a fresh registry install, avoiding local workspace symlinks:

- installed Agent Framework 0.6.4 and Membrane 0.5.71 from npm
- `ANTHROPIC_API_KEY=sk-test bun test` — 392 tests passed
- `bunx tsc --noEmit`
- `npm run build:web`
