### PR TITLE
fix(subscription-gc): honest provenance, explicit-open respect, ops receipts (#5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## Unreleased
 
+### Changed
+
+- **Subscription-GC closes carry honest provenance and respect explicit
+  opens** (Discord issue #5, the Mythos "channel settings keep resetting"
+  mechanism). GC closes are now recorded as `subscription-gc`, never
+  `agent-tool`; a channel the resident/operator explicitly opened is no
+  longer auto-closed under the *default* budget — an agent-set per-channel
+  budget in `agent_settings.channel_idle_limits` counts as an explicit
+  idle lease and still closes at that budget. Pins and policy-opened
+  channels behave as before. Requires agent-framework with machine-close
+  provenance; against an older framework GC behaves as it did.
+- **GC closes emit an operator-side ops receipt** (`subscription-gc-close`
+  via the framework ops channel: failures.log + `ops:alert` trace +
+  webhook) naming channel, threshold, decision source, and the restore
+  action — ids and thresholds only, no content. A durable listening-state
+  change no longer looks spontaneous from outside the transcript.
+
 ## 0.7.2 — 2026-07-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,14 @@
   opens** (Discord issue #5, the Mythos "channel settings keep resetting"
   mechanism). GC closes are now recorded as `subscription-gc`, never
   `agent-tool`; a channel the resident/operator explicitly opened is no
-  longer auto-closed under the *default* budget — an agent-set per-channel
-  budget in `agent_settings.channel_idle_limits` counts as an explicit
-  idle lease and still closes at that budget. Pins and policy-opened
-  channels behave as before. Requires agent-framework with machine-close
-  provenance; against an older framework GC behaves as it did.
+  longer auto-closed under the *default* budget — a configured per-channel
+  numeric budget in `agent_settings.channel_idle_limits` counts as an
+  explicit idle lease and still closes at that budget. (The override state
+  records no actor — agent, operator, or imported are all possible — so
+  receipts say `configured-budget`, claiming no more than the state
+  proves.) Pins and policy-opened channels behave as before. Requires
+  agent-framework with machine-close provenance; against an older
+  framework GC behaves as it did.
 - **GC closes emit an operator-side ops receipt** (`subscription-gc-close`
   via the framework ops channel: failures.log + `ops:alert` trace +
   webhook) naming channel, threshold, decision source, and the restore

--- a/src/modules/subscription-gc-module.ts
+++ b/src/modules/subscription-gc-module.ts
@@ -336,11 +336,22 @@ export class SubscriptionGcModule implements Module {
       // Cross the threshold → close and clear the counter.
       delete this.state.counters[channelId];
       this.persistNow();
+      // An agent-set NUMERIC budget for this channel is an explicit idle
+      // lease — the agent consented to auto-close at that budget, so the
+      // registry may close even an explicitly-opened channel. The global
+      // default is not consent; the registry refuses machine closes of
+      // explicit opens under it (issue #5).
+      const hasExplicitLease = typeof this.state.overrides[channelId] === 'number';
       const result = await this.ctx
         ?.callTool({
           id: `gc-unsub-${this.callSeq++}`,
           name: 'channel_close',
-          input: { channelId, serverId: this.serverId },
+          input: {
+            channelId,
+            serverId: this.serverId,
+            source: 'subscription-gc',
+            overrideExplicitOpen: hasExplicitLease,
+          },
         })
         .catch((err: unknown) => ({
           success: false,
@@ -349,6 +360,28 @@ export class SubscriptionGcModule implements Module {
         }));
 
       if (result && result.success) {
+        // Operator-side receipt (privacy-minimal: ids and thresholds, no
+        // content) — a GC close changes durable listening state and must
+        // not look spontaneous from outside the transcript. Duck-typed
+        // (same pattern as index.ts's notifyOps wiring): a framework
+        // without ModuleContext.notifyOps just skips the receipt.
+        const notifyOps = (this.ctx as unknown as {
+          notifyOps?: (kind: string, agent: string, message: string, data?: Record<string, unknown>) => void;
+        } | null)?.notifyOps;
+        notifyOps?.(
+          'subscription-gc-close',
+          this.ctx?.getAgents()[0]?.name ?? 'unknown',
+          `subscription-gc auto-closed channel ${channelId} (over ${limit} ambient chars ` +
+          `since last activation${hasExplicitLease ? ', agent-set budget' : ', default budget'}). ` +
+          `Restore: channel_open ${channelId}, or agent_settings channel_idle_limits.`,
+          {
+            channelId,
+            limitChars: limit,
+            decisionSource: 'subscription-gc',
+            lease: hasExplicitLease ? 'agent-set' : 'default',
+            restore: `channel_open ${channelId}`,
+          },
+        );
         return {
           addMessages: [
             {
@@ -367,6 +400,17 @@ export class SubscriptionGcModule implements Module {
           ],
         };
       }
+
+      // The registry refused because the channel was explicitly opened and
+      // we hold no lease: stand down quietly — the janitor doesn't argue
+      // with stated intent. The counter stays cleared, so the next refusal
+      // is at least a full budget away; if the channel's provenance later
+      // changes (reopened by policy), GC self-heals.
+      const refusal = (result as { data?: { refusal?: string } } | undefined)?.data?.refusal;
+      if (refusal === 'explicit-open') {
+        return {};
+      }
+
       // Close failed — keep the channel counted so we retry on the next
       // ambient message rather than silently giving up.
       this.state.counters[channelId] = next;

--- a/src/modules/subscription-gc-module.ts
+++ b/src/modules/subscription-gc-module.ts
@@ -336,12 +336,15 @@ export class SubscriptionGcModule implements Module {
       // Cross the threshold → close and clear the counter.
       delete this.state.counters[channelId];
       this.persistNow();
-      // An agent-set NUMERIC budget for this channel is an explicit idle
-      // lease — the agent consented to auto-close at that budget, so the
-      // registry may close even an explicitly-opened channel. The global
-      // default is not consent; the registry refuses machine closes of
-      // explicit opens under it (issue #5).
-      const hasExplicitLease = typeof this.state.overrides[channelId] === 'number';
+      // A CONFIGURED numeric budget for this channel is an explicit idle
+      // lease: someone chose a close-at-N budget for this specific channel,
+      // so the registry may close even an explicitly-opened one. The state
+      // does not record WHO configured it (agent via agent_settings,
+      // operator, or imported before these semantics existed), so nothing
+      // downstream may claim "agent-set" — receipts say 'configured-budget',
+      // actor unknown. The global default is not consent of any kind; the
+      // registry refuses machine closes of explicit opens under it (#5).
+      const hasConfiguredLease = typeof this.state.overrides[channelId] === 'number';
       const result = await this.ctx
         ?.callTool({
           id: `gc-unsub-${this.callSeq++}`,
@@ -350,7 +353,7 @@ export class SubscriptionGcModule implements Module {
             channelId,
             serverId: this.serverId,
             source: 'subscription-gc',
-            overrideExplicitOpen: hasExplicitLease,
+            overrideExplicitOpen: hasConfiguredLease,
           },
         })
         .catch((err: unknown) => ({
@@ -363,22 +366,28 @@ export class SubscriptionGcModule implements Module {
         // Operator-side receipt (privacy-minimal: ids and thresholds, no
         // content) — a GC close changes durable listening state and must
         // not look spontaneous from outside the transcript. Duck-typed
-        // (same pattern as index.ts's notifyOps wiring): a framework
-        // without ModuleContext.notifyOps just skips the receipt.
-        const notifyOps = (this.ctx as unknown as {
+        // against a framework that may not have ModuleContext.notifyOps yet
+        // (skipped there), and invoked THROUGH the context object: the real
+        // ModuleContextImpl.notifyOps reads `this`, so a detached
+        // `const f = ctx.notifyOps; f(...)` throws in production while
+        // passing against arrow-function mocks.
+        const opsCtx = this.ctx as unknown as {
           notifyOps?: (kind: string, agent: string, message: string, data?: Record<string, unknown>) => void;
-        } | null)?.notifyOps;
-        notifyOps?.(
+        } | null;
+        opsCtx?.notifyOps?.(
           'subscription-gc-close',
           this.ctx?.getAgents()[0]?.name ?? 'unknown',
           `subscription-gc auto-closed channel ${channelId} (over ${limit} ambient chars ` +
-          `since last activation${hasExplicitLease ? ', agent-set budget' : ', default budget'}). ` +
+          `since last activation${hasConfiguredLease ? ', configured per-channel budget' : ', default budget'}). ` +
           `Restore: channel_open ${channelId}, or agent_settings channel_idle_limits.`,
           {
             channelId,
             limitChars: limit,
             decisionSource: 'subscription-gc',
-            lease: hasExplicitLease ? 'agent-set' : 'default',
+            // 'configured-budget' deliberately does NOT claim an actor: the
+            // override state records no provenance (agent, operator, or
+            // imported are all possible).
+            lease: hasConfiguredLease ? 'configured-budget' : 'default',
             restore: `channel_open ${channelId}`,
           },
         );

--- a/test/subscription-gc-module.test.ts
+++ b/test/subscription-gc-module.test.ts
@@ -306,7 +306,7 @@ describe('close provenance + explicit-open protection (issue #5)', () => {
     await m.stop();
   });
 
-  test('an agent-set numeric budget is an explicit lease: overrideExplicitOpen true', async () => {
+  test('a configured numeric budget is an explicit lease: overrideExplicitOpen true', async () => {
     const m = new SubscriptionGcModule({ defaultLimitChars: 10, serverId: 'discord' });
     const { ctx, toolCalls } = mockCtx();
     await m.start(ctx);
@@ -356,10 +356,21 @@ describe('close provenance + explicit-open protection (issue #5)', () => {
     const m = new SubscriptionGcModule({ defaultLimitChars: 10, serverId: 'discord' });
     const { ctx } = mockCtx();
     const receipts: Array<{ kind: string; agent: string; message: string; data?: Record<string, unknown> }> = [];
+    // The mock is deliberately `this`-sensitive, like the real
+    // ModuleContextImpl.notifyOps (which reads this.registry): a detached
+    // `const f = ctx.notifyOps; f(...)` throws here instead of passing —
+    // the exact bug class Sol caught in the first revision.
     Object.assign(ctx as object, {
       getAgents: () => [{ name: 'mythos' }],
-      notifyOps: (kind: string, agent: string, message: string, data?: Record<string, unknown>) => {
-        receipts.push({ kind, agent, message, data });
+      _receipts: receipts,
+      notifyOps(
+        this: { _receipts: typeof receipts },
+        kind: string,
+        agent: string,
+        message: string,
+        data?: Record<string, unknown>,
+      ) {
+        this._receipts.push({ kind, agent, message, data });
       },
     });
     await m.start(ctx);
@@ -376,6 +387,41 @@ describe('close provenance + explicit-open protection (issue #5)', () => {
     });
     // Privacy-minimal: the receipt names ids and thresholds, never content.
     expect(receipts[0].message).not.toContain('abcdef');
+
+    await m.stop();
+  });
+
+  test('a configured-budget close reports lease configured-budget, claiming no actor', async () => {
+    const m = new SubscriptionGcModule({ defaultLimitChars: 10, serverId: 'discord' });
+    const { ctx } = mockCtx();
+    const receipts: Array<{ message: string; data?: Record<string, unknown> }> = [];
+    Object.assign(ctx as object, {
+      getAgents: () => [{ name: 'mythos' }],
+      _receipts: receipts,
+      notifyOps(
+        this: { _receipts: typeof receipts },
+        _kind: string,
+        _agent: string,
+        message: string,
+        data?: Record<string, unknown>,
+      ) {
+        this._receipts.push({ message, data });
+      },
+    });
+    await m.start(ctx);
+
+    await m.handleToolCall({
+      id: 't1',
+      name: 'set_channel_idle_limit',
+      input: { channelId: 'discord:g1:c1', limit: 8 },
+    });
+    await m.onProcess(ambient('c1', 'abcdefghij'), PS); // 10 > 8
+    expect(receipts.length).toBe(1);
+    // The override state records no actor (agent, operator, or imported are
+    // all possible) — the receipt must not claim 'agent-set'.
+    expect(receipts[0].data?.lease).toBe('configured-budget');
+    expect(receipts[0].message).toContain('configured per-channel budget');
+    expect(receipts[0].message).not.toContain('agent-set');
 
     await m.stop();
   });

--- a/test/subscription-gc-module.test.ts
+++ b/test/subscription-gc-module.test.ts
@@ -291,3 +291,109 @@ describe('system pins (pin_channel_idle_limit)', () => {
     expect(bad2.success).toBe(false);
   });
 });
+
+describe('close provenance + explicit-open protection (issue #5)', () => {
+  test('closes carry source subscription-gc; default budget certifies no lease', async () => {
+    const m = new SubscriptionGcModule({ defaultLimitChars: 10, serverId: 'discord' });
+    const { ctx, toolCalls } = mockCtx();
+    await m.start(ctx);
+
+    await m.onProcess(ambient('c1', 'abcdefghijkl'), PS); // 12 > 10 → close
+    expect(toolCalls.length).toBe(1);
+    expect(toolCalls[0].input.source).toBe('subscription-gc');
+    expect(toolCalls[0].input.overrideExplicitOpen).toBe(false);
+
+    await m.stop();
+  });
+
+  test('an agent-set numeric budget is an explicit lease: overrideExplicitOpen true', async () => {
+    const m = new SubscriptionGcModule({ defaultLimitChars: 10, serverId: 'discord' });
+    const { ctx, toolCalls } = mockCtx();
+    await m.start(ctx);
+
+    await m.handleToolCall({
+      id: 't1',
+      name: 'set_channel_idle_limit',
+      input: { channelId: 'discord:g1:c1', limit: 8 },
+    });
+    await m.onProcess(ambient('c1', 'abcdefghij'), PS); // 10 > 8 → close under lease
+    expect(toolCalls.length).toBe(1);
+    expect(toolCalls[0].input.overrideExplicitOpen).toBe(true);
+
+    await m.stop();
+  });
+
+  test('a structural explicit-open refusal stands down without a retry loop', async () => {
+    const m = new SubscriptionGcModule({ defaultLimitChars: 10, serverId: 'discord' });
+    const { ctx, toolCalls, getState } = mockCtx();
+    (ctx as unknown as { callTool: unknown }).callTool = async (call: { name: string; input: Record<string, unknown> }) => {
+      toolCalls.push(call);
+      return {
+        success: false,
+        isError: false,
+        error: 'explicitly opened',
+        data: { refusal: 'explicit-open' },
+      };
+    };
+    await m.start(ctx);
+
+    const r = await m.onProcess(ambient('c1', 'abcdefghijkl'), PS); // 12 > 10
+    expect(toolCalls.length).toBe(1);
+    // No context spam, no counter restore: the janitor stands down and the
+    // next attempt is at least a full budget away.
+    expect(r.addMessages).toBeUndefined();
+    const counters = (getState() as { counters: Record<string, number> }).counters;
+    expect(counters['discord:g1:c1']).toBeUndefined();
+
+    // Next ambient message counts from zero rather than instantly re-firing.
+    await m.onProcess(ambient('c1', 'ab'), PS);
+    expect(toolCalls.length).toBe(1);
+
+    await m.stop();
+  });
+
+  test('a successful close emits a privacy-minimal ops receipt when notifyOps exists', async () => {
+    const m = new SubscriptionGcModule({ defaultLimitChars: 10, serverId: 'discord' });
+    const { ctx } = mockCtx();
+    const receipts: Array<{ kind: string; agent: string; message: string; data?: Record<string, unknown> }> = [];
+    Object.assign(ctx as object, {
+      getAgents: () => [{ name: 'mythos' }],
+      notifyOps: (kind: string, agent: string, message: string, data?: Record<string, unknown>) => {
+        receipts.push({ kind, agent, message, data });
+      },
+    });
+    await m.start(ctx);
+
+    await m.onProcess(ambient('c1', 'abcdefghijkl'), PS);
+    expect(receipts.length).toBe(1);
+    expect(receipts[0].kind).toBe('subscription-gc-close');
+    expect(receipts[0].agent).toBe('mythos');
+    expect(receipts[0].data).toMatchObject({
+      channelId: 'discord:g1:c1',
+      limitChars: 10,
+      decisionSource: 'subscription-gc',
+      lease: 'default',
+    });
+    // Privacy-minimal: the receipt names ids and thresholds, never content.
+    expect(receipts[0].message).not.toContain('abcdef');
+
+    await m.stop();
+  });
+
+  test('an ordinary close failure still restores the counter for retry', async () => {
+    const m = new SubscriptionGcModule({ defaultLimitChars: 10, serverId: 'discord' });
+    const { ctx, toolCalls, getState } = mockCtx();
+    (ctx as unknown as { callTool: unknown }).callTool = async (call: { name: string; input: Record<string, unknown> }) => {
+      toolCalls.push(call);
+      return { success: false, error: 'server unreachable', isError: true };
+    };
+    await m.start(ctx);
+
+    await m.onProcess(ambient('c1', 'abcdefghijkl'), PS);
+    expect(toolCalls.length).toBe(1);
+    const counters = (getState() as { counters: Record<string, number> }).counters;
+    expect(counters['discord:g1:c1']).toBe(12);
+
+    await m.stop();
+  });
+});


### PR DESCRIPTION
Host half of the Discord issue **#5** fix — pairs with agent-framework **#71** (machine-close provenance). Implements Sol's patch shape points 1–4; point 5's test matrix is split across both PRs.

## Changes

1. **GC closes name themselves**: `channel_close` calls carry `source: 'subscription-gc'` — with framework #71, the durable record stops blaming the agent for the janitor's work.
2. **Explicit opens are respected**: under the *default* budget, GC no longer closes a channel the resident/operator explicitly opened — the registry refuses structurally and GC **stands down quietly**: no retry loop, no context spam, counter cleared so the next attempt is a full budget away (and it self-heals if the channel's provenance later changes). An agent-set NUMERIC budget in `agent_settings.channel_idle_limits` is treated as an **explicit idle lease** — the agent consented to close at that budget, so GC passes `overrideExplicitOpen` and closes as asked. `'off'` and pins never reach the close path at all (unchanged).
3. **Ops receipts**: successful GC closes emit `subscription-gc-close` via `ctx.notifyOps` (framework ops channel → failures.log + `ops:alert` trace + webhook): channel, threshold, decision source, lease kind, restore action. Ids and thresholds only — no content. The TUI/webui ops surfaces render these today.
4. **GC keeps its job** for policy-opened/unowned channels — behavior there is byte-identical.

Version-skew safe: against a pre-#71 framework the extra inputs are ignored and `notifyOps` is absent (duck-typed), so GC behaves exactly as it does on main today.

## Testing

5 new tests: source + no-lease certification under default budget; lease certification with an agent-set budget; refusal → stand-down (no retry state, no messages, next ambient counts from zero); receipt shape incl. the no-content property; ordinary failures still count-and-retry. Suite: **485/485**. Changelog updated.

Interim mitigations stay valid meanwhile: `agent_settings.channel_idle_limits` (`off`/numeric) or `set_channel_mode debounced` (pins).

🤖 Generated with [Claude Code](https://claude.com/claude-code)