### PR TITLE
fix(retrieval): honor configured reasoning settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Fixed
+
+- **OpenAI retrieval reasoning effort.** Recipes using `openai-responses` or
+  `openai-codex` can set `modules.retrieval.reasoningEffort` independently of
+  the primary agent. Unsupported providers fail recipe validation instead of
+  receiving an invalid OpenAI-shaped request, and reasoning-enabled retrieval
+  requires an explicit model instead of falling through to the Claude default.
+
 ## 0.7.3 — 2026-08-01
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -123,11 +123,21 @@ subscription credits at a higher rate when applied.
 - **Web UI**: browser operator console (`modules.webui`) — live chat with full interiority (thinking, tool calls, streaming), agent/fleet tree, context makeup + compression coverage, call ledger with cache verdicts and billing-grade costs, health/ops alerts, Chronicle branch tree, lessons, MCPL config, workspace files; scoped read-only observer access via device keys
 - **TUI + readline modes**: OpenTUI interactive terminal or `--no-tui` for pipes/CI
 - **Subagent forking** (opt-in, `modules.subagents`): Spawn/fork parallel agents with fleet tree view (Tab to toggle)
-- **Persistent lessons** (opt-in, `modules.lessons`): Knowledge store with confidence scores and tags. Automatic retrieval-injection of lessons into context (`modules.retrieval`) is a separate opt-in — it adds per-turn context churn and Haiku calls, so enable it only for agents that actually curate a lesson library
+- **Persistent lessons** (opt-in, `modules.lessons`): Knowledge store with confidence scores and tags. Automatic retrieval-injection of lessons into context (`modules.retrieval`) is a separate opt-in — it adds per-turn context churn and retrieval-model calls, so enable it only for agents that actually curate a lesson library
 - **Time-travel**: Chronicle-backed undo/redo, named checkpoints, branch exploration
 - **Session management**: Isolated sessions with auto-naming
 - **MCPL support**: Connect any MCP/MCPL server; wake subscriptions for selective event triggering
 - **File products**: Write reports and documents, materialize to disk
+
+For `openai-responses` and `openai-codex`, an object-valued
+`modules.retrieval` can set `reasoningEffort` (`none`, `minimal`, `low`,
+`medium`, `high`, `xhigh`, or `max`) independently of the primary agent.
+Retrieval calls are independent one-shot requests, so there is no separate
+retrieval reasoning-context setting. When `reasoningEffort` is configured,
+`model` must also be set explicitly: the historical retrieval default is a
+Claude model and cannot be sent through an OpenAI adapter. Anthropic/Claude
+uses different native thinking controls and does not accept this OpenAI-shaped
+option.
 
 ## Prerequisites
 

--- a/docs/AGENT-ONBOARDING.md
+++ b/docs/AGENT-ONBOARDING.md
@@ -274,7 +274,7 @@ workloads whose cache is normally reused within five minutes.
 
 **`subagents`/`lessons`/`retrieval` are NOT part of the standard recipe.**
 All three are opt-in. RetrievalModule in particular injects context-dependent
-content into every compile (and spends two Haiku calls per turn), so it must
+content into every compile (and spends up to two configured retrieval-model calls), so it must
 be an explicit opt-in for agents that actually curate a lesson library.
 Current host code defaults all three to off, but keep the explicit `false`
 entries in the recipe anyway — older host checkouts treated these as opt-out,

--- a/docs/debug-context-api.md
+++ b/docs/debug-context-api.md
@@ -75,8 +75,8 @@ The trade-off is fidelity: the default response **omits the dynamically
 gathered injections** (lessons, retrieval results, MCPL `beforeInference`
 context), because gathering those is *not* free or transparent:
 
-- module `gatherContext` can run inference — e.g. the retrieval module makes
-  Haiku calls, which cost tokens and add latency;
+- module `gatherContext` can run inference — e.g. the retrieval module makes configured model calls, which cost tokens and add
+  latency;
 - MCPL `beforeInference` hooks are arbitrary RPCs to external servers with
   side effects, and a preview never sends the paired `afterInference`, which
   can leave a stateful server half-open.

