### PR TITLE
feat(recipe): witnessedBeforeSequence passthrough

### DIFF
--- a/src/framework-strategy.ts
+++ b/src/framework-strategy.ts
@@ -34,6 +34,8 @@ const PASSTHROUGH_KEYS: ReadonlyArray<keyof RecipeStrategy> = [
   'summarySystemPrompt',
   'summaryUserPrompt',
   'summaryContextLabel',
+  'witnessedBeforeSequence',
+  'witnessedInstruction',
 ];
 
 export function buildFrameworkStrategy(

--- a/src/recipe.ts
+++ b/src/recipe.ts
@@ -85,6 +85,13 @@ export interface RecipeStrategy {
   summarySystemPrompt?: string;
   summaryUserPrompt?: string;
   summaryContextLabel?: string;
+  /** As-of perspective pin: chunks wholly below this message sequence are
+   *  compressed as inherited/witnessed record, not first-person memory.
+   *  For residents continued from a shared log they joined partway through. */
+  witnessedBeforeSequence?: number;
+  /** Override wording for the witnessed-record instruction ({targetTokens}
+   *  substituted). */
+  witnessedInstruction?: string;
 }
 
 export interface RecipeAgent {


### PR DESCRIPTION
Companion to context-manager's witnessedBeforeSequence (as-of perspective pin). Recipe type + PASSTHROUGH_KEYS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)