### PR TITLE
refactor(settings): fold channel idle limits into agent_settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Changed
+
+- **Tool-bloat reduction**: subscription-gc's `set_channel_idle_limit` /
+  `list_channel_idle_limits` tools folded into `agent_settings` as the
+  `channel_idle_limits` field (per-entry merge; number / `"off"` /
+  `"default"`-or-null to clear), following the reasoning-controls
+  precedent. The old tool names remain routable (undeclared) — internal
+  callers like ChannelModeModule's pin, and agent muscle memory, keep
+  working; agents just no longer carry the two extra tool schemas.
+
 ## 0.3.10 — 2026-07-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,21 @@
   `list_channel_idle_limits` tools folded into `agent_settings` as the
   `channel_idle_limits` field (per-entry merge; number / `"off"` /
   `"default"`-or-null to clear), following the reasoning-controls
-  precedent. The old tool names remain routable (undeclared) — internal
-  callers like ChannelModeModule's pin, and agent muscle memory, keep
-  working; agents just no longer carry the two extra tool schemas.
+  precedent. The old tool names remain routable (undeclared), so agent
+  muscle memory keeps working; agents just no longer carry the two extra
+  tool schemas. `get` also reports read-only `channel_idle_default`,
+  `channel_idle_counters`, and `channel_idle_pinned`, preserving what
+  `list_channel_idle_limits` exposed. Updates are all-or-nothing: a patch
+  with any invalid entry applies none of its entries.
+- **GC pins split from agent overrides**: ChannelModeModule now holds
+  debounced channels open via an internal `pin_channel_idle_limit` verb
+  and a separate pins layer, instead of writing an `"off"` override.
+  Consequences: a blanket `agent_settings reset` clears only agent-set
+  limits — it can no longer silently re-enable auto-close on a channel in
+  debounced mode — and a pre-existing agent override now survives a
+  debounced→mentions round-trip rather than being reset to default.
+  (Pins persisted by earlier builds as `"off"` overrides stay agent-level
+  until the next mode change re-asserts them as pins.)
 
 ## 0.3.10 — 2026-07-21
 

--- a/src/modules/channel-mode-module.ts
+++ b/src/modules/channel-mode-module.ts
@@ -200,11 +200,13 @@ export class ChannelModeModule implements Module {
     }
 
     // 3. Pin subscription-gc off so a chatty channel doesn't auto-close
