### PR TITLE
Report-only audit of subagents/lessons/retrieval opt-ins (issue #32, closure-gate step 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## Unreleased
 
+### Upgrade notes
+
+- **subagents/lessons/retrieval are now opt-in** (they were opt-out, and
+  DEFAULT_RECIPE enabled all three). A recipe that omits them ran them under
+  v0.7.2 and stops running them on this upgrade — that is the fix for
+  "lessons injected despite following the onboarding guide" (Discord issue
+  #32) working as intended. A recipe that *explicitly* enables them keeps
+  them, deliberately: a defaults change cannot tell old boilerplate from a
+  real choice. Before upgrading an existing deployment, run
+
+      bun scripts/audit-module-optins.ts <recipes-and-data-dirs...>
+
+  It reports every explicit enable, every omission that changes behavior,
+  and every retrieval-without-lessons combination that would go silently
+  inert — and modifies nothing; the decisions stay with the operator.
+  Persisted `data/.recipe.json` files are launch-time snapshots, not
+  authoritative sources — the audit lists them separately as pointers back
+  to the source recipe. Retrieved-lesson injection also moved from the
+  system prompt to after the last user message, which keeps the stable
+  prefix KV-cacheable.
+
 ### Changed
 
 - **Subscription-GC closes carry honest provenance and respect explicit

--- a/scripts/audit-module-optins.ts
+++ b/scripts/audit-module-optins.ts
@@ -1,0 +1,288 @@
+/**
+ * Report-only audit of subagents/lessons/retrieval opt-ins across recipes.
+ *
+ * Background: published v0.7.2 and earlier treated these three modules as
+ * opt-OUT (an omitted `modules` key meant enabled), and DEFAULT_RECIPE
+ * enabled all three explicitly. Current main treats them as opt-IN
+ * (a4bd9fd). That flip is the right default, but it leaves existing
+ * deployments with two things only a human can settle:
+ *
+ *   1. A source recipe that explicitly says `lessons: true` stays enabled
+ *      after upgrade — intentionally. Whether that `true` was a real choice
+ *      or boilerplate copied from the old onboarding guide is not something
+ *      a defaults change (or this script) can infer. It gets reported;
+ *      the operator decides.
+ *   2. A persisted `data/.recipe.json` is a resolved snapshot of whatever
+ *      was in effect at launch — under the old defaults that includes
+ *      `subagents/lessons/retrieval: true` the operator never wrote. It is
+ *      not necessarily the authoritative source recipe, so it's reported
+ *      separately, as a pointer back to the source, never as a finding in
+ *      itself.
+ *
+ * This script reads and reports. It never modifies a file, and it has no
+ * flag that would make it modify a file.
+ *
+ * Usage:
+ *   bun scripts/audit-module-optins.ts <recipe.json | directory> [...more]
+ *
+ * Directories are scanned recursively for *.json (including .recipe.json
+ * snapshots; node_modules/.git skipped). Fleet children referenced by
+ * local path are followed automatically.
+ *
+ * Exit codes: 0 = nothing needs an operator decision; 2 = explicit enables
+ * (or inert-retrieval combinations) found — review the report; 1 = a path
+ * argument could not be read.
+ */
+
+import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
+import { basename, dirname, isAbsolute, join, resolve } from 'node:path';
+
+export const AUDITED_MODULES = ['subagents', 'lessons', 'retrieval'] as const;
+export type AuditedModule = (typeof AUDITED_MODULES)[number];
+
+export type ModuleState = 'explicit-enable' | 'explicit-disable' | 'omitted';
+
+export interface RecipeAudit {
+  /** Path as reported (relative to cwd where possible). */
+  path: string;
+  recipeName: string;
+  /** basename === '.recipe.json': a resolved launch snapshot, not a source. */
+  isSnapshot: boolean;
+  states: Record<AuditedModule, ModuleState>;
+  /** Snapshot has all three explicitly true — the old DEFAULT_RECIPE shape.
+   *  Almost certainly captured pre-flip defaults, not an operator choice. */
+  matchesOldDefaultBoilerplate: boolean;
+  /** retrieval explicitly enabled while lessons is omitted: worked under the
+   *  old defaults (omitted lessons = on), silently inert after upgrade. */
+  inertRetrieval: boolean;
+  /** Local fleet-children recipe paths referenced by this recipe. */
+  childRecipePaths: string[];
+}
+
+interface RawRecipeShape {
+  name?: unknown;
+  agent?: unknown;
+  modules?: Record<string, unknown>;
+}
+
+/** A JSON document we treat as a recipe: object with a name and an agent
+ *  block. Anything else in a scanned directory is silently skipped. */
+export function looksLikeRecipe(raw: unknown): raw is RawRecipeShape {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return false;
+  const o = raw as RawRecipeShape;
+  return typeof o.name === 'string' && !!o.agent && typeof o.agent === 'object';
+}
+
+export function classifyModule(value: unknown): ModuleState {
+  if (value === undefined || value === null) return 'omitted';
+  if (value === false) return 'explicit-disable';
+  // true or a config object both enable (matches createFramework wiring).
+  return 'explicit-enable';
+}
+
+export function auditRecipe(raw: RawRecipeShape, path: string): RecipeAudit {
+  const modules = (raw.modules && typeof raw.modules === 'object' ? raw.modules : {}) as Record<string, unknown>;
+  const states = Object.fromEntries(
+    AUDITED_MODULES.map((m) => [m, classifyModule(modules[m])]),
+  ) as Record<AuditedModule, ModuleState>;
+
+  const isSnapshot = basename(path) === '.recipe.json';
+
+  const childRecipePaths: string[] = [];
+  const fleet = modules.fleet;
+  if (fleet && typeof fleet === 'object') {
+    const children = (fleet as { children?: unknown }).children;
+    if (Array.isArray(children)) {
+      for (const child of children) {
+        const ref = (child as { recipe?: unknown })?.recipe;
+        if (typeof ref !== 'string' || !ref) continue;
+        if (ref.startsWith('http://') || ref.startsWith('https://')) continue;
+        childRecipePaths.push(isAbsolute(ref) ? ref : resolve(dirname(resolve(path)), ref));
+      }
+    }
+  }
+
+  return {
+    path,
+    recipeName: String(raw.name),
+    isSnapshot,
+    states,
+    matchesOldDefaultBoilerplate:
+      isSnapshot &&
+      modules.subagents === true && modules.lessons === true && modules.retrieval === true,
+    inertRetrieval: states.retrieval === 'explicit-enable' && states.lessons === 'omitted',
+    childRecipePaths,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Filesystem walk (main-path only; the logic above is what the tests pin)
+// ---------------------------------------------------------------------------
+
+const SKIP_DIRS = new Set(['node_modules', '.git', 'web']);
+
+function collectJsonFiles(root: string, out: string[]): void {
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    const full = join(root, entry.name);
+    if (entry.isDirectory()) {
+      if (!SKIP_DIRS.has(entry.name)) collectJsonFiles(full, out);
+    } else if (entry.name.endsWith('.json')) {
+      out.push(full);
+    }
+  }
+}
+
+export function auditPaths(paths: string[]): { audits: RecipeAudit[]; unreadable: string[] } {
+  const files: string[] = [];
+  const unreadable: string[] = [];
+  for (const p of paths) {
+    if (!existsSync(p)) {
+      unreadable.push(p);
+      continue;
+    }
+    if (statSync(p).isDirectory()) collectJsonFiles(p, files);
+    else files.push(p);
+  }
+
+  const audits: RecipeAudit[] = [];
+  const seen = new Set<string>();
+  const queue = [...files];
+  while (queue.length > 0) {
+    const file = queue.shift()!;
+    const key = resolve(file);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    let raw: unknown;
+    try {
+      raw = JSON.parse(readFileSync(file, 'utf-8'));
+    } catch {
+      continue; // not JSON we can read — not our business to complain about
+    }
+    if (!looksLikeRecipe(raw)) continue;
+    const audit = auditRecipe(raw, file);
+    audits.push(audit);
+    // Follow local fleet children so a parent path argument covers the tree.
+    for (const child of audit.childRecipePaths) {
+      if (existsSync(child)) queue.push(child);
+    }
+  }
+  return { audits, unreadable };
+}
+
+// ---------------------------------------------------------------------------
+// Report
+// ---------------------------------------------------------------------------
+
+const STATE_LINES: Record<AuditedModule, Record<ModuleState, string>> = {
+  subagents: {
+    'explicit-enable':
+      'explicitly enabled — stays on after upgrade. Keep if this agent really forks workers.',
+    'explicit-disable': 'explicitly disabled — no change on upgrade (belt-and-braces for old checkouts).',
+    omitted:
+      'omitted — ON under published ≤0.7.2, OFF after upgrade. Declare `true` only if this agent relied on forking.',
+  },
+  lessons: {
+    'explicit-enable':
+      'explicitly enabled — stays on after upgrade. Keep if this agent curates a lesson library.',
+    'explicit-disable': 'explicitly disabled — no change on upgrade (belt-and-braces for old checkouts).',
+    omitted:
+      'omitted — ON under published ≤0.7.2, OFF after upgrade. Declare `true` only if this agent relied on lessons.',
+  },
+  retrieval: {
+    'explicit-enable':
+      'explicitly enabled — stays on after upgrade: per-compile injection plus two Haiku calls per turn. Keep only as a real choice.',
+    'explicit-disable': 'explicitly disabled — no change on upgrade (belt-and-braces for old checkouts).',
+    omitted: 'omitted — ON under published ≤0.7.2 (when lessons ran), OFF after upgrade.',
+  },
+};
+
+export function renderReport(audits: RecipeAudit[]): { text: string; needsDecision: number } {
+  const lines: string[] = [];
+  let needsDecision = 0;
+
+  const sources = audits.filter((a) => !a.isSnapshot);
+  const snapshots = audits.filter((a) => a.isSnapshot);
+
+  for (const a of sources) {
+    lines.push(`${a.path}  (recipe "${a.recipeName}")`);
+    for (const m of AUDITED_MODULES) {
+      const state = a.states[m];
+      if (state === 'explicit-enable') needsDecision++;
+      lines.push(`  ${m}: ${STATE_LINES[m][state]}`);
+    }
+    if (a.inertRetrieval) {
+      needsDecision++;
+      lines.push(
+        '  ⚠ retrieval is enabled but lessons is omitted. Under the old defaults omitted lessons still ran,',
+        '    so retrieval worked; after upgrade lessons is off and retrieval is silently inert.',
+        '    Either add `lessons: true` (if retrieval is a real choice) or drop `retrieval`.',
+      );
+    }
+    lines.push('');
+  }
+
+  if (snapshots.length > 0) {
+    lines.push('Resolved snapshots (data/.recipe.json) — informational only:');
+    lines.push(
+      '  These are launch-time captures, not authoritative sources. Under the old defaults they',
+      '  include enables the operator never wrote. Audit the source recipe each run was launched',
+      '  from; the snapshot refreshes on the next launch from source.',
+    );
+    for (const a of snapshots) {
+      const enabled = AUDITED_MODULES.filter((m) => a.states[m] === 'explicit-enable');
+      const note = a.matchesOldDefaultBoilerplate
+        ? 'all three enabled — matches the old DEFAULT_RECIPE shape, almost certainly pre-flip defaults, not a choice'
+        : enabled.length > 0
+          ? `explicitly enabled here: ${enabled.join(', ')}`
+          : 'no audited modules enabled';
+      lines.push(`  ${a.path}  (recipe "${a.recipeName}"): ${note}`);
+    }
+    lines.push('');
+  }
+
+  return { text: lines.join('\n'), needsDecision };
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function main(): void {
+  const args = process.argv.slice(2).filter((a) => !a.startsWith('--'));
+  if (args.length === 0) {
+    console.error('Usage: bun scripts/audit-module-optins.ts <recipe.json | directory> [...more]');
+    console.error('Report-only: reads recipes, changes nothing.');
+    process.exit(1);
+  }
+
+  const { audits, unreadable } = auditPaths(args);
+  for (const p of unreadable) console.error(`cannot read: ${p}`);
+
+  console.log('connectome-host module opt-in audit — report only, nothing is modified\n');
+  console.log(
+    'Published ≤0.7.2 treated subagents/lessons/retrieval as opt-OUT (omitted = enabled).\n' +
+      'Current main treats them as opt-IN (omitted = disabled). Explicit enables survive the\n' +
+      'upgrade by design — this report shows where each recipe stands so you can decide which\n' +
+      'of those are real choices and which are old boilerplate.\n',
+  );
+
+  let needsDecision = 0;
+  if (audits.length === 0) {
+    console.log('No recipe-shaped JSON found under the given paths.');
+  } else {
+    const report = renderReport(audits);
+    needsDecision = report.needsDecision;
+    console.log(report.text);
+    const sources = audits.filter((a) => !a.isSnapshot).length;
+    console.log(
+      `Summary: ${audits.length} recipe(s) audited (${sources} source, ${audits.length - sources} snapshot), ` +
+        `${needsDecision} item(s) need an operator decision.`,
+    );
+  }
+
+  // Unreadable path arguments outrank findings in the exit code.
+  if (unreadable.length > 0) process.exit(1);
+  if (needsDecision > 0) process.exit(2);
+}
+
+if (import.meta.main) main();

--- a/test/audit-module-optins.test.ts
+++ b/test/audit-module-optins.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Tests for the report-only module opt-in audit (Sol's #32 closure gate,
+ * step 3). The contract under test: explicit enables are surfaced for an
+ * operator decision, omissions are explained as the defaults flip working,
+ * resolved .recipe.json snapshots are pointers rather than findings, and
+ * nothing is ever modified.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { mkdtempSync, writeFileSync, mkdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  classifyModule,
+  looksLikeRecipe,
+  auditRecipe,
+  auditPaths,
+  renderReport,
+  AUDITED_MODULES,
+} from '../scripts/audit-module-optins.js';
+
+function tmp(): string {
+  return mkdtempSync(join(tmpdir(), 'optin-audit-'));
+}
+
+const AGENT = { name: 'test-agent', systemPrompt: 'hi' };
+
+describe('classifyModule', () => {
+  test('true and config objects are explicit enables', () => {
+    expect(classifyModule(true)).toBe('explicit-enable');
+    expect(classifyModule({ model: 'x' })).toBe('explicit-enable');
+  });
+  test('false is an explicit disable; absent is omitted', () => {
+    expect(classifyModule(false)).toBe('explicit-disable');
+    expect(classifyModule(undefined)).toBe('omitted');
+  });
+});
+
+describe('looksLikeRecipe', () => {
+  test('recipe-shaped objects pass; package.json-shaped ones do not', () => {
+    expect(looksLikeRecipe({ name: 'r', agent: AGENT })).toBe(true);
+    expect(looksLikeRecipe({ name: 'pkg', version: '1.0.0' })).toBe(false);
+    expect(looksLikeRecipe(['name'])).toBe(false);
+    expect(looksLikeRecipe(null)).toBe(false);
+  });
+});
+
+describe('auditRecipe', () => {
+  test('classifies each audited module independently', () => {
+    const a = auditRecipe(
+      { name: 'r', agent: AGENT, modules: { lessons: true, retrieval: false, wake: true } },
+      'r.json',
+    );
+    expect(a.states).toEqual({ subagents: 'omitted', lessons: 'explicit-enable', retrieval: 'explicit-disable' });
+    expect(a.isSnapshot).toBe(false);
+    expect(a.matchesOldDefaultBoilerplate).toBe(false);
+  });
+
+  test('flags retrieval-without-lessons as inert after upgrade', () => {
+    const a = auditRecipe({ name: 'r', agent: AGENT, modules: { retrieval: true } }, 'r.json');
+    expect(a.inertRetrieval).toBe(true);
+    // With lessons enabled the combination is coherent, not inert.
+    const ok = auditRecipe({ name: 'r', agent: AGENT, modules: { retrieval: true, lessons: true } }, 'r.json');
+    expect(ok.inertRetrieval).toBe(false);
+  });
+
+  test('a .recipe.json with all three true is old-default boilerplate; a source recipe never is', () => {
+    const modules = { subagents: true, lessons: true, retrieval: true };
+    const snap = auditRecipe({ name: 'r', agent: AGENT, modules }, 'data/.recipe.json');
+    expect(snap.isSnapshot).toBe(true);
+    expect(snap.matchesOldDefaultBoilerplate).toBe(true);
+    const src = auditRecipe({ name: 'r', agent: AGENT, modules }, 'data/recipe.json');
+    expect(src.matchesOldDefaultBoilerplate).toBe(false);
+  });
+
+  test('collects local fleet children, resolves relative paths, skips URLs', () => {
+    const a = auditRecipe(
+      {
+        name: 'parent',
+        agent: AGENT,
+        modules: { fleet: { children: [{ recipe: 'child.json' }, { recipe: 'https://x.example/c.json' }] } },
+      },
+      '/deploy/recipes/parent.json',
+    );
+    expect(a.childRecipePaths).toEqual(['/deploy/recipes/child.json']);
+  });
+});
+
+describe('auditPaths', () => {
+  test('scans directories, follows fleet children, skips non-recipes, modifies nothing', () => {
+    const dir = tmp();
+    const recipesDir = join(dir, 'recipes');
+    mkdirSync(recipesDir);
+    writeFileSync(
+      join(recipesDir, 'parent.json'),
+      JSON.stringify({
+        name: 'parent',
+        agent: AGENT,
+        modules: { lessons: true, fleet: { children: [{ recipe: '../elsewhere/child.json' }] } },
+      }),
+    );
+    // Child lives OUTSIDE the scanned dir — reachable only by following the reference.
+    mkdirSync(join(dir, 'elsewhere'));
+    const childPath = join(dir, 'elsewhere', 'child.json');
+    writeFileSync(childPath, JSON.stringify({ name: 'child', agent: AGENT, modules: { retrieval: true } }));
+    writeFileSync(join(recipesDir, 'package.json'), JSON.stringify({ name: 'pkg', version: '1.0.0' }));
+    writeFileSync(join(recipesDir, 'broken.json'), '{nope');
+
+    const before = statSync(join(recipesDir, 'parent.json')).mtimeMs;
+    const { audits, unreadable } = auditPaths([recipesDir]);
+    expect(unreadable).toEqual([]);
+    expect(audits.map((a) => a.recipeName).sort()).toEqual(['child', 'parent']);
+    // Report-only, literally: nothing was rewritten.
+    expect(statSync(join(recipesDir, 'parent.json')).mtimeMs).toBe(before);
+    expect(readFileSync(childPath, 'utf-8')).toContain('"retrieval":true');
+  });
+
+  test('finds dot-prefixed .recipe.json snapshots in scanned directories', () => {
+    const dir = tmp();
+    writeFileSync(
+      join(dir, '.recipe.json'),
+      JSON.stringify({ name: 'snap', agent: AGENT, modules: { subagents: true, lessons: true, retrieval: true } }),
+    );
+    const { audits } = auditPaths([dir]);
+    expect(audits.length).toBe(1);
+    expect(audits[0].isSnapshot).toBe(true);
+    expect(audits[0].matchesOldDefaultBoilerplate).toBe(true);
+  });
+
+  test('reports unreadable path arguments', () => {
+    const { audits, unreadable } = auditPaths([join(tmp(), 'nope.json')]);
+    expect(audits).toEqual([]);
+    expect(unreadable.length).toBe(1);
+  });
+});
+
+describe('renderReport', () => {
+  test('explicit enables and inert retrieval need decisions; omissions and disables do not', () => {
+    const clean = auditRecipe({ name: 'clean', agent: AGENT, modules: { lessons: false } }, 'clean.json');
+    expect(renderReport([clean]).needsDecision).toBe(0);
+
+    const enabled = auditRecipe({ name: 'e', agent: AGENT, modules: { lessons: true, retrieval: true } }, 'e.json');
+    // two explicit enables, no inert-retrieval (lessons present)
+    expect(renderReport([enabled]).needsDecision).toBe(2);
+
+    const inert = auditRecipe({ name: 'i', agent: AGENT, modules: { retrieval: true } }, 'i.json');
+    // one explicit enable + one inert-retrieval warning
+    expect(renderReport([inert]).needsDecision).toBe(2);
+  });
+
+  test('snapshot enables are informational, never decision items', () => {
+    const snap = auditRecipe(
+      { name: 's', agent: AGENT, modules: { subagents: true, lessons: true, retrieval: true } },
+      'data/.recipe.json',
+    );
+    const { text, needsDecision } = renderReport([snap]);
+    expect(needsDecision).toBe(0);
+    expect(text).toContain('not authoritative');
+    expect(text).toContain('old DEFAULT_RECIPE shape');
+  });
+
+  test('every audited module appears in a source-recipe report', () => {
+    const a = auditRecipe({ name: 'r', agent: AGENT }, 'r.json');
+    const { text } = renderReport([a]);
+    for (const m of AUDITED_MODULES) expect(text).toContain(`${m}:`);
+  });
+});


### PR DESCRIPTION
Implements step 3 of Sol's #32 closure gate ([ruling relayed from Anima Mundi]): an upgrade audit that **reports explicit lessons/retrieval enables without changing them**, so operators can decide.

## What it does

`bun scripts/audit-module-optins.ts <recipes-and-data-dirs...>` walks the given files/directories (following local fleet-children references, including ones outside the scanned tree), and reports per recipe:

- **explicit enables** — survive the upgrade by design; flagged for an operator decision since old-guide boilerplate and real choices are indistinguishable to a script
- **omissions** — ran under published ≤0.7.2 opt-out defaults, stop on upgrade; explained as the fix working, with a note on when to declare `true`
- **retrieval-without-lessons** — worked under opt-out (omitted lessons still ran), goes *silently inert* under opt-in; the report says to either add `lessons: true` or drop `retrieval`. This migration edge wasn't in the closure gate but falls out of the same wiring (`modules.retrieval && lessonsModule`)
- **`data/.recipe.json` snapshots** — listed in a separate informational section as pointers back to the source recipe, never as findings; the all-three-true old-DEFAULT_RECIPE shape is called out as almost certainly captured defaults, not a choice

There is no write path in the script at all. Exit codes: 0 clean / 2 decisions needed / 1 unreadable path argument, so it can gate deployment scripts.

The CHANGELOG `## Unreleased` section gains the corresponding upgrade note (it had no entry for the defaults flip yet), so `npm version` folds it into whatever release first contains `5ba1bce` + `a4bd9fd` — which per the closure gate is what actually resolves #32 for users.

## Tests

13 new tests (classification, boilerplate/inert detection, directory walk + child-following, report decision-counting, and a literal nothing-was-modified assertion). Full suite **510/510**; `tsc --noEmit` adds no new errors — note main currently has 10 pre-existing errors (9 in `tts-relay-module.ts`, 1 in `mcpl-admin-module.ts` — `tokenProvider` missing from `McplServerConfig`, possibly fallout from f15d78c), verified identical on clean main.

Steps 4 (clean-onboard test against the packed artifact) can follow as a separate PR if wanted — it tests the layer the existing source-level regression can't see.

*(Implementation and this description drafted by Claude at Ra's request.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)