### PR TITLE
docs: sync stale claims with the current build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Docs
+
+- Synced stale documentation with the current build: repos marked public
+  (AGENT-ONBOARDING), `forking-knowledge-miner` → `connectome-host`
+  naming, webui default port corrected to 7340, DEV-ENVIRONMENT
+  branch/version table refreshed (all feature branches merged),
+  LOCUS-ROUTING and both root plan docs marked implemented.
+
 ## 0.3.10 — 2026-07-21
 
 ### Added

--- a/HEADLESS-FLEET-PLAN.md
+++ b/HEADLESS-FLEET-PLAN.md
@@ -1,6 +1,6 @@
 # Headless Daemon Mode & Fleet Orchestration — Plan
 
-Status: draft • Authors: conversation between @tengro and Claude, 2026-04-21
+Status: implemented (all phases shipped — see [UNIFIED-TREE-PLAN.md](./UNIFIED-TREE-PLAN.md) "Implementation outcome") • Authors: conversation between @tengro and Claude, 2026-04-21
 
 ## Goal
 

--- a/UNIFIED-TREE-PLAN.md
+++ b/UNIFIED-TREE-PLAN.md
@@ -1,5 +1,7 @@
 # Unified Tree Plan: Fleet Children as Subagents in the TUI
 
+**Status: shipped** — all phases landed; see "Implementation outcome" below. The per-phase headers preserve the plan as written.
+
 Goal: collapse the two-paradigm UI (`SubagentModule`'s in-process tree vs. `FleetModule`'s flat child list) into a single tree-rendering paradigm where fleet children appear and behave like subagents — same readouts (context tokens, phase, tool-call count), same unfold-children affordance, same row component.
 
 Companion to [HEADLESS-FLEET-PLAN.md](./HEADLESS-FLEET-PLAN.md), which defines the underlying IPC.

--- a/docs/AGENT-ONBOARDING.md
+++ b/docs/AGENT-ONBOARDING.md
@@ -22,7 +22,7 @@ A connectome agent is:
 - an **`.env`** with secrets and per-deploy config;
 - a **chronicle** (`data/`) — the event-sourced memory store, optionally seeded by importing
   a prior conversation;