--- a/docs/webui-deployment.md
+++ b/docs/webui-deployment.md
@@ -160,7 +160,8 @@ Query params:
 - `agent=<name>` — defaults to the recipe's root agent
 - `injections=1` — opt into full fidelity: gather the dynamic injections too.
   **Not transparent** — this can run inference (e.g. the retrieval module's
-  Haiku calls cost tokens) and fires MCPL `beforeInference` hooks (whose paired
+  configured model calls cost tokens) and fires MCPL `beforeInference` hooks
+  (whose paired
   `afterInference` is never sent, so a stateful server may be left half-open).
 - `pretty=1` — pretty-print the JSON
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,7 @@ import { readFileSync, existsSync } from 'node:fs';
 import { SubagentModule } from './modules/subagent-module.js';
 import { LessonsModule } from './modules/lessons-module.js';
 import { RetrievalModule } from './modules/retrieval-module.js';
+import { buildRetrievalModuleConfig } from './retrieval-config.js';
 import type { RecipeWorkspaceMount } from './recipe.js';
 import { TuiModule } from './modules/tui-module.js';
 import { TimeModule } from './modules/time-module.js';
@@ -227,16 +228,13 @@ async function createFramework(
   }
 
   // Retrieval (requires lessons). OPT-IN — not part of the standard recipe:
-  // it injects context-dependent content into every compile (plus two Haiku
-  // calls per turn), which adds per-turn context churn. Enable explicitly via
-  // modules.retrieval only when an agent actually curates a lesson library.
+  // it injects context-dependent content into every compile (plus up to two
+  // configured retrieval-model calls), which adds per-turn context churn.
+  // Enable explicitly only when an agent actually curates a lesson library.
   if (modules.retrieval && lessonsModule) {
-    const retrievalConfig = typeof modules.retrieval === 'object' ? modules.retrieval : {};
-    moduleInstances.push(new RetrievalModule({
-      membrane,
-      retrievalModel: retrievalConfig.model,
-      maxInjectedLessons: retrievalConfig.maxInjected,
-    }));
+    moduleInstances.push(new RetrievalModule(
+      buildRetrievalModuleConfig(membrane, modules.retrieval, recipe.agent.provider),
+    ));
   }
 
   // Gate config — core AF EventGate feature.

--- a/src/modules/retrieval-module.ts
+++ b/src/modules/retrieval-module.ts
@@ -2,12 +2,12 @@
  * RetrievalModule — LLM-as-retriever for semantic memory.
  *
  * Three-step retrieval pipeline running in gatherContext():
- *   1. Flag concepts (Haiku): identify concepts being discussed that might
- *      benefit from background knowledge
+ *   1. Flag concepts: identify concepts being discussed that might benefit
+ *      from background knowledge
  *   2. Mechanical query: keyword-match against LessonsModule
- *   3. Validate relevance (Haiku): filter to actually relevant lessons
+ *   3. Validate relevance: filter to actually relevant lessons
  *
- * Steps 1 and 3 use cheap Haiku calls (~$0.001 each).
+ * Steps 1 and 3 use the configured retrieval model and optional reasoning.
  * Results are cached to avoid redundant calls on unchanged context.
  */
 
@@ -29,11 +29,19 @@ import type { LessonsModule, Lesson } from './lessons-module.js';
 // Configuration
 // ---------------------------------------------------------------------------
 
