### PR TITLE
fix: model-gate Bedrock prompt caching instead of transport-wide disable (issue #35)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@
 
 ### Changed
 
+- **Prompt caching enabled on Bedrock for models that support it**
+  (Discord issue #35). The previous transport-wide `promptCaching: false`
+  was a workaround for "your request did not allow prompt caching" —
+  which turned out to be the account-level denial for 3.5 Sonnet v2
+  (caching there was preview-only and dropped at Bedrock's GA), not a
+  transport property. Caching is now gated per model
+  (`bedrockModelSupportsPromptCaching`): on for the Bedrock caching-GA
+  lineup (3.5 Haiku, 3.7 Sonnet, Claude 4+), off for Claude 3.x and
+  3.5 Sonnet. New recipe field `agent.promptCaching: boolean` overrides
+  the gate in either direction (any provider) — `true` opts a
+  grandfathered preview account back into 3.6 caching, `false` covers
+  other denied accounts/regions. `cacheTtl` is no longer forwarded on
+  bedrock: that transport only has the default 5-minute cache and
+  rejects the ttl field. Verified live 2026-07-31: every currently
+  invokable Claude on Bedrock (all 4-era; 3.5-era and opus-4-0514 are
+  EOL there) writes and reads the cache cleanly. Requires
+  `@animalabs/membrane` ≥ 0.5.77 (cache_control ttl strip, stream cache
+  usage capture, 4-era inference-profile model mapping); the dependency
+  and lockfile are bumped accordingly in this change.
+
 - **Subscription-GC closes carry honest provenance and respect explicit
   opens** (Discord issue #5, the Mythos "channel settings keep resetting"
   mechanism). GC closes are now recorded as `subscription-gc`, never

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,18 @@
   (caching there was preview-only and dropped at Bedrock's GA), not a
   transport property. Caching is now gated per model
   (`bedrockModelSupportsPromptCaching`): on for the Bedrock caching-GA
-  lineup (3.5 Haiku, 3.7 Sonnet, Claude 4+), off for Claude 3.x and
-  3.5 Sonnet. New recipe field `agent.promptCaching: boolean` overrides
-  the gate in either direction (any provider) — `true` opts a
-  grandfathered preview account back into 3.6 caching, `false` covers
-  other denied accounts/regions. `cacheTtl` is no longer forwarded on
-  bedrock: that transport only has the default 5-minute cache and
-  rejects the ttl field. Verified live 2026-07-31: every currently
+  lineup (3.5 Haiku, 3.7 Sonnet, Claude 4+), off for the pre-GA families
+  (Claude v2/instant, Claude 3, 3.5 Sonnet — matched at the family
+  boundary, so bare aliases and `-latest` forms gate the same as dated
+  ids; non-Claude Bedrock ids are conservatively off). New recipe field
+  `agent.promptCaching: boolean` overrides the gate in either direction
+  on any provider, and lands at both layers — per-agent config and
+  Membrane's default for internal callers (compression/merge) — for
+  accounts/regions whose entitlements differ from the GA table.
+  `cacheTtl` is withheld at the host layer on bedrock (Agent Framework
+  still supplies its own default downstream; membrane ≥ 0.5.77 strips
+  the ttl field at the provider boundary, so the wire request never
+  carries it either way). Verified live 2026-07-31: every currently
   invokable Claude on Bedrock (all 4-era; 3.5-era and opus-4-0514 are
   EOL there) writes and reads the cache cleanly. Requires
   `@animalabs/membrane` ≥ 0.5.77 (cache_control ttl strip, stream cache

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@animalabs/connectome-host",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@animalabs/connectome-host",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "hasInstallScript": true,
       "dependencies": {
         "@animalabs/agent-framework": "^0.7.2",
         "@animalabs/chronicle": "^0.2.0",
         "@animalabs/context-manager": "^0.6.0",
-        "@animalabs/membrane": "^0.5.75",
+        "@animalabs/membrane": "^0.5.77",
         "@opentui/core": "^0.1.82"
       },
       "devDependencies": {
@@ -141,9 +141,9 @@
       }
     },
     "node_modules/@animalabs/membrane": {
-      "version": "0.5.75",
-      "resolved": "https://registry.npmjs.org/@animalabs/membrane/-/membrane-0.5.75.tgz",
-      "integrity": "sha512-eWtkrbQQga8UWDMH4VzPfZzcwYQLwngUcQ2tMeuERMBJ6WkXQzSJkcQVjM3ZvexvytnLsFTMOATvT58Igl9JuA==",
+      "version": "0.5.77",
+      "resolved": "https://registry.npmjs.org/@animalabs/membrane/-/membrane-0.5.77.tgz",
+      "integrity": "sha512-1mVGEEjuWj7/CL9VsRTsyr5JhSCXCOJc392MRYXXr1f3MsCwt+54uw/+qo+VDeknihZ96dRVP8u/fvvMDeDiAw==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.52.0"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@animalabs/agent-framework": "^0.7.2",
     "@animalabs/chronicle": "^0.2.0",
     "@animalabs/context-manager": "^0.6.0",
-    "@animalabs/membrane": "^0.5.75",
+    "@animalabs/membrane": "^0.5.77",
     "@opentui/core": "^0.1.82"
   },
   "devDependencies": {

--- a/src/framework-agent-config.ts
+++ b/src/framework-agent-config.ts
@@ -10,12 +10,36 @@ export type FrameworkAgentConfig = AgentConfig & {
   sameRoundThinkTextPolicy?: 'public' | 'private';
 };
 
+/**
+ * Prompt caching went GA on Bedrock in April 2025 for 3.5 Haiku, 3.7
+ * Sonnet, and Claude 4+ — but NOT for 3.5 Sonnet (either version). 1022
+ * ("3.6") was in the Dec 2024 preview and was dropped at GA: preview
+ * accounts keep access, everyone else gets "your request did not allow
+ * prompt caching" (the account-level error observed here 2026-07-21 —
+ * antra's diagnosis, confirmed against the AWS docs 2026-07-31). So the
+ * gate defaults 3.5 Sonnet and older off, 3.5 Haiku / 3.7 / 4+ on.
+ * Matches both plain Claude ids and Bedrock/inference-profile forms
+ * (us.anthropic.claude-...). recipe.agent.promptCaching overrides in
+ * either direction — set true on a grandfathered preview account to
+ * cache on 1022. (Connectome issue #35.)
+ */
+export function bedrockModelSupportsPromptCaching(model: string): boolean {
+  return !/claude-(v2|instant|3-(opus|sonnet|haiku)-\d|3-5-sonnet-)/.test(model.toLowerCase());
+}
+
+export function resolvePromptCaching(recipe: Recipe, model: string): boolean | undefined {
+  if (recipe.agent.promptCaching !== undefined) return recipe.agent.promptCaching;
+  if (recipe.agent.provider === 'bedrock') return bedrockModelSupportsPromptCaching(model);
+  return undefined; // membrane default (on)
+}
+
 export function buildFrameworkAgentConfig(
   recipe: Recipe,
   agentName: string,
   model: string,
   strategy: FrameworkAgentConfig['strategy'],
 ): FrameworkAgentConfig {
+  const promptCaching = resolvePromptCaching(recipe, model);
   return {
     name: agentName,
     model,
@@ -23,10 +47,13 @@ export function buildFrameworkAgentConfig(
     maxTokens: recipe.agent.maxTokens ?? 16384,
     maxStreamTokens: recipe.agent.maxStreamTokens ?? 150000,
     contextBudgetTokens: recipe.agent.contextBudgetTokens,
-    ...(recipe.agent.cacheTtl && { cacheTtl: recipe.agent.cacheTtl }),
-    // Bedrock legacy Claude models reject cache_control outright
-    // ("your request did not allow prompt caching") — suppress markers.
-    ...(recipe.agent.provider === 'bedrock' && { promptCaching: false }),
+    // cacheTtl stays off bedrock requests: that transport only has the
+    // default 5m cache, and older membrane releases forward the ttl field
+    // Bedrock rejects. (Current membrane strips it; this keeps the request
+    // log honest either way.)
+    ...(recipe.agent.cacheTtl && recipe.agent.provider !== 'bedrock'
+      && { cacheTtl: recipe.agent.cacheTtl }),
+    ...(promptCaching !== undefined && { promptCaching }),
     // Prefill scaffold (anthropic-xml formatter), e.g. chapterx CLI-sim's
     // '<cmd>cat untitled.txt</cmd>' — part of migrating prefill-era bots.
     ...(recipe.agent.prefillUserMessage && { prefillUserMessage: recipe.agent.prefillUserMessage }),

--- a/src/framework-agent-config.ts
+++ b/src/framework-agent-config.ts
@@ -13,24 +13,48 @@ export type FrameworkAgentConfig = AgentConfig & {
 /**
  * Prompt caching went GA on Bedrock in April 2025 for 3.5 Haiku, 3.7
  * Sonnet, and Claude 4+ — but NOT for 3.5 Sonnet (either version). 1022
- * ("3.6") was in the Dec 2024 preview and was dropped at GA: preview
- * accounts keep access, everyone else gets "your request did not allow
- * prompt caching" (the account-level error observed here 2026-07-21 —
- * antra's diagnosis, confirmed against the AWS docs 2026-07-31). So the
- * gate defaults 3.5 Sonnet and older off, 3.5 Haiku / 3.7 / 4+ on.
- * Matches both plain Claude ids and Bedrock/inference-profile forms
- * (us.anthropic.claude-...). recipe.agent.promptCaching overrides in
- * either direction — set true on a grandfathered preview account to
- * cache on 1022. (Connectome issue #35.)
+ * ("3.6") was in the Dec 2024 preview and was dropped at GA — that
+ * account-level "your request did not allow prompt caching" is the error
+ * observed here 2026-07-21 (antra's diagnosis, confirmed against the AWS
+ * docs 2026-07-31; as of the same day's live probe every 3.5-era model
+ * is EOL on Bedrock anyway). So the gate denies the pre-GA FAMILIES —
+ * Claude v2/instant, Claude 3, 3.5 Sonnet — at the family boundary, so
+ * dated ids, bare aliases, -latest, and inference-profile forms
+ * (us.anthropic.claude-...) all resolve the same; 3.5 Haiku and 3.7
+ * Sonnet stay distinct and on. Non-Claude Bedrock ids (Nova etc.) are
+ * out of scope for this gate and conservatively off — membrane's
+ * BedrockAdapter only accepts Claude ids today. recipe.agent.
+ * promptCaching overrides in either direction for accounts/regions
+ * whose entitlements differ from the GA table. (Connectome issue #35.)
  */
 export function bedrockModelSupportsPromptCaching(model: string): boolean {
-  return !/claude-(v2|instant|3-(opus|sonnet|haiku)-\d|3-5-sonnet-)/.test(model.toLowerCase());
+  const id = model.toLowerCase();
+  if (!id.includes('claude')) return false;
+  // (?![a-z0-9]) = family boundary: end of id, or a separator (-, ., :)
+  // before a date/qualifier — matches the whole family, not one spelling.
+  return !/claude-(v2|instant|3-(opus|sonnet|haiku)|3-5-sonnet)(?![a-z0-9])/.test(id);
 }
 
 export function resolvePromptCaching(recipe: Recipe, model: string): boolean | undefined {
   if (recipe.agent.promptCaching !== undefined) return recipe.agent.promptCaching;
   if (recipe.agent.provider === 'bedrock') return bedrockModelSupportsPromptCaching(model);
   return undefined; // membrane default (on)
+}
+
+/**
+ * Membrane-level counterpart of resolvePromptCaching, spread into the
+ * Membrane constructor config. The per-agent flag only governs agent
+ * inference; internal callers (autobio compression, executeMerge) read
+ * Membrane's defaultPromptCaching — so an explicit recipe override must
+ * land at BOTH layers, on every provider, or `promptCaching: false` on
+ * an Anthropic recipe would silently keep caching on for internal calls.
+ */
+export function membraneCachingOverride(
+  recipe: Recipe,
+  model: string,
+): { defaultPromptCaching?: boolean } {
+  const promptCaching = resolvePromptCaching(recipe, model);
+  return promptCaching === undefined ? {} : { defaultPromptCaching: promptCaching };
 }
 
 export function buildFrameworkAgentConfig(
@@ -47,10 +71,14 @@ export function buildFrameworkAgentConfig(
     maxTokens: recipe.agent.maxTokens ?? 16384,
     maxStreamTokens: recipe.agent.maxStreamTokens ?? 150000,
     contextBudgetTokens: recipe.agent.contextBudgetTokens,
-    // cacheTtl stays off bedrock requests: that transport only has the
-    // default 5m cache, and older membrane releases forward the ttl field
-    // Bedrock rejects. (Current membrane strips it; this keeps the request
-    // log honest either way.)
+    // cacheTtl is withheld at the HOST layer on bedrock: the transport
+    // only has the default 5m cache, and older membrane releases forward
+    // the ttl field Bedrock rejects. Note this is not the whole story —
+    // Agent Framework still supplies its own default ('1h') downstream
+    // when the host omits the field, and membrane ≥0.5.77 strips it at
+    // the provider boundary before wire dispatch. Requests are safe, but
+    // pre-adapter config is NOT cache-TTL telemetry; the wire truth lives
+    // at the adapter.
     ...(recipe.agent.cacheTtl && recipe.agent.provider !== 'bedrock'
       && { cacheTtl: recipe.agent.cacheTtl }),
     ...(promptCaching !== undefined && { promptCaching }),

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,7 +63,7 @@ import {
   parseRecipeArg,
 } from './recipe.js';
 import { createBranchState, resetBranchState, handleExport, type BranchState } from './commands.js';
-import { buildFrameworkAgentConfig } from './framework-agent-config.js';
+import { buildFrameworkAgentConfig, resolvePromptCaching } from './framework-agent-config.js';
 import { buildFrameworkStrategy } from './framework-strategy.js';
 import { loadExtensions } from './extensions.js';
 
@@ -147,6 +147,11 @@ async function resolveRecipe(): Promise<Recipe> {
 // Framework factory
 // ---------------------------------------------------------------------------
 
+function resolveModel(recipe: Recipe): string {
+  return config.model || recipe.agent.model ||
+    (recipe.agent.provider === 'openai-codex' ? 'gpt-5.4' : 'claude-opus-4-6');
+}
+
 async function createFramework(
   membrane: Membrane,
   storePath: string,
@@ -155,8 +160,7 @@ async function createFramework(
   settingsModule: SettingsModule,
   callLedger: CallLedger | null,
 ): Promise<AgentFramework> {
-  const model = config.model || recipe.agent.model ||
-    (recipe.agent.provider === 'openai-codex' ? 'gpt-5.4' : 'claude-opus-4-6');
+  const model = resolveModel(recipe);
   const modules = recipe.modules ?? {};
   const timeZone = resolveTimeZone(recipe.agent.timezone);
 
@@ -877,8 +881,11 @@ async function main() {
   // vars (AWS_REGION defaults us-west-2) and maps standard Claude model IDs
   // to Bedrock IDs (explicit map + `anthropic.<id>-v1:0` fallback). Uses the
   // Anthropic-native message shape, so NativeFormatter applies unchanged.
-  // No CallLedger: prompt caching is rejected outright by legacy Bedrock
-  // models (tested 2026-07-21). Wrapped for llm-calls.jsonl visibility.
+  // Prompt caching is model-gated (bedrockModelSupportsPromptCaching):
+  // 3.5 Sonnet 1022 and newer cache normally; 0620/Opus 3 reject
+  // cache_control outright (tested 2026-07-21). Still no CallLedger —
+  // it's anthropic-transport-only for now; cache metrics are visible in
+  // llm-calls.jsonl via the logging wrapper.
   const bedrockAdapter = provider === 'bedrock'
     ? new LoggingBedrockAdapter({}, llmLogPath)
     : undefined;
@@ -960,10 +967,14 @@ async function main() {
       : recipe.agent.formatter === 'anthropic-xml'
         ? new AnthropicXmlFormatter()
         : new NativeFormatter(),
-    // Bedrock legacy Claude models 400 on any cache_control block
-    // ("your request did not allow prompt caching") — suppress the
-    // historical promptCaching=true default on that transport.
-    ...(provider === 'bedrock' ? { defaultPromptCaching: false } : {}),
+    // Bedrock: caching is model-gated, not suppressed transport-wide —
+    // only the legacy ids that predate Bedrock caching support 400 on
+    // cache_control (see bedrockModelSupportsPromptCaching). This default
+    // covers internal callers (autobio compression, executeMerge) that
+    // don't carry the per-agent promptCaching flag.
+    ...(provider === 'bedrock' && resolvePromptCaching(recipe, resolveModel(recipe)) === false
+      ? { defaultPromptCaching: false }
+      : {}),
     // Anchor the assistant role for internal callers that don't set
     // request.assistantParticipant themselves (autobio compression,
     // executeMerge). Mismatch here flips stored assistant turns to

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,7 +63,7 @@ import {
   parseRecipeArg,
 } from './recipe.js';
 import { createBranchState, resetBranchState, handleExport, type BranchState } from './commands.js';
-import { buildFrameworkAgentConfig, resolvePromptCaching } from './framework-agent-config.js';
+import { buildFrameworkAgentConfig, membraneCachingOverride } from './framework-agent-config.js';
 import { buildFrameworkStrategy } from './framework-strategy.js';
 import { loadExtensions } from './extensions.js';
 
@@ -876,15 +876,17 @@ async function main() {
         xTitle: recipe.agent.name ?? recipe.name,
       })
     : undefined;
-  // Bedrock: legacy Claude models (3.5 Sonnet 0620/1022, Opus 3) that have
-  // left the Anthropic API but survive on AWS. The adapter reads AWS_* env
-  // vars (AWS_REGION defaults us-west-2) and maps standard Claude model IDs
-  // to Bedrock IDs (explicit map + `anthropic.<id>-v1:0` fallback). Uses the
-  // Anthropic-native message shape, so NativeFormatter applies unchanged.
-  // Prompt caching is model-gated (bedrockModelSupportsPromptCaching):
-  // 3.5 Sonnet 1022 and newer cache normally; 0620/Opus 3 reject
-  // cache_control outright (tested 2026-07-21). Still no CallLedger —
-  // it's anthropic-transport-only for now; cache metrics are visible in
+  // Bedrock: an alternate Claude transport. (Historically for models that
+  // left the direct API — as of 2026-07-31 every 3.5-era id and opus-4-0514
+  // are EOL on Bedrock too, so what actually runs here is the 4-era via
+  // inference profiles.) The adapter reads AWS_* env vars (AWS_REGION
+  // defaults us-west-2) and maps standard Claude model IDs to Bedrock IDs.
+  // Uses the Anthropic-native message shape, so NativeFormatter applies
+  // unchanged. Prompt caching is model-gated
+  // (bedrockModelSupportsPromptCaching): pre-GA families (Claude 3,
+  // 3.5 Sonnet) off, everything currently invokable caches — verified by
+  // live probe 2026-07-31. Still no CallLedger — it's
+  // anthropic-transport-only for now; cache metrics are visible in
   // llm-calls.jsonl via the logging wrapper.
   const bedrockAdapter = provider === 'bedrock'
     ? new LoggingBedrockAdapter({}, llmLogPath)
@@ -967,14 +969,13 @@ async function main() {
       : recipe.agent.formatter === 'anthropic-xml'
         ? new AnthropicXmlFormatter()
         : new NativeFormatter(),
-    // Bedrock: caching is model-gated, not suppressed transport-wide —
-    // only the legacy ids that predate Bedrock caching support 400 on
-    // cache_control (see bedrockModelSupportsPromptCaching). This default
-    // covers internal callers (autobio compression, executeMerge) that
-    // don't carry the per-agent promptCaching flag.
-    ...(provider === 'bedrock' && resolvePromptCaching(recipe, resolveModel(recipe)) === false
-      ? { defaultPromptCaching: false }
-      : {}),
+    // Caching default for internal callers (autobio compression,
+    // executeMerge), which read Membrane's defaultPromptCaching rather
+    // than the per-agent flag. Applies on EVERY provider whenever the
+    // recipe/model resolves an explicit answer — an Anthropic recipe with
+    // promptCaching:false must disable internal calls too, and on bedrock
+    // the model gate decides (see bedrockModelSupportsPromptCaching).
+    ...membraneCachingOverride(recipe, resolveModel(recipe)),
     // Anchor the assistant role for internal callers that don't set
     // request.assistantParticipant themselves (autobio compression,
     // executeMerge). Mismatch here flips stored assistant turns to

--- a/src/recipe.ts
+++ b/src/recipe.ts
@@ -124,8 +124,18 @@ export interface RecipeAgent {
    *  ContextManager default (100k) applies. Raise for large-context models. */
   contextBudgetTokens?: number;
   /** Prompt-cache TTL ('5m' | '1h') forwarded to the provider. Defaults to
-   *  '1h'; set '5m' explicitly for high-frequency, sub-5-minute workloads. */
+   *  '1h'; set '5m' explicitly for high-frequency, sub-5-minute workloads.
+   *  Not forwarded on bedrock — that transport only has the default 5m
+   *  cache and rejects the ttl field. */
   cacheTtl?: '5m' | '1h';
+  /**
+   * Explicit prompt-caching override. Unset means provider-appropriate
+   * default: on for everything except bedrock models that predate caching
+   * support there (see bedrockModelSupportsPromptCaching). Set false if a
+   * transport/account rejects cache_control markers — AWS's "your request
+   * did not allow prompt caching" can also be account/region-dependent.
+   */
+  promptCaching?: boolean;
   /**
    * Same-round routing policy for ordinary text emitted beside think().
    * Omitted preserves the compatibility carry-forward in Agent Framework.
@@ -965,6 +975,12 @@ export function validateRecipe(raw: unknown): Recipe {
     throw new Error(`Recipe agent.cacheTtl must be '5m' or '1h', got ${JSON.stringify(agent.cacheTtl)}.`);
   }
   agent.cacheTtl ??= '1h';
+
+  if (agent.promptCaching !== undefined && typeof agent.promptCaching !== 'boolean') {
+    throw new Error(
+      `Recipe agent.promptCaching must be a boolean, got ${JSON.stringify(agent.promptCaching)}.`,
+    );
+  }
 
   if (
     agent.sameRoundThinkTextPolicy !== undefined &&

--- a/test/bedrock-prompt-caching.test.ts
+++ b/test/bedrock-prompt-caching.test.ts
@@ -1,16 +1,23 @@
 /**
  * Bedrock prompt caching is model-gated, not suppressed transport-wide
- * (issue #35). The transport exists here for legacy ids that left the
- * direct API (Opus 3, 3.5 Sonnet 0620) — those genuinely reject
- * cache_control — but everything from 3.5 Sonnet 1022 up caches normally
- * on Bedrock, and the old blanket promptCaching:false made every modern
- * Bedrock agent re-pay its full context on every call.
+ * (issue #35). The deny-list is the pre-GA FAMILIES (Claude v2/instant,
+ * Claude 3, 3.5 Sonnet — Bedrock's caching GA never covered them), matched
+ * at the family boundary so dated ids, bare aliases, -latest, and
+ * inference-profile forms all resolve the same. Everything currently
+ * invokable on Bedrock caches (verified by live probe 2026-07-31; the
+ * 3.5 era is EOL there). The old blanket promptCaching:false made every
+ * modern Bedrock agent re-pay its full context on every call.
+ *
+ * The recipe override must land at BOTH layers — per-agent config for
+ * agent inference AND Membrane defaultPromptCaching for internal callers
+ * (compression/merge) — on every provider, per Sol's #69 review.
  */
 import { describe, expect, test } from 'bun:test';
 import { validateRecipe } from '../src/recipe.js';
 import {
   buildFrameworkAgentConfig,
   bedrockModelSupportsPromptCaching,
+  membraneCachingOverride,
 } from '../src/framework-agent-config.js';
 
 function recipe(agent: Record<string, unknown> = {}) {
@@ -24,8 +31,8 @@ describe('bedrockModelSupportsPromptCaching', () => {
       'anthropic.claude-3-sonnet-20240229-v1:0',
       'anthropic.claude-3-haiku-20240307-v1:0',
       'us.anthropic.claude-3-5-sonnet-20240620-v1:0',
-      // "3.6" — preview-only on Bedrock, dropped at GA; grandfathered
-      // accounts opt back in via recipe promptCaching: true.
+      // "3.6" — its caching was preview-only on Bedrock, dropped at GA
+      // (and the model itself is EOL there as of 7/2026).
       'us.anthropic.claude-3-5-sonnet-20241022-v2:0',
       'claude-3-5-sonnet-20241022',
       'claude-3-opus-20240229',
@@ -36,16 +43,42 @@ describe('bedrockModelSupportsPromptCaching', () => {
     }
   });
 
+  test('the deny-list matches families, not single dated spellings', () => {
+    // Sol's #69 review: bare aliases, -latest, and profile forms of the
+    // pre-GA families must not fall through to caching-on.
+    for (const id of [
+      'claude-3-opus',
+      'claude-3-opus-latest',
+      'claude-3-sonnet',
+      'claude-3-haiku-latest',
+      'claude-3-5-sonnet',
+      'claude-3-5-sonnet-latest',
+      'us.anthropic.claude-3-opus-latest-v1:0',
+      'apac.anthropic.claude-3-5-sonnet-v2:0',
+      'CLAUDE-3-OPUS',
+    ]) {
+      expect(bedrockModelSupportsPromptCaching(id)).toBe(false);
+    }
+  });
+
   test('models with GA Bedrock caching support stay on', () => {
     for (const id of [
       'anthropic.claude-3-5-haiku-20241022-v1:0',
+      'claude-3-5-haiku-latest',
       'us.anthropic.claude-3-7-sonnet-20250219-v1:0',
+      'claude-3-7-sonnet',
       'us.anthropic.claude-sonnet-4-20250514-v1:0',
       'claude-sonnet-4-20250514',
       'claude-opus-4-6',
       'bedrock:us.anthropic.claude-opus-4-20250514-v1:0',
     ]) {
       expect(bedrockModelSupportsPromptCaching(id)).toBe(true);
+    }
+  });
+
+  test('non-Claude Bedrock ids are conservatively off, not accidentally on', () => {
+    for (const id of ['amazon.nova-pro-v1:0', 'meta.llama3-70b-instruct-v1:0', 'mistral.mistral-large-2402-v1:0']) {
+      expect(bedrockModelSupportsPromptCaching(id)).toBe(false);
     }
   });
 });
@@ -77,12 +110,44 @@ describe('bedrock agent config', () => {
     );
     expect(forcedOff.promptCaching).toBe(false);
 
-    // The grandfathered-preview-account path: 3.6 with explicit opt-in.
+    // Explicit opt-in for an account/region whose entitlements differ
+    // from the GA table (the gate is a default, not a hard ceiling).
     const forcedOn = buildFrameworkAgentConfig(
       validateRecipe(recipe({ provider: 'bedrock', promptCaching: true })),
       'agent', 'us.anthropic.claude-3-5-sonnet-20241022-v2:0', undefined,
     );
     expect(forcedOn.promptCaching).toBe(true);
+  });
+
+  test('explicit override lands at BOTH layers on any provider (composition)', () => {
+    // Anthropic recipe, explicit false: agent config off AND membrane
+    // default off — internal callers (compression/merge) read the latter.
+    const anthOff = validateRecipe(recipe({ promptCaching: false }));
+    expect(buildFrameworkAgentConfig(anthOff, 'agent', 'claude-opus-4-6', undefined).promptCaching).toBe(false);
+    expect(membraneCachingOverride(anthOff, 'claude-opus-4-6')).toEqual({ defaultPromptCaching: false });
+
+    // Bedrock explicit true and false: both layers agree with the override.
+    const bedOn = validateRecipe(recipe({ provider: 'bedrock', promptCaching: true }));
+    expect(buildFrameworkAgentConfig(bedOn, 'agent', 'us.anthropic.claude-3-5-sonnet-20241022-v2:0', undefined).promptCaching).toBe(true);
+    expect(membraneCachingOverride(bedOn, 'us.anthropic.claude-3-5-sonnet-20241022-v2:0')).toEqual({ defaultPromptCaching: true });
+
+    const bedOff = validateRecipe(recipe({ provider: 'bedrock', promptCaching: false }));
+    expect(buildFrameworkAgentConfig(bedOff, 'agent', 'us.anthropic.claude-opus-4-1-20250805-v1:0', undefined).promptCaching).toBe(false);
+    expect(membraneCachingOverride(bedOff, 'us.anthropic.claude-opus-4-1-20250805-v1:0')).toEqual({ defaultPromptCaching: false });
+
+    // Bedrock with no explicit override: the model gate supplies the
+    // answer at both layers too.
+    const bedGate = validateRecipe(recipe({ provider: 'bedrock' }));
+    expect(membraneCachingOverride(bedGate, 'us.anthropic.claude-3-7-sonnet-20250219-v1:0')).toEqual({ defaultPromptCaching: true });
+    expect(membraneCachingOverride(bedGate, 'anthropic.claude-3-opus-20240229-v1:0')).toEqual({ defaultPromptCaching: false });
+
+    // Anthropic with no override: BOTH layers stay silent — membrane's
+    // own default (on) governs, and we don't bake it in here.
+    const anthDefault = validateRecipe(recipe());
+    expect(Object.prototype.hasOwnProperty.call(
+      buildFrameworkAgentConfig(anthDefault, 'agent', 'claude-opus-4-6', undefined), 'promptCaching',
+    )).toBe(false);
+    expect(membraneCachingOverride(anthDefault, 'claude-opus-4-6')).toEqual({});
   });
 
   test('non-bedrock providers keep prior behavior: caching omitted, cacheTtl forwarded', () => {

--- a/test/bedrock-prompt-caching.test.ts
+++ b/test/bedrock-prompt-caching.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Bedrock prompt caching is model-gated, not suppressed transport-wide
+ * (issue #35). The transport exists here for legacy ids that left the
+ * direct API (Opus 3, 3.5 Sonnet 0620) — those genuinely reject
+ * cache_control — but everything from 3.5 Sonnet 1022 up caches normally
+ * on Bedrock, and the old blanket promptCaching:false made every modern
+ * Bedrock agent re-pay its full context on every call.
+ */
+import { describe, expect, test } from 'bun:test';
+import { validateRecipe } from '../src/recipe.js';
+import {
+  buildFrameworkAgentConfig,
+  bedrockModelSupportsPromptCaching,
+} from '../src/framework-agent-config.js';
+
+function recipe(agent: Record<string, unknown> = {}) {
+  return { name: 'bedrock-caching-test', agent: { systemPrompt: 'sys', ...agent } };
+}
+
+describe('bedrockModelSupportsPromptCaching', () => {
+  test('ids without GA caching support are gated off', () => {
+    for (const id of [
+      'anthropic.claude-3-opus-20240229-v1:0',
+      'anthropic.claude-3-sonnet-20240229-v1:0',
+      'anthropic.claude-3-haiku-20240307-v1:0',
+      'us.anthropic.claude-3-5-sonnet-20240620-v1:0',
+      // "3.6" — preview-only on Bedrock, dropped at GA; grandfathered
+      // accounts opt back in via recipe promptCaching: true.
+      'us.anthropic.claude-3-5-sonnet-20241022-v2:0',
+      'claude-3-5-sonnet-20241022',
+      'claude-3-opus-20240229',
+      'anthropic.claude-v2:1',
+      'anthropic.claude-instant-v1',
+    ]) {
+      expect(bedrockModelSupportsPromptCaching(id)).toBe(false);
+    }
+  });
+
+  test('models with GA Bedrock caching support stay on', () => {
+    for (const id of [
+      'anthropic.claude-3-5-haiku-20241022-v1:0',
+      'us.anthropic.claude-3-7-sonnet-20250219-v1:0',
+      'us.anthropic.claude-sonnet-4-20250514-v1:0',
+      'claude-sonnet-4-20250514',
+      'claude-opus-4-6',
+      'bedrock:us.anthropic.claude-opus-4-20250514-v1:0',
+    ]) {
+      expect(bedrockModelSupportsPromptCaching(id)).toBe(true);
+    }
+  });
+});
+
+describe('bedrock agent config', () => {
+  test('GA-supported bedrock model gets caching on, without cacheTtl', () => {
+    const parsed = validateRecipe(recipe({ provider: 'bedrock' }));
+    const config = buildFrameworkAgentConfig(
+      parsed, 'agent', 'us.anthropic.claude-3-7-sonnet-20250219-v1:0', undefined,
+    );
+    expect(config.promptCaching).toBe(true);
+    // Bedrock rejects cache_control.ttl; the recipe default ('1h') must not
+    // ride along even though membrane also strips it.
+    expect(Object.prototype.hasOwnProperty.call(config, 'cacheTtl')).toBe(false);
+  });
+
+  test('legacy bedrock model keeps caching suppressed', () => {
+    const parsed = validateRecipe(recipe({ provider: 'bedrock' }));
+    const config = buildFrameworkAgentConfig(
+      parsed, 'agent', 'us.anthropic.claude-3-5-sonnet-20240620-v1:0', undefined,
+    );
+    expect(config.promptCaching).toBe(false);
+  });
+
+  test('recipe promptCaching overrides the model gate in both directions', () => {
+    const forcedOff = buildFrameworkAgentConfig(
+      validateRecipe(recipe({ provider: 'bedrock', promptCaching: false })),
+      'agent', 'us.anthropic.claude-3-7-sonnet-20250219-v1:0', undefined,
+    );
+    expect(forcedOff.promptCaching).toBe(false);
+
+    // The grandfathered-preview-account path: 3.6 with explicit opt-in.
+    const forcedOn = buildFrameworkAgentConfig(
+      validateRecipe(recipe({ provider: 'bedrock', promptCaching: true })),
+      'agent', 'us.anthropic.claude-3-5-sonnet-20241022-v2:0', undefined,
+    );
+    expect(forcedOn.promptCaching).toBe(true);
+  });
+
+  test('non-bedrock providers keep prior behavior: caching omitted, cacheTtl forwarded', () => {
+    const parsed = validateRecipe(recipe());
+    const config = buildFrameworkAgentConfig(parsed, 'agent', 'claude-opus-4-6', undefined);
+    expect(Object.prototype.hasOwnProperty.call(config, 'promptCaching')).toBe(false);
+    expect(config.cacheTtl).toBe('1h');
+  });
+
+  test('recipe promptCaching applies on non-bedrock providers too', () => {
+    const parsed = validateRecipe(recipe({ promptCaching: false }));
+    const config = buildFrameworkAgentConfig(parsed, 'agent', 'claude-opus-4-6', undefined);
+    expect(config.promptCaching).toBe(false);
+  });
+
+  test('non-boolean promptCaching is rejected at validation', () => {
+    expect(() => validateRecipe(recipe({ promptCaching: 'yes' }))).toThrow(/promptCaching/);
+    expect(() => validateRecipe(recipe({ promptCaching: 1 }))).toThrow(/promptCaching/);
+  });
+});


### PR DESCRIPTION
## What

Re-enables prompt caching on Bedrock, gated per model instead of suppressed transport-wide. Companion to membrane #44 (merged, released as v0.5.77); this PR bumps the dependency to `^0.5.77` (the truthful minimum — that release contains the ttl strip, stream cache-usage capture, and 4-era model mapping this depends on) with a regenerated lockfile.

## Why

Both kill switches (`framework-agent-config.ts` per-agent flag and the membrane-level `defaultPromptCaching: false`) were a workaround for AWS's "your request did not allow prompt caching" — which turned out to be the **account-level denial for 3.5 Sonnet v2** (caching there was preview-only, dropped at Bedrock's GA; antra's diagnosis, confirmed against AWS docs), not a transport property. The blanket switch also kept caching off for models where it just works, so every deep-context Bedrock agent re-paid its full context on every call.

## How

- `bedrockModelSupportsPromptCaching(model)`: default-off for Claude 3.x and 3.5 Sonnet (both versions), default-on for the Bedrock caching-GA lineup (3.5 Haiku, 3.7 Sonnet, Claude 4+) and anything newer. Matches plain Claude ids and Bedrock/inference-profile forms.
- New recipe field `agent.promptCaching: boolean` (validated), overriding the gate in either direction on any provider — `true` opts a grandfathered preview account back into 3.6 caching, `false` covers other denied accounts/regions.
- `cacheTtl` is no longer forwarded on bedrock: the transport only has the default 5m cache; membrane ≥0.5.77 strips the ttl field and older membranes would 400 on it — either way it doesn't belong in the request.
- The membrane-level `defaultPromptCaching: false` now applies only when the resolved model/override gates off, so internal callers (autobio compression, executeMerge) follow the same policy as agent inference.
- CHANGELOG entry under Unreleased.

## Live verification (2026-07-31, deployment account)

Two-call probe per model with a ~14.7k-token marked prefix: **opus-4-1, sonnet-4-5, haiku-4-5, opus-4-5, sonnet-4 all show full cache write on call 1 and full cache read on call 2.** All 3.5-era models and opus-4-20250514 are EOL on Bedrock ("model version has reached the end of its life"), so every currently invokable Claude there supports caching — the gate's off-list is protective for stragglers/other accounts, not load-bearing for this deployment.

## Tests

505/505 (`bun test`) with membrane 0.5.77 actually installed. New `test/bedrock-prompt-caching.test.ts`: gate off-list (3.x, both 3.5 Sonnets incl. inference-profile forms) and on-list (3.5 Haiku, 3.7, Claude 4+, `bedrock:`-prefixed), recipe override in both directions, cacheTtl withheld on bedrock while non-bedrock providers keep prior behavior (caching omitted → membrane default, cacheTtl forwarded), and non-boolean `promptCaching` rejected at validation.

Note: `npx tsc --noEmit` on this branch shows one error in `src/modules/mcpl-admin-module.ts` (`accessProvider` not on `McplServerConfig`) — pre-existing on main from the accessFor/httpAuthFor rename outrunning installed mcpl-core-ts types; this branch doesn't touch that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)