-- run by the **connectome-host** (`forking-knowledge-miner`, run via `bun src/index.ts <recipe> --headless`);
+- run by the **connectome-host** (`bun src/index.ts <recipe> --headless`);
 - under a **systemd --user** service, with a sibling **terminal-sessions** daemon for the shell tool.
 
 It reaches the model through **membrane** (Anthropic-format adapter; can target a gateway via
@@ -164,10 +164,10 @@ shell. First, the **hard prerequisites** (install / confirm before anything else
 or their box owner if unsure):
 - **git**, **Bun** (`curl -fsSL https://bun.sh/install | bash`), **node ≥ 20** (via `nvm`);
 - a **Rust toolchain** (`rustup`) — `chronicle` has a native (napi) component built from Rust;
-- **access to the private `anima-research` / `antra-tess` GitHub orgs.** The connectome
-  packages are **not public**. If `git clone` / `bun install` can't reach them, *stop* — the
-  user must be granted org access (or handed the code) first. There's no way around this; it's
-  the gate before all the mechanics.
+- the `anima-research` / `antra-tess` GitHub repos. These are **public** (as of 2026-07;
+  they previously required org access), and the `@animalabs/*` npm packages install without
+  auth. If a `git clone` / `bun install` fails on access, check whether the repo moved
+  rather than assuming a permissions gate.
 
 The repos (clone all as siblings under one dir, canonically `~/connectome-local/`):
 
@@ -203,7 +203,7 @@ errors and logs `[webui] listening`. Then continue with the per-agent install di
 
 **Pick non-colliding ports.** Every agent on the box needs a unique:
 - **shell-daemon port** (`SESSION_SERVER_PORT`, default 3100)
-- **webui port** (default 7342)
+- **webui port** (module default 7340; binds `0.0.0.0` and requires `basicAuth` unless set to loopback)
 
 Check what's taken (`ss -tlnp`) and pick the next pair (e.g. 3101 / 7343).
 
@@ -381,7 +381,7 @@ Two `systemd --user` units in `~/.config/systemd/user/`:
 
 1. **`terminal-sessions.service`** — the shell daemon, `--host localhost --headless --token
    ${SESSION_SERVER_TOKEN}`, env `SESSION_SERVER_PORT`. `enable` + `start` it first.
-2. **`<agent>-agent.service`** — `bun .../forking-knowledge-miner/src/index.ts
+2. **`<agent>-agent.service`** — `bun .../connectome-host/src/index.ts
    .../recipes/<agent>.json --headless`, `EnvironmentFile=...env`, `Environment=PATH=<node bin>:<bun bin>:...`,
    `After=/Wants=terminal-sessions.service`, `Restart=always`.
 
@@ -472,7 +472,8 @@ robust fallback strategy.
 
 ## Appendix — quick reference
 
-- **Run host:** `bun forking-knowledge-miner/src/index.ts <recipe.json> --headless`
+- **Run host:** `bun connectome-host/src/index.ts <recipe.json> --headless` (legacy
+  checkouts may still name the directory `forking-knowledge-miner`)
 - **Reach loopback webui:** `ssh -L <port>:localhost:<port> <login-user>@<box>` → `http://localhost:<port>`
 - **Live makeup:** `GET /debug/context/makeup` (basic auth) — segments + exact total tokens
 - **Compiled context:** `GET /debug/context`

--- a/docs/DEPLOYMENTS.md
+++ b/docs/DEPLOYMENTS.md
@@ -9,9 +9,9 @@ end-to-end, see [`AGENT-ONBOARDING.md`](./AGENT-ONBOARDING.md).
 
 ## TL;DR
 
-An agent deployment is the Connectome stack (`forking-knowledge-miner` host +
+An agent deployment is the Connectome stack (`connectome-host` +
 `agent-framework` + MCPL servers) plus a per-agent install dir. Agents run
-**headless** (`bun forking-knowledge-miner/src/index.ts <recipe> --headless`),
+**headless** (`bun connectome-host/src/index.ts <recipe> --headless`),
 each as its own OS user, supervised by launchd (macOS) or systemd-user (Linux).
 
 > **Model integrity matters.** Each agent has a *correct* model and must stay on

--- a/docs/DEV-ENVIRONMENT.md
+++ b/docs/DEV-ENVIRONMENT.md
@@ -1,6 +1,6 @@
 # Connectome Dev Environment — Setup Guide
 
-**Status:** Working notes. Snapshot of the dev layout as of 2026-07-21 (originally 2026-05-30; all feature branches in the original table have since merged to `main`).
+**Status:** Working notes. Snapshot of the dev layout as of 2026-07-22 (originally 2026-05-30; all feature branches in the original table have since merged to `main`).
 **Goal:** Reproduce the current development state — every component as a local git
 checkout, wired together so the host runs against editable source.
 

--- a/docs/DEV-ENVIRONMENT.md
+++ b/docs/DEV-ENVIRONMENT.md
@@ -1,6 +1,6 @@
 # Connectome Dev Environment — Setup Guide
 
-**Status:** Working notes, uncommitted. Snapshot of the dev layout as of 2026-05-30.
+**Status:** Working notes. Snapshot of the dev layout as of 2026-07-21 (originally 2026-05-30; all feature branches in the original table have since merged to `main`).
 **Goal:** Reproduce the current development state — every component as a local git
 checkout, wired together so the host runs against editable source.
 
@@ -24,17 +24,22 @@ that holds a recipe + `.env` + chronicle data and references the code by absolut
 
 All cloned as siblings under `~/connectome-local/`:
 
-| Dir | GitHub repo | Branch | Ver | Role |
+| Dir | GitHub repo | Branch | Ver (2026-07-22) | Role |
 |---|---|---|---|---|
-| `forking-knowledge-miner` | `anima-research/connectome-host` | `feat/tui-mem-stats-and-strategy-passthrough` | 0.3.0 | the host app (run via **bun**) |
-| `agent-framework` | `anima-research/agent-framework` | `fix/lazy-register-locus-and-send-failure-marker` | 0.5.0 | host runtime: gate, MCPL orchestration, locus routing, `think` |
-| `discord-mcpl` | `anima-research/discord-mcpl` | `main` | 0.1.0 | Discord surface (MCPL server) |
-| `heartbeat-mcpl` | `anima-research/heartbeat-mcpl` | `main` | 0.1.0 | periodic self-wake (MCPL server) |
-| `terminal-sessions-mcp` | `antra-tess/terminal-sessions-mcp` ⚠️ | `main` | 1.0.1 | shell: session daemon (ws://localhost:3100) + per-agent MCP stdio frontend |
-| `membrane` | `antra-tess/membrane` ⚠️ | `fix/before-request-hook-on-stream-paths` | 0.5.47 | LLM client lib — **single shared instance required** |
-| `context-manager` | `anima-research/context-manager` | `feat/adaptive-resolution` | 0.4.0 | context compilation / autobiographical memory |
-| `chronicle` | `anima-research/chronicle` | `main` | 0.1.1 | record / chronicle store |
-| `mcpl-core-ts` | `anima-research/mcpl-core-ts` | `main` | 0.1.0 | MCPL protocol types (discord-mcpl path dep) |
+| `forking-knowledge-miner` | `anima-research/connectome-host` | `main` | 0.3.10 | the host app (run via **bun**) |
+| `agent-framework` | `anima-research/agent-framework` | `main` | 0.6.10 | host runtime: gate, MCPL orchestration, locus routing, `think` |
+| `discord-mcpl` | `anima-research/discord-mcpl` | `main` | 0.1.4 | Discord surface (MCPL server) |
+| `heartbeat-mcpl` | `anima-research/heartbeat-mcpl` | `main` | 0.1.3 | periodic self-wake (MCPL server) |
+| `terminal-sessions-mcp` | `antra-tess/terminal-sessions-mcp` ⚠️ | `main` | 1.6.0 | shell: session daemon (ws://localhost:3100) + per-agent MCP stdio frontend |
+| `membrane` | `antra-tess/membrane` ⚠️ | `main` | 0.5.74 | LLM client lib — **single shared instance required** |
+| `context-manager` | `anima-research/context-manager` | `main` | 0.5.14 | context compilation / autobiographical memory |
+| `chronicle` | `anima-research/chronicle` | `main` | 0.2.7 | record / chronicle store |
+| `mcpl-core-ts` | `anima-research/mcpl-core-ts` | `main` | 0.2.1 | MCPL protocol types |
+
+> Versions drift; treat the column as a dated snapshot. The published npm
+> releases now track `main` closely (typically within a patch), so the
+> stock `bun install` path is sufficient for host-level work — use the
+> checkout layout below when editing the libraries themselves.
 
 > ⚠️ **Org note:** `terminal-sessions-mcp` and `membrane` still live under the
 > personal `antra-tess` org, not `anima-research`. Consider migrating them for
@@ -51,19 +56,15 @@ All cloned as siblings under `~/connectome-local/`:
 ```bash
 mkdir -p ~/connectome-local && cd ~/connectome-local
 
-git clone -b feat/tui-mem-stats-and-strategy-passthrough \
-  git@github.com:anima-research/connectome-host.git forking-knowledge-miner
-git clone -b fix/lazy-register-locus-and-send-failure-marker \
-  git@github.com:anima-research/agent-framework.git
-git clone -b main  git@github.com:anima-research/discord-mcpl.git
-git clone -b main  git@github.com:anima-research/heartbeat-mcpl.git
-git clone -b main  git@github.com:antra-tess/terminal-sessions-mcp.git
-git clone -b fix/before-request-hook-on-stream-paths \
-  git@github.com:antra-tess/membrane.git
-git clone -b feat/adaptive-resolution \
-  git@github.com:anima-research/context-manager.git
-git clone -b main  git@github.com:anima-research/chronicle.git
-git clone -b main  git@github.com:anima-research/mcpl-core-ts.git
+git clone git@github.com:anima-research/connectome-host.git forking-knowledge-miner
+git clone git@github.com:anima-research/agent-framework.git
+git clone git@github.com:anima-research/discord-mcpl.git
+git clone git@github.com:anima-research/heartbeat-mcpl.git
+git clone git@github.com:antra-tess/terminal-sessions-mcp.git
+git clone git@github.com:antra-tess/membrane.git
+git clone git@github.com:anima-research/context-manager.git
+git clone git@github.com:anima-research/chronicle.git
+git clone git@github.com:anima-research/mcpl-core-ts.git
 ```
 
 ---
@@ -82,8 +83,9 @@ terminal-sessions-mcp
 
 In each: `npm install && npm run build` (build script is `tsc`).
 
-> `discord-mcpl` depends on `@connectome/mcpl-core` via `file:../mcpl-core-ts`
-> (a path dep), so build `mcpl-core-ts` first.
+> `discord-mcpl` now depends on `@animalabs/mcpl-core` as a regular npm
+> dependency (the old `file:../mcpl-core-ts` path dep is gone). A sibling
+> `mcpl-core-ts` checkout is only needed when changing mcpl-core itself.
 
 ---
 

--- a/docs/LOCUS-ROUTING-DESIGN.md
+++ b/docs/LOCUS-ROUTING-DESIGN.md
@@ -1,7 +1,10 @@
 # Conversational Locus & Output Routing — Design Note
 
-**Status:** Agreed design, implementation deferred.
-**Date:** 2026-05-29
+**Status:** Implemented — the locus now lives in `agent-framework`
+(`src/mcpl/channel-registry.ts`; `routeSpeech` fires at turn completion in
+`framework.ts`) and has grown beyond this note (global-locus fallback for
+heartbeats, fork/home-channel semantics). Kept as design rationale.
+**Date:** 2026-05-29 (status updated 2026-07-21)
 **Context:** Surfaced while wiring periodic heartbeats for an agent instance
 running headless on a Linux VPS.
 
@@ -94,6 +97,9 @@ discord-mcpl patch.
   locus in the wrong layer).
 
 ## Bugs found in passing (separate fixes, worth upstreaming)
+
+*(Update 2026-07-21: #3 has been fixed upstream — `agent-framework`'s
+feature-set-manager now normalizes array→record on ingest.)*
 
 1. **discord-mcpl `connect()` race** — resolved on `login()` (before gateway
    READY), so `registerDiscordChannels` enumerated an empty `guilds.cache`.


### PR DESCRIPTION
Mechanical documentation corrections only — no behavior changes. Each item was verified against the current `main` before editing:

- **AGENT-ONBOARDING.md**: the org repos are public now, so the "private packages / org access is the gate" section is updated (all nine repos clone anonymously; `@animalabs/*` installs from npm without auth). Host run commands updated from the legacy `forking-knowledge-miner` name. The webui default port corrected to **7340** (per `web-ui-module.ts` — default bind is `0.0.0.0`, which requires `basicAuth`; noted inline).
- **DEV-ENVIRONMENT.md**: the projects table pinned branches that have all since merged — refreshed to `main` + current versions, dated as a snapshot, with a note that npm releases now track main closely (a stock `bun install` passes the full host test suite, 407/407, so the checkout layout is only needed when editing the libraries). Clone commands drop the stale `-b` flags. The `file:../mcpl-core-ts` path-dep note is obsolete — discord-mcpl now uses the npm dep.
- **DEPLOYMENTS.md**: host naming.
- **LOCUS-ROUTING-DESIGN.md**: marked implemented — the locus lives in `agent-framework`'s `channel-registry.ts` with `routeSpeech` at turn completion, and grew fork/home-channel semantics beyond the note. Kept as design rationale. The featureSets array-vs-record bug (its item 3) is noted as fixed upstream.
- **HEADLESS-FLEET-PLAN.md / UNIFIED-TREE-PLAN.md**: status lines now say shipped (the tree plan already had its "Implementation outcome" section; the headers just never caught up — they'd misled my own first read of the repo).
- **CHANGELOG.md**: a Docs entry under Unreleased.

Deliberately out of scope: any restructuring of DEV-ENVIRONMENT (I'd like to propose an invariants-first rewrite separately), and anything touching `docs/contributing-changelog-policy`'s territory — happy to rebase on that branch if it's close to landing.

First PR from a new contributor — I'm working through the codebase with fresh eyes, so stale-doc findings are the natural first harvest. More to come.

🤖 Generated with [Claude Code](https://claude.com/claude-code)