+export type RetrievalReasoningEffort = 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max';
+
+export interface RetrievalReasoningConfig {
+  effort: RetrievalReasoningEffort;
+}
+
 export interface RetrievalModuleConfig {
-  /** Membrane instance for Haiku calls */
+  /** Membrane instance for retrieval calls */
   membrane: Membrane;
   /** Model to use for retrieval calls (default: claude-haiku-4-5-20251001) */
   retrievalModel?: string;
+  /** Optional OpenAI reasoning effort, applied to both retrieval LLM stages. */
+  retrievalReasoning?: RetrievalReasoningConfig;
   /** Max lessons to inject (default: 5) */
   maxInjectedLessons?: number;
   /** Minimum lesson confidence for injection (default: 0.3) */
@@ -176,11 +184,19 @@ export class RetrievalModule implements Module {
   // Pipeline Steps
   // =========================================================================
 
+  /** Build OpenAI request parameters for configured retrieval reasoning effort. */
+  private retrievalProviderParams(): Record<string, unknown> | undefined {
+    const reasoning = this.config.retrievalReasoning;
+    if (!reasoning) return undefined;
+    return { reasoning: { effort: reasoning.effort } };
+  }
+
   /**
-   * Step 1: Use Haiku to identify concepts that might benefit from background knowledge.
+   * Step 1: Use the configured retrieval model to identify concepts that might benefit from background knowledge.
    */
   private async flagConcepts(recentContext: string): Promise<string[]> {
     const model = this.config.retrievalModel ?? 'claude-haiku-4-5-20251001';
+    const providerParams = this.retrievalProviderParams();
 
     const request: NormalizedRequest = {
       messages: [
@@ -191,6 +207,7 @@ export class RetrievalModule implements Module {
       ],
       system: CONCEPT_FLAG_PROMPT,
       config: { model, maxTokens: 500, temperature: 0 },
+      ...(providerParams ? { providerParams } : {}),
     };
 
     const response = await this.config.membrane.complete(request);
@@ -250,7 +267,7 @@ export class RetrievalModule implements Module {
   }
 
   /**
-   * Step 3: Use Haiku to validate which candidates are actually relevant.
+   * Step 3: Use the configured retrieval model to validate which candidates are actually relevant.
    */
   private async validateRelevance(recentContext: string, candidates: Lesson[]): Promise<Lesson[]> {
     if (candidates.length <= 3) {
@@ -259,6 +276,7 @@ export class RetrievalModule implements Module {
     }
 
     const model = this.config.retrievalModel ?? 'claude-haiku-4-5-20251001';
+    const providerParams = this.retrievalProviderParams();
 
     const candidateList = candidates.map(l =>
       `[${l.id}] (${l.confidence.toFixed(2)}) ${l.content}`
@@ -273,6 +291,7 @@ export class RetrievalModule implements Module {
       ],
       system: RELEVANCE_VALIDATION_PROMPT,
       config: { model, maxTokens: 500, temperature: 0 },
+      ...(providerParams ? { providerParams } : {}),
     };
 
     const response = await this.config.membrane.complete(request);

--- a/src/modules/web-ui-module.ts
+++ b/src/modules/web-ui-module.ts
@@ -1417,7 +1417,7 @@ export class WebUiModule implements Module {
    * MCPL calls — the preview leaves the system state untouched. This omits the
    * dynamically-gathered injections (lessons/retrieval/MCPL context). Pass
    * `?injections=1` to gather them for full fidelity, which is NOT transparent:
-   * it can run inference (e.g. RetrievalModule's Haiku calls) and fire MCPL
+   * it can run inference (e.g. RetrievalModule's configured model calls) and fire MCPL
    * `beforeInference` hooks (whose paired `afterInference` is never sent).
    */
   private async handleDebugContext(url: URL): Promise<Response> {

--- a/src/recipe.ts
+++ b/src/recipe.ts
@@ -421,10 +421,19 @@ export interface RecipeModules {
   /**
    * Lesson retrieval-injection (requires `lessons`). OPT-IN — defaults to off
    * and is deliberately not part of the standard recipe: it injects
-   * context-dependent content into every compile and spends two Haiku calls
-   * per turn. Enable only for agents that actually curate a lesson library.
+   * context-dependent content into every compile and spends up to two
+   * configured retrieval-model calls. Enable only for agents that actually
+   * curate a lesson library.
    */
-  retrieval?: boolean | { model?: string; maxInjected?: number };
+  retrieval?: boolean | {
+    model?: string;
+    maxInjected?: number;
+    /**
+     * Optional OpenAI Responses/Codex reasoning effort for both retrieval calls.
+     * Requires an explicit retrieval model.
+     */
+    reasoningEffort?: 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max';
+  };
   wake?: boolean | import('@animalabs/agent-framework').GateConfig;
   workspace?: boolean | { mounts: RecipeWorkspaceMount[]; configMount?: boolean };
   /**
@@ -718,7 +727,7 @@ export const DEFAULT_RECIPE: Recipe = {
   },
   modules: {
     // subagents + lessons + retrieval deliberately omitted — all opt-in only
-    // (retrieval additionally adds per-turn context churn + Haiku costs);
+    // (retrieval additionally adds per-turn context churn + retrieval-model costs);
     // see the RecipeModules field docs.
     wake: true,
     workspace: true,
@@ -1252,6 +1261,43 @@ export function validateRecipe(raw: unknown): Recipe {
         if (m.mode !== undefined && m.mode !== 'read-write' && m.mode !== 'read-only') {
           throw new Error(`workspace.mounts[${i}].mode must be "read-write" or "read-only"`);
         }
+      }
+    }
+
+    // Validate retrieval provider reasoning when configured.
+    const retrieval = mods.retrieval;
+    if (retrieval !== undefined && typeof retrieval !== 'boolean') {
+      if (!retrieval || typeof retrieval !== 'object' || Array.isArray(retrieval)) {
+        throw new Error('Recipe modules.retrieval must be a boolean or object.');
+      }
+      const retrievalConfig = retrieval as Record<string, unknown>;
+      if (retrievalConfig.reasoningContext !== undefined) {
+        throw new Error(
+          'modules.retrieval.reasoningContext is not supported: retrieval model calls ' +
+          'are independent one-shot requests with no earlier reasoning items.',
+        );
+      }
+      const efforts = ['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'];
+      if (retrievalConfig.reasoningEffort !== undefined &&
+          (typeof retrievalConfig.reasoningEffort !== 'string'
+            || !efforts.includes(retrievalConfig.reasoningEffort))) {
+        throw new Error(`Invalid modules.retrieval.reasoningEffort ${JSON.stringify(retrievalConfig.reasoningEffort)}.`);
+      }
+      if (retrievalConfig.reasoningEffort !== undefined
+          && agent.provider !== 'openai-responses'
+          && agent.provider !== 'openai-codex') {
+        throw new Error(
+          'modules.retrieval.reasoningEffort requires agent.provider ' +
+          '"openai-responses" or "openai-codex".',
+        );
+      }
+      if (retrievalConfig.reasoningEffort !== undefined
+          && (typeof retrievalConfig.model !== 'string'
+            || !retrievalConfig.model.trim())) {
+        throw new Error(
+          'modules.retrieval.model must be a non-empty string when ' +
+          'modules.retrieval.reasoningEffort is configured.',
+        );
       }
     }
 

--- a/src/retrieval-config.ts
+++ b/src/retrieval-config.ts
@@ -1,0 +1,39 @@
+import type { Membrane } from '@animalabs/membrane';
+import type { RecipeAgent, RecipeModules } from './recipe.js';
+import type { RetrievalModuleConfig } from './modules/retrieval-module.js';
+
+type RetrievalRecipeConfig = Exclude<RecipeModules['retrieval'], boolean | undefined>;
+
+/** Translate the recipe's retrieval block into the module's runtime config. */
+export function buildRetrievalModuleConfig(
+  membrane: Membrane,
+  retrieval: RecipeModules['retrieval'],
+  provider: RecipeAgent['provider'] = 'anthropic',
+): RetrievalModuleConfig {
+  const config: RetrievalRecipeConfig = typeof retrieval === 'object' ? retrieval : {};
+  if (config.reasoningEffort
+      && provider !== 'openai-responses'
+      && provider !== 'openai-codex') {
+    throw new Error(
+      'modules.retrieval.reasoningEffort requires agent.provider ' +
+      '"openai-responses" or "openai-codex".',
+    );
+  }
+  if (config.reasoningEffort
+      && (typeof config.model !== 'string' || !config.model.trim())) {
+    throw new Error(
+      'modules.retrieval.model must be a non-empty string when ' +
+      'modules.retrieval.reasoningEffort is configured.',
+    );
+  }
+  const retrievalReasoning = config.reasoningEffort
+    ? { effort: config.reasoningEffort }
+    : undefined;
+
+  return {
+    membrane,
+    retrievalModel: config.model,
+    retrievalReasoning,
+    maxInjectedLessons: config.maxInjected,
+  };
+}

--- a/test/retrieval-config.test.ts
+++ b/test/retrieval-config.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from 'bun:test';
+import type { Membrane } from '@animalabs/membrane';
+import { validateRecipe } from '../src/recipe.js';
+import { buildRetrievalModuleConfig } from '../src/retrieval-config.js';
+
+const membrane = {} as Membrane;
+
+function recipe(retrieval: unknown, provider: string = 'openai-codex') {
+  return {
+    name: 'retrieval-config-test',
+    agent: { systemPrompt: 'sys', provider },
+    modules: { retrieval },
+  };
+}
+
+describe('retrieval recipe config', () => {
+  test('accepts and maps provider reasoning settings', () => {
+    const parsed = validateRecipe(recipe({
+      model: 'test-model',
+      maxInjected: 7,
+      reasoningEffort: 'minimal',
+    }));
+
+    expect(parsed.modules?.retrieval).toEqual({
+      model: 'test-model',
+      maxInjected: 7,
+      reasoningEffort: 'minimal',
+    });
+    expect(buildRetrievalModuleConfig(membrane, parsed.modules!.retrieval!, 'openai-codex')).toEqual({
+      membrane,
+      retrievalModel: 'test-model',
+      maxInjectedLessons: 7,
+      retrievalReasoning: { effort: 'minimal' },
+    });
+  });
+
+  test('preserves boolean shorthand and omits unconfigured reasoning', () => {
+    expect(validateRecipe(recipe(true)).modules?.retrieval).toBe(true);
+    expect(validateRecipe(recipe(false)).modules?.retrieval).toBe(false);
+    expect(buildRetrievalModuleConfig(membrane, { model: 'test-model' }, 'anthropic')).toEqual({
+      membrane,
+      retrievalModel: 'test-model',
+    });
+  });
+
+  test('rejects malformed retrieval reasoning settings', () => {
+    expect(() => validateRecipe(recipe(null))).toThrow(/modules\.retrieval must be a boolean or object/);
+    expect(() => validateRecipe(recipe([]))).toThrow(/modules\.retrieval must be a boolean or object/);
+    expect(() => validateRecipe(recipe({ reasoningEffort: 'ultra' }))).toThrow(/reasoningEffort/);
+    expect(() => validateRecipe(recipe({ reasoningEffort: ['high'] }))).toThrow(/reasoningEffort/);
+    expect(() => validateRecipe(recipe({ reasoningContext: 'current_turn' }))).toThrow(
+      /independent one-shot requests/,
+    );
+    expect(() => validateRecipe(recipe({ reasoningEffort: 'high' }, 'anthropic'))).toThrow(
+      /requires agent\.provider/,
+    );
+    expect(() => buildRetrievalModuleConfig(
+      membrane,
+      { reasoningEffort: 'high' },
+      'anthropic',
+    )).toThrow(/requires agent\.provider/);
+    expect(() => validateRecipe(recipe({ reasoningEffort: 'high' }))).toThrow(
+      /model must be a non-empty string/,
+    );
+    expect(() => validateRecipe(recipe({ model: '  ', reasoningEffort: 'high' }))).toThrow(
+      /model must be a non-empty string/,
+    );
+    expect(() => buildRetrievalModuleConfig(
+      membrane,
+      { reasoningEffort: 'high' },
+      'openai-codex',
+    )).toThrow(/model must be a non-empty string/);
+  });
+});

--- a/test/retrieval-module.test.ts
+++ b/test/retrieval-module.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from 'bun:test';
+import type { Membrane, NormalizedRequest } from '@animalabs/membrane';
+import { RetrievalModule } from '../src/modules/retrieval-module.js';
+import { buildRetrievalModuleConfig } from '../src/retrieval-config.js';
+import type { Lesson } from '../src/modules/lessons-module.js';
+
+function lesson(id: string, content: string): Lesson {
+  return {
+    id,
+    content,
+    confidence: 0.9,
+    tags: ['memory'],
+    evidence: [],
+    created: 1,
+    updated: 1,
+    deprecated: false,
+  };
+}
+
+function harness(responses: Array<string | Error>, lessons: Lesson[]) {
+  const calls: NormalizedRequest[] = [];
+  const membrane = {
+    complete: async (request: NormalizedRequest) => {
+      calls.push(structuredClone(request));
+      const next = responses.shift();
+      if (next instanceof Error) throw next;
+      if (next === undefined) throw new Error('unexpected retrieval call');
+      return { content: [{ type: 'text', text: next }] };
+    },
+  } as unknown as Membrane;
+
+  const installContext = (mod: RetrievalModule) => {
+    (mod as unknown as { ctx: unknown }).ctx = {
+      getModule: (name: string) => name === 'lessons' ? { getLessons: () => lessons } : null,
+      queryMessages: () => ({
+        messages: [{
+          participant: 'user',
+          content: [{ type: 'text', text: 'Please recall the relevant memory context.' }],
+        }],
+        totalCount: 1,
+      }),
+    };
+  };
+
+  return { calls, membrane, installContext };
+}
+
+describe('RetrievalModule provider-specific reasoning', () => {
+  test('passes configured reasoning to concept extraction and relevance validation', async () => {
+    const lessons = [1, 2, 3, 4].map(n => lesson(`l${n}`, `memory detail ${n}`));
+    const h = harness(['["memory"]', '["l1", "l3"]'], lessons);
+    const mod = new RetrievalModule(buildRetrievalModuleConfig(h.membrane, {
+      model: 'gpt-5.6-sol',
+      reasoningEffort: 'xhigh',
+    }, 'openai-codex'));
+    h.installContext(mod);
+
+    const injections = await mod.gatherContext('sol');
+
+    expect(h.calls).toHaveLength(2);
+    for (const request of h.calls) {
+      expect(request.config.model).toBe('gpt-5.6-sol');
+      expect(request.providerParams).toEqual({
+        reasoning: { effort: 'xhigh' },
+      });
+    }
+    const text = (injections[0].content[0] as { type: 'text'; text: string }).text;
+    expect(text).toContain('memory detail 1');
+    expect(text).toContain('memory detail 3');
+    expect(text).not.toContain('memory detail 2');
+  });
+
+  test('omits providerParams when retrieval reasoning is not configured', async () => {
+    const h = harness(['[]'], [lesson('l1', 'memory detail')]);
+    const mod = new RetrievalModule({ membrane: h.membrane, retrievalModel: 'gpt-5.4-mini' });
+    h.installContext(mod);
+
+    expect(await mod.gatherContext('sol')).toEqual([]);
+    expect(h.calls).toHaveLength(1);
+    expect(h.calls[0].providerParams).toBeUndefined();
+  });
+
+  test('skips relevance validation for three or fewer candidates and caches non-empty results', async () => {
+    const h = harness(['["memory"]'], [lesson('l1', 'memory alpha'), lesson('l2', 'memory beta')]);
+    const mod = new RetrievalModule({
+      membrane: h.membrane,
+      retrievalModel: 'gpt-5.6-sol',
+      retrievalReasoning: { effort: 'xhigh' },
+    });
+    h.installContext(mod);
+
+    const first = await mod.gatherContext('sol');
+    const second = await mod.gatherContext('sol');
+
+    expect(first).toHaveLength(1);
+    expect(second).toEqual(first);
+    expect(h.calls).toHaveLength(1);
+    expect(h.calls[0].providerParams).toEqual({ reasoning: { effort: 'xhigh' } });
+  });
+
+  test('fails open when the concept extraction provider call fails', async () => {
+    const h = harness([new Error('provider unavailable')], [lesson('l1', 'memory detail')]);
+    const mod = new RetrievalModule({
+      membrane: h.membrane,
+      retrievalModel: 'gpt-5.6-sol',
+      retrievalReasoning: { effort: 'xhigh' },
+    });
+    h.installContext(mod);
+
+    expect(await mod.gatherContext('sol')).toEqual([]);
+    expect(h.calls).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

- add optional `modules.retrieval.reasoningEffort` for `openai-responses` and `openai-codex`
- require an explicit retrieval model whenever reasoning effort is configured, avoiding the historical Claude fallback through an OpenAI adapter
- pass that effort to both retrieval model calls without inheriting the primary agent's reasoning setting
- reject unsupported providers and the obsolete `reasoningContext` key at recipe validation
- preserve existing behavior when retrieval reasoning is unconfigured

## Why

Retrieval uses independent one-shot model calls. Operators using OpenAI Responses or Codex should be able to tune those calls separately from the primary agent, while Anthropic recipes should not receive an OpenAI-shaped `reasoning` request.

There is intentionally no retrieval-specific reasoning-context option: these calls do not replay earlier response or reasoning items, so `current_turn` versus `all_turns` would not change their behavior.

## Validation

- focused retrieval/config tests
- reasoning-only full Host suite: 515 passed, 0 failed, 1,402 assertions
- TypeScript
- Web production build
- diff hygiene

Co-authored with OpenAI Codex; authored and maintained by [Sol](https://git.io/start).

