### PR TITLE
feat(recipe): extensions seam — custom strategies and modules via local imports

### DIFF
--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -1,0 +1,201 @@
+/**
+ * Recipe extensions — the loading seam for deployment-specific code.
+ *
+ * A recipe may declare an `extensions` block mapping a name to a local
+ * TypeScript/JavaScript module that registers custom context strategies
+ * and/or framework modules:
+ *
+ *   "extensions": {
+ *     "zk-strategy": {
+ *       "kind": "strategy",
+ *       "path": "./extensions/zk-strategy/index.ts",
+ *       "config": { "floodWindowMs": 250 }
+ *     }
+ *   }
+ *
+ * The entry module must export a `register` function (named or default):
+ *
+ *   export function register(api: ExtensionApi, config: Record<string, unknown>) {
+ *     api.registerStrategy('zk', (ctx) => new ZkStrategy({ ...ctx.config }));
+ *     api.registerModule((ctx) => new ZkFeederModule(config));
+ *   }
+ *
+ * Design constraint: this loader is deliberately dumb. It resolves nothing,
+ * fetches nothing, and negotiates no versions — it imports a local path and
+ * calls `register`. The invariant "this path exists and is compatible with
+ * the host's dependency tree" is established at install time by build
+ * tooling (connectome-cook), not here. Extensions run in-process and share
+ * the host's node_modules, so `extends AutobiographicalStrategy` resolves
+ * against the exact @animalabs/* versions the host ships.
+ *
+ * `kind` declares the extension's primary purpose. It gates recipe
+ * validation (a non-built-in `agent.strategy.type` is only accepted when at
+ * least one `kind: "strategy"` extension is declared) and informs build
+ * tooling; it does NOT restrict what `register` may call — a strategy
+ * extension may also register a companion module.
+ */
+
+import { isAbsolute } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import type { ContextStrategy, Module } from '@animalabs/agent-framework';
+import type { Recipe, RecipeExtension, RecipeStrategy } from './recipe.js';
+
+// ---------------------------------------------------------------------------
+// Factory contexts
+// ---------------------------------------------------------------------------
+
+export interface StrategyFactoryContext {
+  /** The recipe's `agent.strategy` block verbatim — including keys the
+   *  built-in schema doesn't know about, so custom strategies can define
+   *  their own knobs without upstream schema changes. */
+  config: RecipeStrategy & Record<string, unknown>;
+  /** Resolved agent model id (recipe/env fallback chain already applied). */
+  model: string;
+  /** Resolved IANA time zone for the session. */
+  timeZone: string;
+}
+
+export type StrategyFactory = (ctx: StrategyFactoryContext) => ContextStrategy;
+
+export interface ModuleFactoryContext {
+  timeZone: string;
+  /** Session store path (Chronicle data dir) — same value createFramework uses. */
+  storePath: string;
+  /** Resolved agent model id. */
+  model: string;
+  /** The declaring extension entry's `config` blob, verbatim. */
+  config: Record<string, unknown>;
+}
+
+export type ModuleFactory = (ctx: ModuleFactoryContext) => Module;
+
+// ---------------------------------------------------------------------------
+// Registry
+// ---------------------------------------------------------------------------
+
+export interface ExtensionApi {
+  /** Register a context-strategy factory under a `agent.strategy.type` name.
+   *  Built-in names and duplicate registrations are rejected. */
+  registerStrategy(type: string, factory: StrategyFactory): void;
+  /** Register a framework-module factory. Instantiated after the built-in
+   *  module list is assembled; if the instance has a `setFramework` method
+   *  it is called after framework creation (same duck-typed contract the
+   *  built-in modules use). */
+  registerModule(factory: ModuleFactory): void;
+}
+
+export interface RegisteredModule {
+  /** Name of the extension entry that registered this factory. */
+  extensionName: string;
+  factory: ModuleFactory;
+  /** The extension entry's `config`, passed to the factory context. */
+  config: Record<string, unknown>;
+}
+
+export interface ExtensionRegistry {
+  strategies: Map<string, StrategyFactory>;
+  modules: RegisteredModule[];
+}
+
+export const BUILTIN_STRATEGY_TYPES = ['autobiographical', 'passthrough', 'frontdesk'] as const;
+
+export function isBuiltinStrategyType(type: string): boolean {
+  return (BUILTIN_STRATEGY_TYPES as readonly string[]).includes(type);
+}
+
+/** An empty registry — used when a recipe declares no extensions. */
+export function emptyExtensionRegistry(): ExtensionRegistry {
+  return { strategies: new Map(), modules: [] };
+}
+
+// ---------------------------------------------------------------------------
+// Loader
+// ---------------------------------------------------------------------------
+
+/**
+ * Import every extension declared by the recipe and collect registrations.
+ *
+ * Paths must be absolute by the time this runs — `loadRecipe` resolves
+ * relative extension paths against the recipe file's directory. Errors are
+ * wrapped with the extension name + path so a broken deployment names the
+ * component instead of surfacing a bare import stack.
+ */
+export async function loadExtensions(recipe: Recipe): Promise<ExtensionRegistry> {
+  const registry = emptyExtensionRegistry();
+  for (const [name, ext] of Object.entries(recipe.extensions ?? {})) {
+    await loadOneExtension(name, ext, registry);
+  }
+  return registry;
+}
+
+async function loadOneExtension(
+  name: string,
+  ext: RecipeExtension,
+  registry: ExtensionRegistry,
+): Promise<void> {
+  if (!isAbsolute(ext.path)) {
+    throw new Error(
+      `extension "${name}": path "${ext.path}" is not absolute. ` +
+      `Relative paths are resolved by loadRecipe against the recipe file's directory; ` +
+      `URL-loaded recipes must use absolute extension paths.`,
+    );
+  }
+
+  let mod: Record<string, unknown>;
+  try {
+    mod = await import(pathToFileURL(ext.path).href) as Record<string, unknown>;
+  } catch (err) {
+    throw new Error(
+      `extension "${name}": failed to import ${ext.path}: ` +
+      `${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
+    );
+  }
+
+  const register = (mod.register ?? mod.default) as unknown;
+  if (typeof register !== 'function') {
+    throw new Error(
+      `extension "${name}" (${ext.path}) must export a "register" function ` +
+      `(named export or default export); got ${typeof register}.`,
+    );
+  }
+
+  const config = ext.config ?? {};
+  const api: ExtensionApi = {
+    registerStrategy(type, factory) {
+      if (typeof type !== 'string' || !type) {
+        throw new Error(`extension "${name}": registerStrategy requires a non-empty type name`);
+      }
+      if (isBuiltinStrategyType(type)) {
+        throw new Error(
+          `extension "${name}": strategy type "${type}" collides with a built-in strategy`,
+        );
+      }
+      if (registry.strategies.has(type)) {
+        throw new Error(
+          `extension "${name}": strategy type "${type}" is already registered by another extension`,
+        );
+      }
+      if (typeof factory !== 'function') {
+        throw new Error(`extension "${name}": registerStrategy("${type}") requires a factory function`);
+      }
+      registry.strategies.set(type, factory);
+    },
+    registerModule(factory) {
+      if (typeof factory !== 'function') {
+        throw new Error(`extension "${name}": registerModule requires a factory function`);
+      }
+      registry.modules.push({ extensionName: name, factory, config });
+    },
+  };
+
+  try {
+    await Promise.resolve((register as (api: ExtensionApi, config: Record<string, unknown>) => unknown)(api, config));
+  } catch (err) {
+    throw new Error(
+      `extension "${name}" (${ext.path}): register() threw: ` +
+      `${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
+    );
+  }
+}

--- a/src/framework-strategy.ts
+++ b/src/framework-strategy.ts
@@ -5,6 +5,7 @@ import {
 } from '@animalabs/agent-framework';
 import type { Recipe, RecipeStrategy } from './recipe.js';
 import { FrontdeskStrategy } from './strategies/frontdesk-strategy.js';
+import { isBuiltinStrategyType, type ExtensionRegistry } from './extensions.js';
 
 const PASSTHROUGH_KEYS: ReadonlyArray<keyof RecipeStrategy> = [
   'enforceBudget',
@@ -39,9 +40,29 @@ export function buildFrameworkStrategy(
   recipe: Recipe,
   model: string,
   timeZone: string,
+  extensions?: ExtensionRegistry,
 ): ContextStrategy {
   const strategyConfig = recipe.agent.strategy;
   const strategyType = strategyConfig?.type ?? 'autobiographical';
+
+  // Non-built-in types resolve through the extension registry. Validation
+  // already required a strategy-kind extension to be declared; this catches
+  // the declared-but-didn't-register case with a precise error.
+  if (!isBuiltinStrategyType(strategyType)) {
+    const factory = extensions?.strategies.get(strategyType);
+    if (!factory) {
+      const known = extensions ? Array.from(extensions.strategies.keys()) : [];
+      throw new Error(
+        `strategy type "${strategyType}" is not built-in and no loaded extension registered it. ` +
+        `Registered custom types: ${known.length ? known.join(', ') : '(none)'}.`,
+      );
+    }
+    return factory({
+      config: (strategyConfig ?? {}) as RecipeStrategy & Record<string, unknown>,
+      model,
+      timeZone,
+    });
+  }
   const autobiographicalOpts: Record<string, unknown> = {
     headWindowTokens: strategyConfig?.headWindowTokens ?? 4000,
     recentWindowTokens: strategyConfig?.recentWindowTokens ?? 30000,

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,6 +57,7 @@ import {
 import { createBranchState, resetBranchState, handleExport, type BranchState } from './commands.js';
 import { buildFrameworkAgentConfig } from './framework-agent-config.js';
 import { buildFrameworkStrategy } from './framework-strategy.js';
+import { loadExtensions } from './extensions.js';
 
 export type { AppContext };
 
@@ -146,6 +147,11 @@ async function createFramework(
   const model = config.model || recipe.agent.model || 'claude-opus-4-6';
   const modules = recipe.modules ?? {};
   const timeZone = resolveTimeZone(recipe.agent.timezone);
+
+  // Load recipe extensions first — custom strategies must be registered
+  // before buildFrameworkStrategy runs, and custom modules join the module
+  // list below. The loader is a dumb local import; see src/extensions.ts.
+  const extensionRegistry = await loadExtensions(recipe);
 
   // -- Build module list --
   // SettingsModule is constructed in main() (before the adapter, so the
@@ -342,6 +348,16 @@ async function createFramework(
     moduleInstances.push(new ObserversModule({ path: observersPath }));
   }
 
+  // Extension-registered modules. Instantiated last so built-in modules keep
+  // their historical positions; each factory gets the minimal runtime context
+  // plus its declaring extension's config blob.
+  const extensionModules: Module[] = [];
+  for (const entry of extensionRegistry.modules) {
+    const instance = entry.factory({ timeZone, storePath, model, config: entry.config });
+    extensionModules.push(instance);
+    moduleInstances.push(instance);
+  }
+
   // -- Build MCP server list --
   //
   // Recipes are opt-in: a file entry from mcpl-servers.json is loaded only
@@ -401,7 +417,7 @@ async function createFramework(
   // No server augmentation needed — gate is wired via FrameworkConfig.gate
 
   // -- Build strategy --
-  const strategy = buildFrameworkStrategy(recipe, model, timeZone);
+  const strategy = buildFrameworkStrategy(recipe, model, timeZone, extensionRegistry);
   const agentConfig = buildFrameworkAgentConfig(recipe, agentName, model, strategy);
 
   // -- Create framework --
@@ -465,6 +481,13 @@ async function createFramework(
 
   if (channelModeModule) {
     channelModeModule.setFramework(framework);
+  }
+
+  // Extension modules get the same duck-typed post-creation hook the
+  // built-ins use: if the instance exposes setFramework, call it.
+  for (const instance of extensionModules) {
+    const hooked = instance as unknown as { setFramework?: (f: AgentFramework) => void };
+    hooked.setFramework?.(framework);
   }
 
   if (mcplAdminModule) {

--- a/src/recipe.ts
+++ b/src/recipe.ts
@@ -19,7 +19,11 @@ import { dirname, isAbsolute, resolve } from 'node:path';
 // ---------------------------------------------------------------------------
 
 export interface RecipeStrategy {
-  type: 'autobiographical' | 'passthrough' | 'frontdesk';
+  /** Built-in strategy name, or a custom type registered by a
+   *  `kind: "strategy"` extension (see `Recipe.extensions`). The
+   *  `string & {}` arm keeps literal autocompletion while admitting
+   *  extension-registered names. */
+  type: 'autobiographical' | 'passthrough' | 'frontdesk' | (string & {});
   // Core window/compression sizing
   headWindowTokens?: number;
   recentWindowTokens?: number;
@@ -503,6 +507,31 @@ export interface RecipeFleetChild {
   autoRestart?: boolean;
 }
 
+/**
+ * A deployment-specific code extension: a local TS/JS module that registers
+ * custom context strategies and/or framework modules at boot. See
+ * src/extensions.ts for the loader and the `register(api, config)` contract.
+ */
+export interface RecipeExtension {
+  /** Primary purpose. Gates validation (a non-built-in `agent.strategy.type`
+   *  requires at least one `kind: "strategy"` extension) and informs build
+   *  tooling; does not restrict what `register` may call. */
+  kind: 'strategy' | 'module';
+  /** Path to the extension entry module. Relative paths resolve against the
+   *  recipe file's directory at load time; URL-loaded recipes must use
+   *  absolute paths (the host never imports code over the network). */
+  path: string;
+  /** Opaque blob passed verbatim to the extension's `register` function and
+   *  to module factory contexts. */
+  config?: Record<string, unknown>;
+  /** Build-tooling acquisition metadata (git url/ref/install pattern) —
+   *  consumed by connectome-cook at build time, ignored at runtime. */
+  source?: Record<string, unknown>;
+  /** Build-only provenance: `source` demoted by build tooling into the
+   *  shipped recipe. Ignored at runtime. */
+  sourceMeta?: Record<string, unknown>;
+}
+
 export interface Recipe {
   name: string;
   description?: string;
@@ -510,6 +539,8 @@ export interface Recipe {
   agent: RecipeAgent;
   mcpServers?: Record<string, RecipeMcpServer>;
   modules?: RecipeModules;
+  /** Deployment-specific code extensions, keyed by a human-readable name. */
+  extensions?: Record<string, RecipeExtension>;
   sessionNaming?: { examples?: string[] };
 }
 
@@ -639,6 +670,7 @@ export async function loadRecipe(source: string): Promise<Recipe> {
   raw = substituteEnvVars(raw, source);
   const recipe = validateRecipe(raw);
   resolveChildRecipePaths(recipe, sourceBase);
+  resolveExtensionPaths(recipe, sourceBase);
   return resolveSystemPrompt(recipe);
 }
 
@@ -660,6 +692,25 @@ function resolveChildRecipePaths(recipe: Recipe, base: RecipeSourceBase): void {
   if (!fleet.children) return;
   for (const child of fleet.children) {
     child.recipe = resolveRecipeRelative(child.recipe, base);
+  }
+}
+
+/**
+ * Resolve relative `extensions[].path` values against the recipe file's
+ * directory. URL-loaded recipes cannot carry relative extension paths — the
+ * host never fetches code over the network, so there is nothing local to
+ * resolve them against.
+ */
+function resolveExtensionPaths(recipe: Recipe, base: RecipeSourceBase): void {
+  for (const [name, ext] of Object.entries(recipe.extensions ?? {})) {
+    if (isAbsolute(ext.path)) continue;
+    if (base.kind === 'url') {
+      throw new Error(
+        `extensions.${name}.path "${ext.path}" is relative, but the recipe was loaded from a URL. ` +
+        `Extension code is never fetched remotely — use an absolute path to a local install.`,
+      );
+    }
+    ext.path = resolve(base.dir, ext.path);
   }
 }
 
@@ -782,6 +833,37 @@ export function validateRecipe(raw: unknown): Recipe {
     }
   }
 
+  // Validate the extensions block if present (before the strategy check,
+  // which consults it to admit custom strategy types).
+  let hasStrategyExtension = false;
+  if (obj.extensions !== undefined) {
+    if (!obj.extensions || typeof obj.extensions !== 'object' || Array.isArray(obj.extensions)) {
+      throw new Error('Recipe "extensions" must be an object mapping names to extension entries.');
+    }
+    for (const [name, entry] of Object.entries(obj.extensions as Record<string, unknown>)) {
+      if (!name) throw new Error('Recipe extensions keys must be non-empty names.');
+      if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+        throw new Error(`extensions.${name} must be an object.`);
+      }
+      const ext = entry as Record<string, unknown>;
+      if (ext.kind !== 'strategy' && ext.kind !== 'module') {
+        throw new Error(`extensions.${name}.kind must be "strategy" or "module", got ${JSON.stringify(ext.kind)}.`);
+      }
+      if (typeof ext.path !== 'string' || !ext.path) {
+        throw new Error(`extensions.${name}.path must be a non-empty string.`);
+      }
+      if (ext.config !== undefined && (!ext.config || typeof ext.config !== 'object' || Array.isArray(ext.config))) {
+        throw new Error(`extensions.${name}.config must be an object.`);
+      }
+      for (const metaKey of ['source', 'sourceMeta'] as const) {
+        if (ext[metaKey] !== undefined && (!ext[metaKey] || typeof ext[metaKey] !== 'object' || Array.isArray(ext[metaKey]))) {
+          throw new Error(`extensions.${name}.${metaKey} must be an object.`);
+        }
+      }
+      if (ext.kind === 'strategy') hasStrategyExtension = true;
+    }
+  }
+
   // Validate strategy type if present
   if (agent.strategy) {
     const strategy = agent.strategy as Record<string, unknown>;
@@ -789,10 +871,13 @@ export function validateRecipe(raw: unknown): Recipe {
       strategy.type &&
       strategy.type !== 'autobiographical' &&
       strategy.type !== 'passthrough' &&
-      strategy.type !== 'frontdesk'
+      strategy.type !== 'frontdesk' &&
+      !hasStrategyExtension
     ) {
       throw new Error(
-        `Invalid strategy type "${strategy.type}". Must be "autobiographical", "passthrough", or "frontdesk".`,
+        `Invalid strategy type "${strategy.type}". Must be "autobiographical", "passthrough", ` +
+        `or "frontdesk" — or a custom type registered by a "kind": "strategy" entry in the ` +
+        `recipe's "extensions" block (none is declared).`,
       );
     }
     if (

--- a/test/recipe-extensions.test.ts
+++ b/test/recipe-extensions.test.ts
@@ -1,0 +1,295 @@
+/**
+ * Tests for the recipe `extensions` seam: schema validation, load-time path
+ * resolution, the extension loader/registry, and custom strategy dispatch
+ * through buildFrameworkStrategy.
+ */
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { loadRecipe, validateRecipe, type Recipe } from '../src/recipe.js';
+import {
+  loadExtensions,
+  emptyExtensionRegistry,
+  isBuiltinStrategyType,
+} from '../src/extensions.js';
+import { buildFrameworkStrategy } from '../src/framework-strategy.js';
+
+let dir: string;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'recipe-ext-'));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function baseRecipe(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    name: 'Ext Test',
+    agent: { systemPrompt: 'x' },
+    ...overrides,
+  };
+}
+
+/** Write an extension module file and return its absolute path. */
+function writeExtension(filename: string, body: string): string {
+  const path = join(dir, filename);
+  writeFileSync(path, body, 'utf-8');
+  return path;
+}
+
+// ---------------------------------------------------------------------------
+// validateRecipe
+// ---------------------------------------------------------------------------
+
+describe('validateRecipe extensions block', () => {
+  test('accepts a well-formed extensions block', () => {
+    const recipe = validateRecipe(baseRecipe({
+      extensions: {
+        zk: { kind: 'strategy', path: './ext.ts', config: { a: 1 } },
+        feeder: { kind: 'module', path: '/abs/feeder.ts' },
+      },
+    }));
+    expect(Object.keys(recipe.extensions!)).toEqual(['zk', 'feeder']);
+  });
+
+  test('rejects bad kind', () => {
+    expect(() => validateRecipe(baseRecipe({
+      extensions: { zk: { kind: 'plugin', path: './ext.ts' } },
+    }))).toThrow(/kind must be "strategy" or "module"/);
+  });
+
+  test('rejects missing path', () => {
+    expect(() => validateRecipe(baseRecipe({
+      extensions: { zk: { kind: 'strategy' } },
+    }))).toThrow(/path must be a non-empty string/);
+  });
+
+  test('rejects non-object config', () => {
+    expect(() => validateRecipe(baseRecipe({
+      extensions: { zk: { kind: 'strategy', path: './e.ts', config: [1] } },
+    }))).toThrow(/config must be an object/);
+  });
+
+  test('rejects array extensions block', () => {
+    expect(() => validateRecipe(baseRecipe({ extensions: [] })))
+      .toThrow(/must be an object mapping names/);
+  });
+
+  test('custom strategy type without a strategy-kind extension is rejected', () => {
+    expect(() => validateRecipe(baseRecipe({
+      agent: { systemPrompt: 'x', strategy: { type: 'zk' } },
+    }))).toThrow(/Invalid strategy type "zk"/);
+  });
+
+  test('custom strategy type with only module-kind extensions is rejected', () => {
+    expect(() => validateRecipe(baseRecipe({
+      agent: { systemPrompt: 'x', strategy: { type: 'zk' } },
+      extensions: { feeder: { kind: 'module', path: './f.ts' } },
+    }))).toThrow(/Invalid strategy type "zk"/);
+  });
+
+  test('custom strategy type with a strategy-kind extension is accepted', () => {
+    const recipe = validateRecipe(baseRecipe({
+      agent: { systemPrompt: 'x', strategy: { type: 'zk' } },
+      extensions: { zk: { kind: 'strategy', path: './e.ts' } },
+    }));
+    expect(recipe.agent.strategy?.type).toBe('zk');
+  });
+
+  test('built-in strategy types still validate without extensions', () => {
+    const recipe = validateRecipe(baseRecipe({
+      agent: { systemPrompt: 'x', strategy: { type: 'frontdesk' } },
+    }));
+    expect(recipe.agent.strategy?.type).toBe('frontdesk');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadRecipe path resolution
+// ---------------------------------------------------------------------------
+
+describe('loadRecipe extension path resolution', () => {
+  test('relative extension paths resolve against the recipe dir', async () => {
+    const recipePath = join(dir, 'r.json');
+    writeFileSync(recipePath, JSON.stringify(baseRecipe({
+      extensions: { zk: { kind: 'module', path: './exts/zk.ts' } },
+    })), 'utf-8');
+    const recipe = await loadRecipe(recipePath);
+    expect(recipe.extensions!.zk!.path).toBe(join(dir, 'exts', 'zk.ts'));
+  });
+
+  test('absolute extension paths pass through', async () => {
+    const recipePath = join(dir, 'r.json');
+    writeFileSync(recipePath, JSON.stringify(baseRecipe({
+      extensions: { zk: { kind: 'module', path: '/opt/zk/index.ts' } },
+    })), 'utf-8');
+    const recipe = await loadRecipe(recipePath);
+    expect(recipe.extensions!.zk!.path).toBe('/opt/zk/index.ts');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadExtensions
+// ---------------------------------------------------------------------------
+
+describe('loadExtensions', () => {
+  test('empty when no extensions declared', async () => {
+    const recipe = validateRecipe(baseRecipe());
+    const registry = await loadExtensions(recipe);
+    expect(registry.strategies.size).toBe(0);
+    expect(registry.modules.length).toBe(0);
+  });
+
+  test('collects strategy and module registrations, passing config', async () => {
+    const path = writeExtension('combo.mjs', `
+      export function register(api, config) {
+        api.registerStrategy('zk', (ctx) => ({ kind: 'zk-strategy', opts: ctx }));
+        api.registerModule((ctx) => ({ name: 'zk-feeder', ctx }));
+        if (config.marker !== 'hello') throw new Error('config not passed');
+      }
+    `);
+    const recipe = validateRecipe(baseRecipe({
+      extensions: { zk: { kind: 'strategy', path, config: { marker: 'hello' } } },
+    }));
+    const registry = await loadExtensions(recipe);
+    expect(registry.strategies.has('zk')).toBe(true);
+    expect(registry.modules.length).toBe(1);
+    expect(registry.modules[0]!.extensionName).toBe('zk');
+    expect(registry.modules[0]!.config).toEqual({ marker: 'hello' });
+  });
+
+  test('accepts a default-export register function', async () => {
+    const path = writeExtension('default.mjs', `
+      export default function (api) {
+        api.registerStrategy('dflt', () => ({ kind: 'dflt' }));
+      }
+    `);
+    const recipe = validateRecipe(baseRecipe({
+      extensions: { d: { kind: 'strategy', path } },
+    }));
+    const registry = await loadExtensions(recipe);
+    expect(registry.strategies.has('dflt')).toBe(true);
+  });
+
+  test('supports async register', async () => {
+    const path = writeExtension('async.mjs', `
+      export async function register(api) {
+        await Promise.resolve();
+        api.registerModule(() => ({ name: 'late' }));
+      }
+    `);
+    const recipe = validateRecipe(baseRecipe({
+      extensions: { a: { kind: 'module', path } },
+    }));
+    const registry = await loadExtensions(recipe);
+    expect(registry.modules.length).toBe(1);
+  });
+
+  test('rejects a module without a register function', async () => {
+    const path = writeExtension('bad.mjs', `export const nothing = 1;`);
+    const recipe = validateRecipe(baseRecipe({
+      extensions: { bad: { kind: 'module', path } },
+    }));
+    await expect(loadExtensions(recipe)).rejects.toThrow(/must export a "register" function/);
+  });
+
+  test('rejects relative paths at load time', async () => {
+    const recipe = validateRecipe(baseRecipe({
+      extensions: { rel: { kind: 'module', path: './never-resolved.ts' } },
+    }));
+    await expect(loadExtensions(recipe)).rejects.toThrow(/not absolute/);
+  });
+
+  test('rejects registering a built-in strategy name', async () => {
+    const path = writeExtension('builtin-clash.mjs', `
+      export function register(api) {
+        api.registerStrategy('autobiographical', () => ({}));
+      }
+    `);
+    const recipe = validateRecipe(baseRecipe({
+      extensions: { clash: { kind: 'strategy', path } },
+    }));
+    await expect(loadExtensions(recipe)).rejects.toThrow(/collides with a built-in/);
+  });
+
+  test('rejects duplicate strategy registrations across extensions', async () => {
+    const p1 = writeExtension('one.mjs', `
+      export function register(api) { api.registerStrategy('zk', () => ({})); }
+    `);
+    const p2 = writeExtension('two.mjs', `
+      export function register(api) { api.registerStrategy('zk', () => ({})); }
+    `);
+    const recipe = validateRecipe(baseRecipe({
+      extensions: {
+        one: { kind: 'strategy', path: p1 },
+        two: { kind: 'strategy', path: p2 },
+      },
+    }));
+    await expect(loadExtensions(recipe)).rejects.toThrow(/already registered/);
+  });
+
+  test('wraps import failures with the extension name', async () => {
+    const path = writeExtension('boom.mjs', `throw new Error('kaboom at import');`);
+    const recipe = validateRecipe(baseRecipe({
+      extensions: { boom: { kind: 'module', path } },
+    }));
+    await expect(loadExtensions(recipe)).rejects.toThrow(/extension "boom".*failed to import/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildFrameworkStrategy custom dispatch
+// ---------------------------------------------------------------------------
+
+describe('buildFrameworkStrategy with extensions', () => {
+  test('dispatches a custom type through the registry with full config', async () => {
+    const path = writeExtension('strat.mjs', `
+      export function register(api) {
+        api.registerStrategy('zk', (ctx) => ({
+          kind: 'zk',
+          model: ctx.model,
+          timeZone: ctx.timeZone,
+          customKnob: ctx.config.customKnob,
+        }));
+      }
+    `);
+    const recipe = validateRecipe(baseRecipe({
+      agent: {
+        systemPrompt: 'x',
+        strategy: { type: 'zk', customKnob: 42 },
+      },
+      extensions: { zk: { kind: 'strategy', path } },
+    })) as Recipe;
+    const registry = await loadExtensions(recipe);
+    const strategy = buildFrameworkStrategy(recipe, 'test-model', 'UTC', registry) as unknown as Record<string, unknown>;
+    expect(strategy.kind).toBe('zk');
+    expect(strategy.model).toBe('test-model');
+    expect(strategy.timeZone).toBe('UTC');
+    expect(strategy.customKnob).toBe(42);
+  });
+
+  test('throws a precise error when a declared type was never registered', () => {
+    const recipe = validateRecipe(baseRecipe({
+      agent: { systemPrompt: 'x', strategy: { type: 'ghost' } },
+      extensions: { zk: { kind: 'strategy', path: '/tmp/unused.ts' } },
+    })) as Recipe;
+    expect(() => buildFrameworkStrategy(recipe, 'm', 'UTC', emptyExtensionRegistry()))
+      .toThrow(/"ghost" is not built-in and no loaded extension registered it/);
+  });
+
+  test('built-in dispatch is unaffected by an empty registry', () => {
+    const recipe = validateRecipe(baseRecipe()) as Recipe;
+    const strategy = buildFrameworkStrategy(recipe, 'm', 'UTC', emptyExtensionRegistry());
+    expect(strategy).toBeDefined();
+  });
+});
+
+describe('isBuiltinStrategyType', () => {
+  test('recognizes the three built-ins and nothing else', () => {
+    expect(isBuiltinStrategyType('autobiographical')).toBe(true);
+    expect(isBuiltinStrategyType('passthrough')).toBe(true);
+    expect(isBuiltinStrategyType('frontdesk')).toBe(true);
+    expect(isBuiltinStrategyType('zk')).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Adds a recipe `extensions` block: a map of names to **local** TS/JS modules that register custom context strategies and/or framework modules at boot.

```json
{
  "agent": { "strategy": { "type": "zk", "floodWindowMs": 250 } },
  "extensions": {
    "zk-strategy": {
      "kind": "strategy",
      "path": "./extensions/zk/index.ts",
      "config": { "engine": "${SPRING_HOME}" }
    }
  }
}
```

The extension entry module exports `register(api, config)` and calls `api.registerStrategy(type, factory)` / `api.registerModule(factory)`.

## Why

Some deployments need code the recipe schema can't express — e.g. a custom compression strategy (autobiographical can't absorb a ~1000-events/sec RTS telemetry flood) or a deployment-specific module. Today `strategy.type` is a closed enum and the module list is hard-wired, so these harnesses can't be expressed as recipes at all.

## Design constraint: the loader stays dumb

`src/extensions.ts` imports a local path and calls `register`. No discovery, no network fetch, no version negotiation, no plugin registry. The invariant *"this path exists and is compatible"* is established at **install time** by build tooling (connectome-cook, which grows the matching support: cloning/building extension sources into images or host installs) — not at boot by the host. Extensions run in-process and share the host's `node_modules`, so `extends AutobiographicalStrategy` resolves against the exact `@animalabs/*` versions the host ships.

## Details

- `agent.strategy.type` widened to admit custom names — validation requires at least one `kind: "strategy"` extension to be declared; `buildFrameworkStrategy` dispatches through the registry and throws a precise error for declared-but-unregistered types. Built-in dispatch unchanged.
- Custom strategy factories receive `{ config, model, timeZone }` where `config` is the recipe's `agent.strategy` block **verbatim** — custom knobs need no upstream schema changes.
- Extension modules are instantiated after the built-in module list (positions of built-ins unchanged) with `{ timeZone, storePath, model, config }`, and get the same duck-typed `setFramework` post-creation hook the built-ins use.
- Relative `extensions[].path` resolves against the recipe file's directory (same rule as fleet children); URL-loaded recipes must use absolute paths — the host never imports code over the network.
- `source` / `sourceMeta` fields on an entry are validated as opaque objects and ignored at runtime — reserved for build tooling (same pattern as `mcpServers[].source`).
- `kind` declares primary purpose (gates the strategy-type validation, informs build tooling); it does not restrict what `register` may call — a strategy extension may register a companion module.

## Testing

- 24 new tests in `test/recipe-extensions.test.ts` covering schema validation, path resolution, loader error paths (missing register, relative path, built-in collision, duplicate registration, import failure wrapping), async `register`, and custom dispatch through `buildFrameworkStrategy`.
- Full suite: 431 pass / 0 fail. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BSnPKxHS7YNpBNXsB7p8vw