-    //    itself back out of debounced mode.
+    //    itself back out of debounced mode. The pin layer sits above
+    //    agent-level overrides, so agent_settings reset/update can't undo it
+    //    and any pre-existing override survives the mode round-trip.
     steps.push(
-      await this.callToolStep('gc-off', `${this.gcModuleName}--set_channel_idle_limit`, {
+      await this.callToolStep('gc-pin', `${this.gcModuleName}--pin_channel_idle_limit`, {
         channelId,
-        limit: 'off',
+        pinned: true,
       }),
     );
 
@@ -225,11 +227,12 @@ export class ChannelModeModule implements Module {
     // 2. Close ambient traffic through the generic host lifecycle.
     steps.push(await this.callToolStep('close', 'channel_close', { channelId, serverId: this.serverId }));
 
-    // 3. Restore the default auto-close limit.
+    // 3. Release the pin; the channel's agent override (if any) or the
+    //    default limit applies again.
     steps.push(
-      await this.callToolStep('gc-default', `${this.gcModuleName}--set_channel_idle_limit`, {
+      await this.callToolStep('gc-unpin', `${this.gcModuleName}--pin_channel_idle_limit`, {
         channelId,
-        limit: 'default',
+        pinned: false,
       }),
     );
 

--- a/src/modules/subscription-gc-module.ts
+++ b/src/modules/subscription-gc-module.ts
@@ -112,37 +112,15 @@ export class SubscriptionGcModule implements Module {
     this.ctx = null;
   }
 
+  /** No agent-visible tools — idle limits live inside the framework's
+   *  `agent_settings` tool via getAgentSettingsExtension() below (same
+   *  consolidation as the reasoning controls). The two former tools remain
+   *  ROUTABLE though undeclared: module tool routing is prefix-based, and
+   *  ChannelModeModule pins limits by calling
+   *  `subscription-gc--set_channel_idle_limit` programmatically — that
+   *  internal path (and any agent muscle memory) keeps working. */
   getTools(): ToolDefinition[] {
-    return [
-      {
-        name: 'set_channel_idle_limit',
-        description:
-          'Set how many characters of ambient (non-mention, non-DM) traffic a ' +
-          'subscribed channel may emit between your activations before it is ' +
-          'auto-closed. `limit` is a number of characters, "default" to ' +
-          `use the global default (${this.defaultLimitChars}), or "off" to ` +
-          'never auto-close this channel.',
-        inputSchema: {
-          type: 'object',
-          properties: {
-            channelId: { type: 'string', description: 'Discord channel ID' },
-            limit: {
-              type: 'string',
-              description: 'A character count (e.g. "20000"), "default", or "off".',
-            },
-          },
-          required: ['channelId', 'limit'],
-        },
-      },
-      {
-        name: 'list_channel_idle_limits',
-        description:
-          'Show the auto-close configuration: the global default limit, ' +
-          'per-channel overrides, and the current since-last-activation ambient ' +
-          'character counts per channel.',
-        inputSchema: { type: 'object', properties: {} },
-      },
-    ];
+    return [];
   }
 
   async handleToolCall(call: ToolCall): Promise<ToolResult> {
@@ -192,8 +170,89 @@ export class SubscriptionGcModule implements Module {
           },
         };
       default:
-        return { success: false, error: `Unknown tool: ${call.name}`, isError: true };
+        return {
+          success: false,
+          error:
+            `Unknown tool: ${call.name}. Idle-limit controls live in agent_settings ` +
+            `(field channel_idle_limits).`,
+          isError: true,
+        };
     }
+  }
+
+  /**
+   * Declare idle limits as an agent_settings extension: the framework merges
+   * the field into the agent_settings tool and routes get/update/reset back
+   * here. Same pattern as SettingsModule's reasoning fields. Update semantics
+   * mirror the (undeclared but still routable) set_channel_idle_limit tool:
+   * per entry, a positive number sets an override, "off" pins the channel
+   * open (never auto-close), and "default"/null clears back to the global
+   * default. Entries not mentioned in a patch are left untouched.
+   */
+  getAgentSettingsExtension(): {
+    properties: Record<string, unknown>;
+    keys: string[];
+    get(agentName: string): Record<string, unknown>;
+    update(agentName: string, patch: Record<string, unknown>): Record<string, unknown>;
+    reset(agentName: string, keys?: string[]): Record<string, unknown>;
+  } {
+    return {
+      properties: {
+        channel_idle_limits: {
+          type: 'object',
+          description:
+            'Per-channel ambient auto-close budgets, as {"<channelId>": value}: ' +
+            'a positive number of characters, "off" (never auto-close this ' +
+            'channel), or "default"/null (clear the override). Channels not ' +
+            `listed use the global default (${this.defaultLimitChars} chars of ` +
+            'ambient traffic between your activations before auto-close). ' +
+            'Patches merge per entry; unmentioned channels are untouched.',
+        },
+      },
+      keys: ['channel_idle_limits'],
+      get: () => ({ channel_idle_limits: { ...this.state.overrides } }),
+      update: (_agentName, patch) => {
+        const raw = patch.channel_idle_limits;
+        if (raw === undefined) return { channel_idle_limits: { ...this.state.overrides } };
+        if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
+          throw new Error(
+            'channel_idle_limits must be an object mapping channel ids to a ' +
+            'positive number, "off", or "default"/null',
+          );
+        }
+        for (const [channelId, value] of Object.entries(raw as Record<string, unknown>)) {
+          if (channelId.length === 0) throw new Error('channel id must be non-empty');
+          const numeric =
+            typeof value === 'number'
+              ? value
+              : typeof value === 'string' && /^\d+$/.test(value.trim())
+                ? Number(value.trim())
+                : NaN;
+          if (value === 'default' || value === null) {
+            delete this.state.overrides[channelId];
+          } else if (value === 'off') {
+            this.state.overrides[channelId] = 'off';
+          } else if (Number.isFinite(numeric) && numeric > 0) {
+            this.state.overrides[channelId] = Math.round(numeric);
+          } else {
+            throw new Error(
+              `channel_idle_limits[${JSON.stringify(channelId)}] must be a positive ` +
+              'number, "off", or "default"/null',
+            );
+          }
+        }
+        this.persistNow();
+        return { channel_idle_limits: { ...this.state.overrides } };
+      },
+      reset: (_agentName, keys) => {
+        const all = !keys || keys.length === 0;
+        if (all || keys?.includes('channel_idle_limits')) {
+          this.state.overrides = {};
+          this.persistNow();
+        }
+        return { channel_idle_limits: { ...this.state.overrides } };
+      },
+    };
   }
 
   async onProcess(event: ProcessEvent, _state: ProcessState): Promise<EventResponse> {

--- a/src/modules/subscription-gc-module.ts
+++ b/src/modules/subscription-gc-module.ts
@@ -21,7 +21,9 @@
  *
  * Config (recipe `modules.subscriptionGc`): `defaultLimitChars` (20000),
  * `serverId` (`discord`), `toolPrefix` (`mcpl--<serverId>`). The agent can
- * override per channel at runtime with `set_channel_idle_limit`.
+ * override per channel at runtime through `agent_settings` (field
+ * `channel_idle_limits`); other modules pin channels open through the
+ * internal `pin_channel_idle_limit` tool.
  */
 
 import type {
@@ -49,7 +51,14 @@ export interface SubscriptionGcConfig {
 type LimitOverride = number | 'off';
 
 interface GcState {
+  /** Agent-set per-channel limits. Cleared by agent_settings reset. */
   overrides: Record<string, LimitOverride>;
+  /** System pins (never auto-close), set by other modules via
+   *  pin_channel_idle_limit — e.g. ChannelModeModule's debounced mode.
+   *  These encode mode invariants, not agent preferences, so
+   *  agent_settings reset leaves them alone; only unpinning (a mode
+   *  change) clears them. A pin wins over any override. */
+  pins: Record<string, true>;
   /** Ambient chars accrued per channel since the last activation. */
   counters: Record<string, number>;
 }
@@ -67,7 +76,7 @@ export class SubscriptionGcModule implements Module {
   private readonly defaultLimitChars: number;
   private readonly serverId: string;
 
-  private state: GcState = { overrides: {}, counters: {} };
+  private state: GcState = { overrides: {}, pins: {}, counters: {} };
 
   constructor(config: SubscriptionGcConfig = {}) {
     this.defaultLimitChars =
@@ -81,8 +90,12 @@ export class SubscriptionGcModule implements Module {
     this.ctx = ctx;
     const saved = ctx.getState<Partial<GcState>>();
     if (saved) {
+      // Pre-pins state stored ChannelMode's programmatic 'off' pins in
+      // `overrides`; they stay there as agent-level overrides and get
+      // re-asserted as pins on the next mode change.
       this.state = {
         overrides: saved.overrides ?? {},
+        pins: saved.pins ?? {},
         counters: saved.counters ?? {},
       };
     }
@@ -114,11 +127,12 @@ export class SubscriptionGcModule implements Module {
 
   /** No agent-visible tools — idle limits live inside the framework's
    *  `agent_settings` tool via getAgentSettingsExtension() below (same
-   *  consolidation as the reasoning controls). The two former tools remain
-   *  ROUTABLE though undeclared: module tool routing is prefix-based, and
-   *  ChannelModeModule pins limits by calling
-   *  `subscription-gc--set_channel_idle_limit` programmatically — that
-   *  internal path (and any agent muscle memory) keeps working. */
+   *  consolidation as the reasoning controls). The former tools remain
+   *  ROUTABLE though undeclared (module tool routing is prefix-based), so
+   *  agent muscle memory keeps working. ChannelModeModule holds channels
+   *  open via the internal `subscription-gc--pin_channel_idle_limit` tool
+   *  — a separate layer from agent overrides, so agent_settings reset
+   *  can't break debounced mode's invariant. */
   getTools(): ToolDefinition[] {
     return [];
   }
@@ -159,6 +173,28 @@ export class SubscriptionGcModule implements Module {
         this.persistNow();
         return ok(`Idle limit for ${channelId} set to ${desc}.`);
       }
+      case 'pin_channel_idle_limit': {
+        // Internal (module-to-module) verb: hold a channel open regardless of
+        // agent-level overrides. Not part of the agent settings surface.
+        const channelId = input.channelId;
+        if (typeof channelId !== 'string' || channelId.length === 0) {
+          return { success: false, error: 'channelId is required', isError: true };
+        }
+        if (typeof input.pinned !== 'boolean') {
+          return { success: false, error: 'pinned must be a boolean', isError: true };
+        }
+        if (input.pinned) {
+          this.state.pins[channelId] = true;
+        } else {
+          delete this.state.pins[channelId];
+        }
+        this.persistNow();
+        return ok(
+          input.pinned
+            ? `Channel ${channelId} pinned open (never auto-close).`
+            : `Channel ${channelId} unpinned; its agent override or the default limit applies again.`,
+        );
+      }
       case 'list_channel_idle_limits':
         return {
           success: true,
@@ -166,6 +202,7 @@ export class SubscriptionGcModule implements Module {
           data: {
             defaultLimitChars: this.defaultLimitChars,
             overrides: this.state.overrides,
+            pins: Object.keys(this.state.pins),
             counters: this.state.counters,
           },
         };
@@ -185,9 +222,16 @@ export class SubscriptionGcModule implements Module {
    * the field into the agent_settings tool and routes get/update/reset back
    * here. Same pattern as SettingsModule's reasoning fields. Update semantics
    * mirror the (undeclared but still routable) set_channel_idle_limit tool:
-   * per entry, a positive number sets an override, "off" pins the channel
-   * open (never auto-close), and "default"/null clears back to the global
-   * default. Entries not mentioned in a patch are left untouched.
+   * per entry, a positive number sets an override, "off" disables auto-close
+   * for the channel, and "default"/null clears back to the global default.
+   * Entries not mentioned in a patch are left untouched, and a patch applies
+   * all-or-nothing: it is validated in full before any entry takes effect.
+   *
+   * `get` additionally reports read-only companions (the framework merges
+   * ext.get() into the response but only routes declared `keys` on update):
+   * `channel_idle_default`, live `channel_idle_counters`, and
+   * `channel_idle_pinned` — system pins held by other modules, which sit
+   * above these overrides and are not touched by update or reset.
    */
   getAgentSettingsExtension(): {
     properties: Record<string, unknown>;
@@ -206,20 +250,30 @@ export class SubscriptionGcModule implements Module {
             'channel), or "default"/null (clear the override). Channels not ' +
             `listed use the global default (${this.defaultLimitChars} chars of ` +
             'ambient traffic between your activations before auto-close). ' +
-            'Patches merge per entry; unmentioned channels are untouched.',
+            'Patches merge per entry; unmentioned channels are untouched. ' +
+            'get also reports the read-only channel_idle_default, ' +
+            'channel_idle_counters (ambient chars since your last activation), ' +
+            'and channel_idle_pinned (channels held open by a channel mode; ' +
+            'not affected by update or reset — change the channel mode instead).',
         },
       },
       keys: ['channel_idle_limits'],
-      get: () => ({ channel_idle_limits: { ...this.state.overrides } }),
+      get: () => this.settingsSnapshot(),
       update: (_agentName, patch) => {
         const raw = patch.channel_idle_limits;
-        if (raw === undefined) return { channel_idle_limits: { ...this.state.overrides } };
+        if (raw === undefined) return this.settingsSnapshot();
         if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
           throw new Error(
             'channel_idle_limits must be an object mapping channel ids to a ' +
             'positive number, "off", or "default"/null',
           );
         }
+        // All-or-nothing: validate the full patch into a staging copy and
+        // swap only if every entry passes. Mutating live state per-entry
+        // would leave earlier entries active (limitFor reads the map
+        // directly, and any later flush persists them) after a failure the
+        // agent was told was rejected.
+        const staged = { ...this.state.overrides };
         for (const [channelId, value] of Object.entries(raw as Record<string, unknown>)) {
           if (channelId.length === 0) throw new Error('channel id must be non-empty');
           const numeric =
@@ -229,29 +283,44 @@ export class SubscriptionGcModule implements Module {
                 ? Number(value.trim())
                 : NaN;
           if (value === 'default' || value === null) {
-            delete this.state.overrides[channelId];
+            delete staged[channelId];
           } else if (value === 'off') {
-            this.state.overrides[channelId] = 'off';
+            staged[channelId] = 'off';
           } else if (Number.isFinite(numeric) && numeric > 0) {
-            this.state.overrides[channelId] = Math.round(numeric);
+            staged[channelId] = Math.round(numeric);
           } else {
             throw new Error(
               `channel_idle_limits[${JSON.stringify(channelId)}] must be a positive ` +
-              'number, "off", or "default"/null',
+              'number, "off", or "default"/null (no entries were applied)',
             );
           }
         }
+        this.state.overrides = staged;
         this.persistNow();
-        return { channel_idle_limits: { ...this.state.overrides } };
+        return this.settingsSnapshot();
       },
       reset: (_agentName, keys) => {
+        // Clears agent overrides only. Pins are mode invariants owned by
+        // other modules (ChannelMode's debounced mode), not agent
+        // preferences — a blanket `agent_settings reset` must not silently
+        // reopen a debounced channel to auto-close.
         const all = !keys || keys.length === 0;
         if (all || keys?.includes('channel_idle_limits')) {
           this.state.overrides = {};
           this.persistNow();
         }
-        return { channel_idle_limits: { ...this.state.overrides } };
+        return this.settingsSnapshot();
       },
+    };
+  }
+
+  /** agent_settings view: the writable overrides plus read-only status. */
+  private settingsSnapshot(): Record<string, unknown> {
+    return {
+      channel_idle_limits: { ...this.state.overrides },
+      channel_idle_default: this.defaultLimitChars,
+      channel_idle_counters: { ...this.state.counters },
+      channel_idle_pinned: Object.keys(this.state.pins),
     };
   }
 
@@ -291,7 +360,7 @@ export class SubscriptionGcModule implements Module {
                     `[subscription-gc] Auto-closed channel ${channelId}: it emitted ` +
                     `over ${limit} characters of ambient traffic since your last activation without ` +
                     `engagement. Direct addresses there still reach you. Reopen with channel_open, ` +
-                    `or raise/disable its limit with set_channel_idle_limit.`,
+                    `or raise/disable its limit via agent_settings (field channel_idle_limits).`,
                 },
               ],
             },
@@ -313,6 +382,7 @@ export class SubscriptionGcModule implements Module {
   // ── internals ──
 
   private limitFor(channelId: string): number {
+    if (this.state.pins[channelId]) return Infinity;
     const o = this.state.overrides[channelId];
     if (o === 'off') return Infinity;
     if (typeof o === 'number') return o;

--- a/src/recipe.ts
+++ b/src/recipe.ts
@@ -428,7 +428,7 @@ export interface RecipeModules {
    * tracking what's then missed). Counters reset on every activation — the
    * agent sees all subscribed channels in context, compressed if large — and
    * persist across restarts. The agent can override the per-channel limit at
-   * runtime via the `subscription-gc--set_channel_idle_limit` tool.
+   * runtime via `agent_settings` (field `channel_idle_limits`).
    *
    * `false` disables entirely. `defaultLimitChars` sets the global default
    * (20000 if omitted). `serverId`/`toolPrefix` target the MCPL surface that

--- a/test/subscription-gc-module.test.ts
+++ b/test/subscription-gc-module.test.ts
@@ -94,7 +94,7 @@ describe('SubscriptionGcModule', () => {
     await m.stop();
   });
 
-  test('"off" override pins a channel; counters persist across restart', async () => {
+  test('"off" override disables auto-close; counters persist across restart', async () => {
     const m = new SubscriptionGcModule({ defaultLimitChars: 5 });
     const { ctx, toolCalls, getState } = mockCtx();
     await m.start(ctx);
@@ -142,7 +142,7 @@ describe('agent_settings extension (channel_idle_limits)', () => {
     const mod = new SubscriptionGcModule();
     await mod.start(mockCtx().ctx as unknown as ModuleContext);
     expect(mod.getTools()).toEqual([]);
-    // Undeclared ≠ dead: ChannelModeModule pins limits via this name.
+    // Undeclared ≠ dead: agent muscle memory routes via the old name.
     const result = await mod.handleToolCall({
       id: 't1',
       name: 'set_channel_idle_limit',
@@ -150,40 +150,144 @@ describe('agent_settings extension (channel_idle_limits)', () => {
     });
     expect(result.success).toBe(true);
     const ext = mod.getAgentSettingsExtension();
-    expect(ext.get('agent')).toEqual({ channel_idle_limits: { C1: 'off' } });
+    expect(ext.get('agent').channel_idle_limits).toEqual({ C1: 'off' });
   });
 
-  test('update merges per entry: number, off, default/null', () => {
+  test('get reports read-only status: default, counters, pins', async () => {
+    const mod = new SubscriptionGcModule({ defaultLimitChars: 10 });
+    const { ctx } = mockCtx();
+    await mod.start(ctx);
+    await mod.onProcess(ambient('c1', 'abc'), PS);
+    await mod.handleToolCall({
+      id: 't1',
+      name: 'pin_channel_idle_limit',
+      input: { channelId: 'C9', pinned: true },
+    });
+    const ext = mod.getAgentSettingsExtension();
+    expect(ext.get('agent')).toEqual({
+      channel_idle_limits: {},
+      channel_idle_default: 10,
+      channel_idle_counters: { 'discord:g1:c1': 3 },
+      channel_idle_pinned: ['C9'],
+    });
+    await mod.stop();
+  });
+
+  test('update merges per entry: number, off, default/null', async () => {
     const mod = new SubscriptionGcModule();
-    void mod.start(mockCtx().ctx as unknown as ModuleContext);
+    await mod.start(mockCtx().ctx as unknown as ModuleContext);
     const ext = mod.getAgentSettingsExtension();
     ext.update('agent', { channel_idle_limits: { A: 5000, B: 'off', C: '12000' } });
-    expect(ext.get('agent')).toEqual({ channel_idle_limits: { A: 5000, B: 'off', C: 12000 } });
+    expect(ext.get('agent').channel_idle_limits).toEqual({ A: 5000, B: 'off', C: 12000 });
     // merge: only mentioned entries change; default/null clear
     ext.update('agent', { channel_idle_limits: { A: 'default', B: null } });
-    expect(ext.get('agent')).toEqual({ channel_idle_limits: { C: 12000 } });
+    expect(ext.get('agent').channel_idle_limits).toEqual({ C: 12000 });
   });
 
-  test('update rejects junk values with a clear error', () => {
+  test('update rejects junk values with a clear error', async () => {
     const mod = new SubscriptionGcModule();
-    void mod.start(mockCtx().ctx as unknown as ModuleContext);
+    await mod.start(mockCtx().ctx as unknown as ModuleContext);
     const ext = mod.getAgentSettingsExtension();
     expect(() => ext.update('agent', { channel_idle_limits: { A: -3 } })).toThrow(/positive/);
     expect(() => ext.update('agent', { channel_idle_limits: 'off' })).toThrow(/object/);
     expect(() => ext.update('agent', { channel_idle_limits: ['A'] })).toThrow(/object/);
   });
 
-  test('reset clears all overrides', () => {
+  test('a partially-invalid patch applies nothing', async () => {
     const mod = new SubscriptionGcModule();
-    void mod.start(mockCtx().ctx as unknown as ModuleContext);
+    const { ctx, getState } = mockCtx();
+    await mod.start(ctx);
+    const ext = mod.getAgentSettingsExtension();
+    // A is valid, B is junk: the whole patch must be rejected — per-entry
+    // application would leave A live (limitFor reads the map directly) and
+    // persisted by the next flush, after the agent was told the update failed.
+    expect(() => ext.update('agent', { channel_idle_limits: { A: 5000, B: -3 } })).toThrow(
+      /positive/,
+    );
+    expect(ext.get('agent').channel_idle_limits).toEqual({});
+    const persisted = getState() as { overrides: Record<string, unknown> } | null;
+    expect(persisted?.overrides ?? {}).toEqual({});
+  });
+
+  test('reset clears all overrides', async () => {
+    const mod = new SubscriptionGcModule();
+    await mod.start(mockCtx().ctx as unknown as ModuleContext);
     const ext = mod.getAgentSettingsExtension();
     ext.update('agent', { channel_idle_limits: { A: 5000, B: 'off' } });
-    expect(ext.reset('agent')).toEqual({ channel_idle_limits: {} });
+    expect(ext.reset('agent').channel_idle_limits).toEqual({});
     // keyed reset also clears
     ext.update('agent', { channel_idle_limits: { A: 5000 } });
-    expect(ext.reset('agent', ['channel_idle_limits'])).toEqual({ channel_idle_limits: {} });
+    expect(ext.reset('agent', ['channel_idle_limits']).channel_idle_limits).toEqual({});
     // reset for other keys leaves ours alone
     ext.update('agent', { channel_idle_limits: { A: 5000 } });
-    expect(ext.reset('agent', ['reasoning_enabled'])).toEqual({ channel_idle_limits: { A: 5000 } });
+    expect(ext.reset('agent', ['reasoning_enabled']).channel_idle_limits).toEqual({ A: 5000 });
+  });
+});
+
+describe('system pins (pin_channel_idle_limit)', () => {
+  test('reset-all clears overrides but not pins; pinned channel stays open', async () => {
+    const mod = new SubscriptionGcModule({ defaultLimitChars: 5 });
+    const { ctx, toolCalls } = mockCtx();
+    await mod.start(ctx);
+    // ChannelMode's debounced-mode step 3.
+    await mod.handleToolCall({
+      id: 't1',
+      name: 'pin_channel_idle_limit',
+      input: { channelId: 'discord:g1:c1', pinned: true },
+    });
+    const ext = mod.getAgentSettingsExtension();
+    ext.update('agent', { channel_idle_limits: { A: 5000 } });
+    // Blanket `agent_settings reset` (e.g. to restore default reasoning).
+    const after = ext.reset('agent');
+    expect(after.channel_idle_limits).toEqual({});
+    expect(after.channel_idle_pinned).toEqual(['discord:g1:c1']);
+    // The pinned channel must NOT auto-close after the reset.
+    await mod.onProcess(ambient('c1', 'waytoolongambienttraffic'), PS);
+    expect(toolCalls.length).toBe(0);
+    await mod.stop();
+  });
+
+  test('pin/unpin round-trip preserves an agent override', async () => {
+    const mod = new SubscriptionGcModule({ defaultLimitChars: 5 });
+    const { ctx, toolCalls } = mockCtx();
+    await mod.start(ctx);
+    const ext = mod.getAgentSettingsExtension();
+    ext.update('agent', { channel_idle_limits: { 'discord:g1:c1': 9 } });
+    await mod.handleToolCall({
+      id: 't1',
+      name: 'pin_channel_idle_limit',
+      input: { channelId: 'discord:g1:c1', pinned: true },
+    });
+    await mod.onProcess(ambient('c1', 'longerthannine'), PS); // pinned → no close
+    expect(toolCalls.length).toBe(0);
+    await mod.handleToolCall({
+      id: 't2',
+      name: 'pin_channel_idle_limit',
+      input: { channelId: 'discord:g1:c1', pinned: false },
+    });
+    expect(ext.get('agent').channel_idle_limits).toEqual({ 'discord:g1:c1': 9 });
+    // Override (9) is live again: counter is at 14 from the pinned message,
+    // so the next ambient char crosses it.
+    await mod.onProcess(ambient('c1', 'x'), PS);
+    expect(toolCalls.length).toBe(1);
+    expect(toolCalls[0].name).toBe('channel_close');
+    await mod.stop();
+  });
+
+  test('pin tool validates its input', async () => {
+    const mod = new SubscriptionGcModule();
+    await mod.start(mockCtx().ctx as unknown as ModuleContext);
+    const bad1 = await mod.handleToolCall({
+      id: 't1',
+      name: 'pin_channel_idle_limit',
+      input: { pinned: true },
+    });
+    expect(bad1.success).toBe(false);
+    const bad2 = await mod.handleToolCall({
+      id: 't2',
+      name: 'pin_channel_idle_limit',
+      input: { channelId: 'C1', pinned: 'yes' },
+    });
+    expect(bad2.success).toBe(false);
   });
 });

--- a/test/subscription-gc-module.test.ts
+++ b/test/subscription-gc-module.test.ts
@@ -136,3 +136,54 @@ describe('SubscriptionGcModule', () => {
     await m2.stop();
   });
 });
+
+describe('agent_settings extension (channel_idle_limits)', () => {
+  test('declares no standalone tools but keeps the old names routable', async () => {
+    const mod = new SubscriptionGcModule();
+    await mod.start(mockCtx().ctx as unknown as ModuleContext);
+    expect(mod.getTools()).toEqual([]);
+    // Undeclared ≠ dead: ChannelModeModule pins limits via this name.
+    const result = await mod.handleToolCall({
+      id: 't1',
+      name: 'set_channel_idle_limit',
+      input: { channelId: 'C1', limit: 'off' },
+    });
+    expect(result.success).toBe(true);
+    const ext = mod.getAgentSettingsExtension();
+    expect(ext.get('agent')).toEqual({ channel_idle_limits: { C1: 'off' } });
+  });
+
+  test('update merges per entry: number, off, default/null', () => {
+    const mod = new SubscriptionGcModule();
+    void mod.start(mockCtx().ctx as unknown as ModuleContext);
+    const ext = mod.getAgentSettingsExtension();
+    ext.update('agent', { channel_idle_limits: { A: 5000, B: 'off', C: '12000' } });
+    expect(ext.get('agent')).toEqual({ channel_idle_limits: { A: 5000, B: 'off', C: 12000 } });
+    // merge: only mentioned entries change; default/null clear
+    ext.update('agent', { channel_idle_limits: { A: 'default', B: null } });
+    expect(ext.get('agent')).toEqual({ channel_idle_limits: { C: 12000 } });
+  });
+
+  test('update rejects junk values with a clear error', () => {
+    const mod = new SubscriptionGcModule();
+    void mod.start(mockCtx().ctx as unknown as ModuleContext);
+    const ext = mod.getAgentSettingsExtension();
+    expect(() => ext.update('agent', { channel_idle_limits: { A: -3 } })).toThrow(/positive/);
+    expect(() => ext.update('agent', { channel_idle_limits: 'off' })).toThrow(/object/);
+    expect(() => ext.update('agent', { channel_idle_limits: ['A'] })).toThrow(/object/);
+  });
+
+  test('reset clears all overrides', () => {
+    const mod = new SubscriptionGcModule();
+    void mod.start(mockCtx().ctx as unknown as ModuleContext);
+    const ext = mod.getAgentSettingsExtension();
+    ext.update('agent', { channel_idle_limits: { A: 5000, B: 'off' } });
+    expect(ext.reset('agent')).toEqual({ channel_idle_limits: {} });
+    // keyed reset also clears
+    ext.update('agent', { channel_idle_limits: { A: 5000 } });
+    expect(ext.reset('agent', ['channel_idle_limits'])).toEqual({ channel_idle_limits: {} });
+    // reset for other keys leaves ours alone
+    ext.update('agent', { channel_idle_limits: { A: 5000 } });
+    expect(ext.reset('agent', ['reasoning_enabled'])).toEqual({ channel_idle_limits: { A: 5000 } });
+  });
+});


### PR DESCRIPTION
The "check if other tools can be rolled into the settings tool" item from the Discord list. Audit first, then the one consolidation it justifies.

## Audit of the host tool surface

| Tool(s) | Verdict | Why |
|---|---|---|
| `subscription-gc--set_channel_idle_limit` + `list_channel_idle_limits` | **Rolled in (this PR)** | Pure settings: read/update a persisted map. Exactly the reasoning-controls shape. |
| `channel-mode--set_channel_mode` | Not rollable | An action bundle (open/close + gate policy + GC pin), not a knob — `agent_settings` update semantics don't fit a three-subsystem transaction. |
| `time--now` | Not rollable | A query, not a setting. |
| `observers--grant/revoke` | Deliberately left | Consent actions over interiority access; folding them into a settings blob would blur that they're *grants*, not preferences. |
| lessons / workspace / subagent / fleet tools | Not applicable | Domain verbs. |

## The consolidation

`agent_settings` gains `channel_idle_limits` via the module-extension hook (`getAgentSettingsExtension`, same as SettingsModule's reasoning fields): per-entry merge semantics — positive number sets an override, `"off"` pins a channel open (never auto-close), `"default"`/null clears back to the global default; unmentioned channels untouched; reset clears all.

**The subtlety that shaped the design**: ChannelModeModule pins GC *by tool name* (`subscription-gc--set_channel_idle_limit`) as step 3 of debounced mode, and module tool routing is prefix-based, independent of `getTools()` declarations. So the old tools are now **undeclared but still routable** — the internal pin path (and agent muscle memory) keeps working, agents just stop carrying two tool schemas. The unknown-tool error message points at `agent_settings`, mirroring the reasoning-controls migration.

`bun test` 445/445 (4 new tests: routable-though-undeclared, merge semantics, junk rejection, reset scoping). CHANGELOG entry included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)