### PR TITLE
feat(retrieval): lesson retrieval traces + selected-lesson WebUI page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Fixed
+
+- **OpenAI retrieval reasoning effort.** Recipes using `openai-responses` or
+  `openai-codex` can set `modules.retrieval.reasoningEffort` independently of
+  the primary agent. Unsupported providers fail recipe validation instead of
+  receiving an invalid OpenAI-shaped request, and reasoning-enabled retrieval
+  requires an explicit model instead of falling through to the Claude default.
+
 ## 0.7.3 — 2026-08-01
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### Added
+
+- **Operator retrieval traces.** The Web UI now exposes operator-only,
+  process-memory retrieval traces at `/debug/retrieval` and a readable
+  lesson-selection viewer at `/debug/retrieval/view`, including invoking-agent
+  attribution, mechanical candidates, relevance decisions, cache provenance,
+  and the exact injected lesson block. Exact conversation/model inputs remain
+  opt-in via literal `includeInputs=1`.
+
 ### Fixed
 
 - **OpenAI retrieval reasoning effort.** Recipes using `openai-responses` or

--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ non-loopback binds require basic-auth credentials. Build the SPA bundle once wit
 - Ops alerts (compression quarantine, refusal streaks, inference-exhausted) render as persistent banner rows
 - Usage panel: per-agent costs and a billing-grade call ledger with cache verdicts
 - `/curve` — compression-curve visualization; `/healthz` — liveness JSON for doctor/fleet tooling
+- `/debug/retrieval/view` — operator-only per-run lesson selection viewer (see `docs/retrieval-traces.md`)
 - Read-only observer access via Ed25519 device keys with per-grant scopes (see `docs/webui-deployment.md`)
 
 For SPA development: `cd web && bun run dev` proxies the Vite dev server onto a

--- a/README.md
+++ b/README.md
@@ -123,11 +123,21 @@ subscription credits at a higher rate when applied.
 - **Web UI**: browser operator console (`modules.webui`) — live chat with full interiority (thinking, tool calls, streaming), agent/fleet tree, context makeup + compression coverage, call ledger with cache verdicts and billing-grade costs, health/ops alerts, Chronicle branch tree, lessons, MCPL config, workspace files; scoped read-only observer access via device keys
 - **TUI + readline modes**: OpenTUI interactive terminal or `--no-tui` for pipes/CI
 - **Subagent forking** (opt-in, `modules.subagents`): Spawn/fork parallel agents with fleet tree view (Tab to toggle)
-- **Persistent lessons** (opt-in, `modules.lessons`): Knowledge store with confidence scores and tags. Automatic retrieval-injection of lessons into context (`modules.retrieval`) is a separate opt-in — it adds per-turn context churn and Haiku calls, so enable it only for agents that actually curate a lesson library
+- **Persistent lessons** (opt-in, `modules.lessons`): Knowledge store with confidence scores and tags. Automatic retrieval-injection of lessons into context (`modules.retrieval`) is a separate opt-in — it adds per-turn context churn and retrieval-model calls, so enable it only for agents that actually curate a lesson library
 - **Time-travel**: Chronicle-backed undo/redo, named checkpoints, branch exploration
 - **Session management**: Isolated sessions with auto-naming
 - **MCPL support**: Connect any MCP/MCPL server; wake subscriptions for selective event triggering
 - **File products**: Write reports and documents, materialize to disk
+
+For `openai-responses` and `openai-codex`, an object-valued
+`modules.retrieval` can set `reasoningEffort` (`none`, `minimal`, `low`,
+`medium`, `high`, `xhigh`, or `max`) independently of the primary agent.
+Retrieval calls are independent one-shot requests, so there is no separate
+retrieval reasoning-context setting. When `reasoningEffort` is configured,
+`model` must also be set explicitly: the historical retrieval default is a
+Claude model and cannot be sent through an OpenAI adapter. Anthropic/Claude
+uses different native thinking controls and does not accept this OpenAI-shaped
+option.
 
 ## Prerequisites
 

--- a/docs/AGENT-ONBOARDING.md
+++ b/docs/AGENT-ONBOARDING.md
@@ -274,7 +274,7 @@ workloads whose cache is normally reused within five minutes.
 
 **`subagents`/`lessons`/`retrieval` are NOT part of the standard recipe.**
 All three are opt-in. RetrievalModule in particular injects context-dependent
-content into every compile (and spends two Haiku calls per turn), so it must
+content into every compile (and spends up to two configured retrieval-model calls), so it must
 be an explicit opt-in for agents that actually curate a lesson library.
 Current host code defaults all three to off, but keep the explicit `false`
 entries in the recipe anyway — older host checkouts treated these as opt-out,

--- a/docs/debug-context-api.md
+++ b/docs/debug-context-api.md
@@ -75,8 +75,8 @@ The trade-off is fidelity: the default response **omits the dynamically
 gathered injections** (lessons, retrieval results, MCPL `beforeInference`
 context), because gathering those is *not* free or transparent:
 
-- module `gatherContext` can run inference — e.g. the retrieval module makes
-  Haiku calls, which cost tokens and add latency;
+- module `gatherContext` can run inference — e.g. the retrieval module makes configured model calls, which cost tokens and add
+  latency;
 - MCPL `beforeInference` hooks are arbitrary RPCs to external servers with
   side effects, and a preview never sends the paired `afterInference`, which
   can leave a stateful server half-open.

--- a/docs/retrieval-traces.md
+++ b/docs/retrieval-traces.md
@@ -1,0 +1,173 @@
+# Retrieval Traces
+
+The retrieval module can record a bounded, per-run explanation of automatic
+lesson selection. The trace shows which concepts the selector returned, which
+lessons matched mechanically, which candidates survived relevance filtering,
+and the exact lesson block injected into the next compile.
+
+Tracing is diagnostic. It does not change selection, trigger an extra model
+call, or claim access to hidden chain-of-thought.
+
+## Prerequisites
+
+Enable lessons, retrieval, and the Web UI in the recipe:
+
+```json
+{
+  "modules": {
+    "lessons": true,
+    "retrieval": {
+      "model": "gpt-5.4-mini",
+      "maxInjected": 5,
+      "reasoningEffort": "high"
+    },
+    "webui": {
+      "host": "127.0.0.1",
+      "port": 7340,
+      "basicAuth": {
+        "username": "${WEBUI_USER}",
+        "password": "${WEBUI_PASS}"
+      }
+    }
+  }
+}
+```
+
+`reasoningEffort` accepts `none`, `minimal`, `low`, `medium`, `high`, `xhigh`,
+or `max`. It is optional, applies to both retrieval calls, and does not inherit
+the primary agent's reasoning setting. This field is supported only when
+`agent.provider` is `openai-responses` or `openai-codex`; Anthropic/Claude uses
+separate native thinking controls and is rejected here rather than receiving an
+invalid OpenAI-shaped request.
+
+Retrieval remains opt-in and requires the lessons module. Depending on the
+candidate count, one turn can use one selector call plus an optional relevance
+call.
+
+## Operator viewer
+
+Open:
+
+```text
+http://127.0.0.1:7340/debug/retrieval/view
+```
+
+The viewer highlights selected lessons, lists all mechanically matched
+candidates and their match provenance, summarizes the relevance decision, and
+keeps the retained trace JSON behind a diagnostic disclosure. Each run is
+labeled with the invoking agent name. Separate Host processes retain separate
+trace stores and viewers; the endpoint does not aggregate fleet children.
+
+## JSON endpoint
+
+```text
+GET /debug/retrieval[?limit=20][&includeInputs=1]
+```
+
+| Parameter | Default | Meaning |
+|---|---:|---|
+| `limit` | `20` | Newest traces to return, clamped to `1..100`. |
+| `includeInputs` | off | Exact recent conversation and model-stage inputs are included only when the value is the literal `1`. |
+
+Example envelope:
+
+```json
+{
+  "schemaVersion": 1,
+  "enabled": true,
+  "includeInputs": false,
+  "traces": []
+}
+```
+
+Each trace can include:
+
+- configured model and request-level reasoning parameters;
+- recent-context hash, message count, and available message IDs;
+- selector prompt, raw returned text, normalized provider blocks, parsed
+  concepts, and parse mode;
+- every mechanical candidate, lesson snapshot, and content/tag match reason;
+- relevance-call output or the reason validation was skipped;
+- final relevant and injected lesson IDs, exact lesson snapshots, injection
+  namespace/position, and rendered `## Retrieved Knowledge` block;
+- cache-hit provenance, outcome, duration, and errors.
+
+Opaque or redacted reasoning blocks are retained only as provider-returned
+content blocks. The trace does not decrypt them or present them as hidden
+chain-of-thought. Each lesson snapshot is a point-in-time copy of every
+`Lesson` field: `id`, `content`, `confidence`, `tags`, `evidence`, `created`,
+`updated`, `deprecated`, and optional `deprecationReason`.
+
+If retrieval is disabled, the endpoint returns `enabled: false` and an empty
+trace list.
+
+## Authentication and privacy
+
+Both routes require password-derived operator authentication, including on a
+loopback bind. Web UI Basic Auth must be configured; the routes accept either
+direct valid Basic Auth or a full session created by password sign-in. A
+loopback-only Web UI without configured credentials returns `401` for these two
+routes, while other Web UI routes retain their historical loopback behavior.
+Read-only observer cookies are rejected even when they carry the `debug` scope.
+
+Exact recent conversation and stage inputs are omitted by default because they
+can contain private text. Use `includeInputs=1` deliberately; values such as
+`true` or `yes` do not enable disclosure. Lesson contents, selector output,
+candidate provenance, and the final injected block remain visible in the
+default trace because they are the subject of the diagnostic.
+
+Every response from either retrieval route uses `Cache-Control: no-store`,
+including authentication failures, not-yet-bound responses, and internal
+errors.
+
+## Retention and failure behavior
+
+The retrieval module retains at most the newest 100 traces and, by default, at
+most 8 MiB of UTF-8 encoded trace JSON in process memory. The limits are
+enforced after every active trace mutation. When the byte budget is reached,
+the oldest traces are evicted until both limits are satisfied. Traces are not
+written to Chronicle and disappear when the Host restarts. Cache provenance is
+rewritten when a referenced source is evicted or truncated, while each
+cache-hit trace keeps its own complete selected-lesson snapshots when they fit
+within the budget.
+
+If one trace alone exceeds the byte budget, it is replaced with a small record
+whose `truncation.kind` is `tombstone` and whose reason and original encoded
+size make clear that the detailed payload is unavailable. Tombstones are never
+presented as exact traces. Payloads that fit remain complete.
+
+Trace recording is fail-open: metadata collection and serialization failures
+must not block retrieval or the primary inference. Arbitrary provider blocks
+and request-level provider parameters are converted to JSON-safe snapshots
+before they are exposed. Their retained representations bound recursion depth,
+total nodes, array items, object keys,
+individual strings, and aggregate string bytes. When a bound applies, the
+stage's `responseContentTruncation` records the explicit reason and active
+limits. Cycles, BigInts, nonfinite numbers, and unreadable properties remain
+safe to serialize using explicit unavailable-value records.
+
+Viewing an existing trace is read-only. Retrieval itself still performs its
+normal model calls and lesson lookup when the agent gathers context.
+
+## Response codes
+
+| Status | Meaning |
+|---:|---|
+| `200` | Viewer or trace response returned. |
+| `401` | Missing operator authentication, including observer-only sessions. |
+| `500` | Retrieval Trace listing failed; the response remains noncacheable. |
+| `503` | Host application has not bound to the Web UI yet. |
+
+## Troubleshooting
+
+- `enabled: false`: enable both `modules.lessons` and `modules.retrieval`, then
+  restart with the updated recipe.
+- Empty `traces`: no retrieval run has completed or started since this Host
+  process began.
+- Many candidates but few selected lessons: the relevance stage is filtering
+  mechanical keyword matches. `maxInjected` is a ceiling, not a quota.
+- `sourceTraceEvicted: true`: a cache hit refers to a run older than the
+  in-memory retention window; the exact selected lesson snapshots remain on the
+  cache-hit trace.
+- `sourceTraceTruncated: true`: the referenced source is retained only as a
+  tombstone; inspect the complete snapshots on the cache-hit trace itself.

--- a/docs/webui-deployment.md
+++ b/docs/webui-deployment.md
@@ -160,7 +160,8 @@ Query params:
 - `agent=<name>` — defaults to the recipe's root agent
 - `injections=1` — opt into full fidelity: gather the dynamic injections too.
   **Not transparent** — this can run inference (e.g. the retrieval module's
-  Haiku calls cost tokens) and fires MCPL `beforeInference` hooks (whose paired
+  configured model calls cost tokens) and fires MCPL `beforeInference` hooks
+  (whose paired
   `afterInference` is never sent, so a stateful server may be left half-open).
 - `pretty=1` — pretty-print the JSON
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,7 @@ import { readFileSync, existsSync } from 'node:fs';
 import { SubagentModule } from './modules/subagent-module.js';
 import { LessonsModule } from './modules/lessons-module.js';
 import { RetrievalModule } from './modules/retrieval-module.js';
+import { buildRetrievalModuleConfig } from './retrieval-config.js';
 import type { RecipeWorkspaceMount } from './recipe.js';
 import { TuiModule } from './modules/tui-module.js';
 import { TimeModule } from './modules/time-module.js';
@@ -227,16 +228,13 @@ async function createFramework(
   }
 
   // Retrieval (requires lessons). OPT-IN — not part of the standard recipe:
-  // it injects context-dependent content into every compile (plus two Haiku
-  // calls per turn), which adds per-turn context churn. Enable explicitly via
-  // modules.retrieval only when an agent actually curates a lesson library.
+  // it injects context-dependent content into every compile (plus up to two
+  // configured retrieval-model calls), which adds per-turn context churn.
+  // Enable explicitly only when an agent actually curates a lesson library.
   if (modules.retrieval && lessonsModule) {
-    const retrievalConfig = typeof modules.retrieval === 'object' ? modules.retrieval : {};
-    moduleInstances.push(new RetrievalModule({
-      membrane,
-      retrievalModel: retrievalConfig.model,
-      maxInjectedLessons: retrievalConfig.maxInjected,
-    }));
+    moduleInstances.push(new RetrievalModule(
+      buildRetrievalModuleConfig(membrane, modules.retrieval, recipe.agent.provider),
+    ));
   }
 
   // Gate config — core AF EventGate feature.

--- a/src/modules/retrieval-module.ts
+++ b/src/modules/retrieval-module.ts
@@ -24,6 +24,11 @@ import type {
 import type { Membrane, NormalizedRequest } from '@animalabs/membrane';
 import type { ContextInjection } from '@animalabs/context-manager';
 import type { LessonsModule, Lesson } from './lessons-module.js';
+import {
+  RetrievalTraceStore,
+  type RetrievalTraceListOptions,
+  type RetrievalTraceRun,
+} from './retrieval-trace.js';
 
 // ---------------------------------------------------------------------------
 // Configuration
@@ -33,6 +38,12 @@ export type RetrievalReasoningEffort = 'none' | 'minimal' | 'low' | 'medium' | '
 
 export interface RetrievalReasoningConfig {
   effort: RetrievalReasoningEffort;
+}
+
+interface RecentRetrievalContext {
+  text: string;
+  messageCount: number;
+  messageIds: string[];
 }
 
 export interface RetrievalModuleConfig {
@@ -75,6 +86,10 @@ export class RetrievalModule implements Module {
   private config: RetrievalModuleConfig;
   private lastContextHash = '';
   private cachedInjections: ContextInjection[] = [];
+  private cachedLessonIds: string[] = [];
+  private cachedLessons: Lesson[] = [];
+  private cachedSourceTraceId: number | undefined;
+  private readonly traceStore = new RetrievalTraceStore();
 
   constructor(config: RetrievalModuleConfig) {
     this.config = config;
@@ -101,50 +116,115 @@ export class RetrievalModule implements Module {
     return {};
   }
 
+  /** Recent retrieval runs, newest first. Exact conversation inputs are opt-in. */
+  getRetrievalTraces(options?: RetrievalTraceListOptions) {
+    return this.traceStore.list(options);
+  }
+
+  private beginTrace(agentName: string): RetrievalTraceRun | undefined {
+    try {
+      const providerParams = this.retrievalProviderParams();
+      return this.traceStore.begin({
+        agentName,
+        model: this.config.retrievalModel ?? 'claude-haiku-4-5-20251001',
+        ...(this.config.retrievalReasoning
+          ? { requestedReasoning: this.config.retrievalReasoning }
+          : {}),
+        ...(providerParams ? { providerParams } : {}),
+        minConfidence: this.config.minConfidence ?? 0.3,
+        maxCandidates: 20,
+        maxInjectedLessons: this.config.maxInjectedLessons ?? 5,
+      });
+    } catch {
+      return undefined;
+    }
+  }
+
   /**
    * Run the 3-step retrieval pipeline before each inference.
    */
-  async gatherContext(_agentName: string): Promise<ContextInjection[]> {
-    if (!this.ctx) return [];
+  async gatherContext(agentName: string): Promise<ContextInjection[]> {
+    const trace = this.beginTrace(agentName);
+    if (!this.ctx) {
+      trace?.finish('not-started');
+      return [];
+    }
 
-    // Get the LessonsModule to query
-    const lessonsModule = this.ctx.getModule<LessonsModule>('lessons');
-    if (!lessonsModule) return [];
+    let lessons: Lesson[];
+    let recentMessages: string;
+    let contextHash: string;
+    try {
+      // These lookups, eligibility checks, context rendering, and hashing are
+      // pre-existing throwing paths. Record their failure, then preserve the
+      // upstream rejection rather than applying the provider-stage fail-open.
+      const lessonsModule = this.ctx.getModule<LessonsModule>('lessons');
+      if (!lessonsModule) {
+        trace?.finish('no-lessons-module');
+        return [];
+      }
 
-    const lessons = lessonsModule.getLessons().filter(
-      l => !l.deprecated && l.confidence >= (this.config.minConfidence ?? 0.3)
-    );
-    if (lessons.length === 0) return [];
+      lessons = lessonsModule.getLessons().filter(
+        l => !l.deprecated && l.confidence >= (this.config.minConfidence ?? 0.3)
+      );
+      if (lessons.length === 0) {
+        trace?.finish('no-eligible-lessons');
+        return [];
+      }
 
-    // Get recent context for concept extraction
-    const recentMessages = this.getRecentContext();
-    if (!recentMessages) return [];
+      const recent = this.getRecentContext();
+      if (!recent) {
+        trace?.finish('no-recent-context');
+        return [];
+      }
+      recentMessages = recent.text;
 
-    // Check cache: if context hasn't changed, reuse cached results
-    const contextHash = this.hashContext(recentMessages);
-    if (contextHash === this.lastContextHash && this.cachedInjections.length > 0) {
-      return this.cachedInjections;
+      // Check cache: if context hasn't changed, reuse cached results.
+      contextHash = this.hashContext(recentMessages);
+      trace?.setContext(contextHash, recentMessages, recent.messageCount, recent.messageIds);
+      if (contextHash === this.lastContextHash && this.cachedInjections.length > 0) {
+        trace?.recordCacheHit(
+          this.cachedSourceTraceId,
+          this.cachedLessonIds,
+          this.cachedLessons,
+          this.cachedInjections,
+        );
+        trace?.finish('cache-hit');
+        return this.cachedInjections;
+      }
+    } catch (error) {
+      trace?.finish('error', error);
+      throw error;
     }
 
     try {
-      // Step 1: Flag concepts (Haiku call)
-      const concepts = await this.flagConcepts(recentMessages);
+      // Step 1: Flag concepts
+      const concepts = await this.flagConcepts(recentMessages, trace);
       if (concepts.length === 0) {
         this.lastContextHash = contextHash;
         this.cachedInjections = [];
+        this.cachedLessonIds = [];
+        this.cachedLessons = [];
+        this.cachedSourceTraceId = undefined;
+        trace?.finish('no-concepts');
         return [];
       }
 
       // Step 2: Mechanical query (keyword matching)
       const candidates = this.queryCandidates(concepts, lessons);
+      trace?.recordCandidates(concepts, candidates);
       if (candidates.length === 0) {
         this.lastContextHash = contextHash;
         this.cachedInjections = [];
+        this.cachedLessonIds = [];
+        this.cachedLessons = [];
+        this.cachedSourceTraceId = undefined;
+        trace?.finish('no-candidates');
         return [];
       }
 
-      // Step 3: Validate relevance (Haiku call)
-      const relevant = await this.validateRelevance(recentMessages, candidates);
+      // Step 3: Validate relevance
+      const relevant = await this.validateRelevance(recentMessages, candidates, trace);
+      trace?.recordRelevant(relevant);
 
       // Build injection
       const maxLessons = this.config.maxInjectedLessons ?? 5;
@@ -153,6 +233,10 @@ export class RetrievalModule implements Module {
       if (injected.length === 0) {
         this.lastContextHash = contextHash;
         this.cachedInjections = [];
+        this.cachedLessonIds = [];
+        this.cachedLessons = [];
+        this.cachedSourceTraceId = undefined;
+        trace?.finish('no-relevant-lessons');
         return [];
       }
 
@@ -172,9 +256,15 @@ export class RetrievalModule implements Module {
 
       this.lastContextHash = contextHash;
       this.cachedInjections = injections;
+      this.cachedLessons = this.safeLessonSnapshots(injected);
+      this.cachedLessonIds = this.safeLessonIds(this.cachedLessons);
+      this.cachedSourceTraceId = trace?.id;
+      trace?.recordInjection(injected, injections);
+      trace?.finish('injected');
       return injections;
     } catch (err) {
       // Fail open — don't block inference if retrieval fails
+      trace?.finish('error', err);
       console.error('RetrievalModule: retrieval failed:', err);
       return [];
     }
@@ -194,15 +284,19 @@ export class RetrievalModule implements Module {
   /**
    * Step 1: Use the configured retrieval model to identify concepts that might benefit from background knowledge.
    */
-  private async flagConcepts(recentContext: string): Promise<string[]> {
+  private async flagConcepts(
+    recentContext: string,
+    trace?: RetrievalTraceRun,
+  ): Promise<string[]> {
     const model = this.config.retrievalModel ?? 'claude-haiku-4-5-20251001';
     const providerParams = this.retrievalProviderParams();
+    const input = `Recent conversation:\n${recentContext}`;
 
     const request: NormalizedRequest = {
       messages: [
         {
           participant: 'user',
-          content: [{ type: 'text', text: `Recent conversation:\n${recentContext}` }],
+          content: [{ type: 'text', text: input }],
         },
       ],
       system: CONCEPT_FLAG_PROMPT,
@@ -210,7 +304,14 @@ export class RetrievalModule implements Module {
       ...(providerParams ? { providerParams } : {}),
     };
 
-    const response = await this.config.membrane.complete(request);
+    trace?.startConceptExtraction(CONCEPT_FLAG_PROMPT, input);
+    let response;
+    try {
+      response = await this.config.membrane.complete(request);
+    } catch (error) {
+      trace?.recordStageError('conceptExtraction', error);
+      throw error;
+    }
     const text = response.content
       .filter((b): b is { type: 'text'; text: string } => b.type === 'text')
       .map(b => b.text)
@@ -219,16 +320,28 @@ export class RetrievalModule implements Module {
     try {
       const parsed = JSON.parse(text);
       if (Array.isArray(parsed)) {
-        return parsed.filter((s): s is string => typeof s === 'string');
+        const concepts = parsed.filter((value): value is string => typeof value === 'string');
+        trace?.finishConceptExtraction(text, concepts, 'json', response.content);
+        return concepts;
       }
+      trace?.finishConceptExtraction(text, [], 'invalid', response.content);
     } catch {
-      // Try to extract from markdown code block
+      // Try to extract an array from a prose/markdown wrapper.
       const match = text.match(/\[([^\]]*)\]/);
       if (match) {
         try {
-          return JSON.parse(`[${match[1]}]`);
+          const parsed = JSON.parse(`[${match[1]}]`);
+          if (Array.isArray(parsed)) {
+            const traceValues = parsed.filter((value): value is string => typeof value === 'string');
+            trace?.finishConceptExtraction(text, traceValues, 'array-extraction', response.content);
+            // Preserve the historical malformed-wrapper behavior exactly: mixed
+            // arrays proceed to queryCandidates(), which then fails open rather
+            // than silently becoming a different, partially valid concept set.
+            return parsed as string[];
+          }
         } catch { /* fall through */ }
       }
+      trace?.finishConceptExtraction(text, [], 'invalid', response.content);
     }
     return [];
   }
@@ -269,9 +382,14 @@ export class RetrievalModule implements Module {
   /**
    * Step 3: Use the configured retrieval model to validate which candidates are actually relevant.
    */
-  private async validateRelevance(recentContext: string, candidates: Lesson[]): Promise<Lesson[]> {
+  private async validateRelevance(
+    recentContext: string,
+    candidates: Lesson[],
+    trace?: RetrievalTraceRun,
+  ): Promise<Lesson[]> {
     if (candidates.length <= 3) {
-      // If only a few candidates, skip validation — they're probably all relevant
+      // If only a few candidates, skip validation — they're probably all relevant.
+      trace?.recordRelevanceSkipped('three-or-fewer-candidates');
       return candidates;
     }
 
@@ -281,12 +399,13 @@ export class RetrievalModule implements Module {
     const candidateList = candidates.map(l =>
       `[${l.id}] (${l.confidence.toFixed(2)}) ${l.content}`
     ).join('\n');
+    const input = `Current conversation:\n${recentContext}\n\nCandidate lessons:\n${candidateList}`;
 
     const request: NormalizedRequest = {
       messages: [
         {
           participant: 'user',
-          content: [{ type: 'text', text: `Current conversation:\n${recentContext}\n\nCandidate lessons:\n${candidateList}` }],
+          content: [{ type: 'text', text: input }],
         },
       ],
       system: RELEVANCE_VALIDATION_PROMPT,
@@ -294,7 +413,14 @@ export class RetrievalModule implements Module {
       ...(providerParams ? { providerParams } : {}),
     };
 
-    const response = await this.config.membrane.complete(request);
+    trace?.startRelevance(RELEVANCE_VALIDATION_PROMPT, input);
+    let response;
+    try {
+      response = await this.config.membrane.complete(request);
+    } catch (error) {
+      trace?.recordStageError('relevance', error);
+      throw error;
+    }
     const text = response.content
       .filter((b): b is { type: 'text'; text: string } => b.type === 'text')
       .map(b => b.text)
@@ -303,38 +429,91 @@ export class RetrievalModule implements Module {
     try {
       const parsed = JSON.parse(text);
       if (Array.isArray(parsed)) {
-        const relevantIds = new Set(parsed.filter((s): s is string => typeof s === 'string'));
+        const parsedIds = parsed.filter((value): value is string => typeof value === 'string');
+        trace?.finishRelevance(text, parsedIds, 'json', response.content);
+        const relevantIds = new Set(parsedIds);
         return candidates.filter(l => relevantIds.has(l.id));
       }
     } catch {
-      // On parse failure, return top 5 by confidence (fail open)
-      return candidates.slice(0, 5);
+      // Fall through to confidence-ordered fallback.
     }
-    return candidates.slice(0, 5);
+
+    const fallback = candidates.slice(0, 5);
+    trace?.finishRelevance(text, [], 'fallback', response.content);
+    return fallback;
   }
 
   // =========================================================================
   // Helpers
   // =========================================================================
 
-  private getRecentContext(): string | null {
+  private getRecentContext(): RecentRetrievalContext | null {
     if (!this.ctx) return null;
 
-    // Get the last few messages from the conversation
+    // Get the last few messages from the conversation.
     const { messages } = this.ctx.queryMessages({});
     if (messages.length === 0) return null;
 
-    // Take the last 10 messages for context
+    // Take the last 10 messages for context.
     const recent = messages.slice(-10);
-    return recent
+    const text = recent
       .map(m => {
-        const text = m.content
+        const messageText = m.content
           .filter((b): b is { type: 'text'; text: string } => b.type === 'text')
           .map(b => b.text)
           .join('\n');
-        return `${m.participant}: ${text}`;
+        return `${m.participant}: ${messageText}`;
       })
       .join('\n\n');
+    const messageIds = recent.flatMap(message => {
+      try {
+        const candidate = (message as unknown as { id?: unknown }).id;
+        return typeof candidate === 'string' || typeof candidate === 'number'
+          ? [String(candidate)]
+          : [];
+      } catch {
+        // Trace-only metadata must never alter retrieval behavior.
+        return [];
+      }
+    });
+
+    return { text, messageCount: recent.length, messageIds };
+  }
+
+  private safeLessonIds(lessons: Lesson[]): string[] {
+    const ids: string[] = [];
+    for (const lesson of lessons) {
+      try {
+        if (typeof lesson.id === 'string') ids.push(lesson.id);
+      } catch {
+        // Cache provenance is observability metadata; omit unreadable IDs.
+      }
+    }
+    return ids;
+  }
+
+  private safeLessonSnapshots(lessons: Lesson[]): Lesson[] {
+    const snapshots: Lesson[] = [];
+    for (const item of lessons) {
+      try {
+        snapshots.push({
+          id: item.id,
+          content: item.content,
+          confidence: item.confidence,
+          tags: [...item.tags],
+          evidence: [...item.evidence],
+          created: item.created,
+          updated: item.updated,
+          deprecated: item.deprecated,
+          ...(item.deprecationReason !== undefined
+            ? { deprecationReason: item.deprecationReason }
+            : {}),
+        });
+      } catch {
+        // Trace-only lesson snapshots must not alter retrieval behavior.
+      }
+    }
+    return snapshots;
   }
 
   private hashContext(text: string): string {

--- a/src/modules/retrieval-module.ts
+++ b/src/modules/retrieval-module.ts
@@ -2,12 +2,12 @@
  * RetrievalModule — LLM-as-retriever for semantic memory.
  *
  * Three-step retrieval pipeline running in gatherContext():
- *   1. Flag concepts (Haiku): identify concepts being discussed that might
- *      benefit from background knowledge
+ *   1. Flag concepts: identify concepts being discussed that might benefit
+ *      from background knowledge
  *   2. Mechanical query: keyword-match against LessonsModule
- *   3. Validate relevance (Haiku): filter to actually relevant lessons
+ *   3. Validate relevance: filter to actually relevant lessons
  *
- * Steps 1 and 3 use cheap Haiku calls (~$0.001 each).
+ * Steps 1 and 3 use the configured retrieval model and optional reasoning.
  * Results are cached to avoid redundant calls on unchanged context.
  */
 
@@ -29,11 +29,19 @@ import type { LessonsModule, Lesson } from './lessons-module.js';
 // Configuration
 // ---------------------------------------------------------------------------
 
+export type RetrievalReasoningEffort = 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max';
+
+export interface RetrievalReasoningConfig {
+  effort: RetrievalReasoningEffort;
+}
+
 export interface RetrievalModuleConfig {
-  /** Membrane instance for Haiku calls */
+  /** Membrane instance for retrieval calls */
   membrane: Membrane;
   /** Model to use for retrieval calls (default: claude-haiku-4-5-20251001) */
   retrievalModel?: string;
+  /** Optional OpenAI reasoning effort, applied to both retrieval LLM stages. */
+  retrievalReasoning?: RetrievalReasoningConfig;
   /** Max lessons to inject (default: 5) */
   maxInjectedLessons?: number;
   /** Minimum lesson confidence for injection (default: 0.3) */
@@ -176,11 +184,19 @@ export class RetrievalModule implements Module {
   // Pipeline Steps
   // =========================================================================
 
+  /** Build OpenAI request parameters for configured retrieval reasoning effort. */
+  private retrievalProviderParams(): Record<string, unknown> | undefined {
+    const reasoning = this.config.retrievalReasoning;
+    if (!reasoning) return undefined;
+    return { reasoning: { effort: reasoning.effort } };
+  }
+
   /**
-   * Step 1: Use Haiku to identify concepts that might benefit from background knowledge.
+   * Step 1: Use the configured retrieval model to identify concepts that might benefit from background knowledge.
    */
   private async flagConcepts(recentContext: string): Promise<string[]> {
     const model = this.config.retrievalModel ?? 'claude-haiku-4-5-20251001';
+    const providerParams = this.retrievalProviderParams();
 
     const request: NormalizedRequest = {
       messages: [
@@ -191,6 +207,7 @@ export class RetrievalModule implements Module {
       ],
       system: CONCEPT_FLAG_PROMPT,
       config: { model, maxTokens: 500, temperature: 0 },
+      ...(providerParams ? { providerParams } : {}),
     };
 
     const response = await this.config.membrane.complete(request);
@@ -250,7 +267,7 @@ export class RetrievalModule implements Module {
   }
 
   /**
-   * Step 3: Use Haiku to validate which candidates are actually relevant.
+   * Step 3: Use the configured retrieval model to validate which candidates are actually relevant.
    */
   private async validateRelevance(recentContext: string, candidates: Lesson[]): Promise<Lesson[]> {
     if (candidates.length <= 3) {
@@ -259,6 +276,7 @@ export class RetrievalModule implements Module {
     }
 
     const model = this.config.retrievalModel ?? 'claude-haiku-4-5-20251001';
+    const providerParams = this.retrievalProviderParams();
 
     const candidateList = candidates.map(l =>
       `[${l.id}] (${l.confidence.toFixed(2)}) ${l.content}`
@@ -273,6 +291,7 @@ export class RetrievalModule implements Module {
       ],
       system: RELEVANCE_VALIDATION_PROMPT,
       config: { model, maxTokens: 500, temperature: 0 },
+      ...(providerParams ? { providerParams } : {}),
     };
 
     const response = await this.config.membrane.complete(request);

--- a/src/modules/retrieval-trace-page.ts
+++ b/src/modules/retrieval-trace-page.ts
@@ -1,0 +1,73 @@
+/** Minimal dependency-free viewer for the authenticated retrieval trace endpoint. */
+export const RETRIEVAL_TRACE_PAGE_HTML = String.raw`<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Retrieval traces</title>
+<style>
+  :root { color-scheme: dark; font: 15px/1.45 ui-monospace, SFMono-Regular, Menlo, monospace; }
+  body { max-width: 1100px; margin: 2rem auto; padding: 0 1rem; background: #0c0e14; color: #d8deea; }
+  header { display: flex; gap: 1rem; align-items: center; flex-wrap: wrap; margin-bottom: 1rem; }
+  h1 { font: 600 1.4rem/1.2 system-ui, sans-serif; margin: 0 auto 0 0; }
+  button, label { font: inherit; }
+  button { padding: .35rem .7rem; background: #1c2434; color: inherit; border: 1px solid #3a4863; border-radius: .35rem; }
+  .note { color: #9ca9bd; margin: .5rem 0 1.25rem; }
+  details { border: 1px solid #283247; border-radius: .45rem; margin: .65rem 0; background: #111722; }
+  summary { cursor: pointer; padding: .7rem .85rem; color: #e7bf76; }
+  pre { white-space: pre-wrap; overflow-wrap: anywhere; margin: 0; padding: .85rem; border-top: 1px solid #283247; color: #c8d4e8; }
+  .error { color: #ff8e8e; }
+</style>
+</head>
+<body>
+<header>
+  <h1>Retrieval traces</h1>
+  <label><input id="inputs" type="checkbox"> include exact conversation inputs</label>
+  <button id="refresh" type="button">refresh</button>
+</header>
+<p class="note">Newest first. In-memory only; reset on Host restart. “Raw output” is selector text returned to the application, not hidden chain-of-thought.</p>
+<div id="status" class="note"></div>
+<main id="traces"></main>
+<script>
+const root = document.getElementById('traces');
+const status = document.getElementById('status');
+const inputs = document.getElementById('inputs');
+
+function summary(trace) {
+  const selected = trace.injected && trace.injected.lessonIds ? trace.injected.lessonIds.join(', ') : '';
+  return '#' + trace.id + '  ' + (trace.outcome || 'running') + '  ' + trace.startedAt +
+    (selected ? '  selected: ' + selected : '');
+}
+
+async function load() {
+  status.textContent = 'loading…';
+  root.replaceChildren();
+  try {
+    const url = '/debug/retrieval?limit=100&includeInputs=' + (inputs.checked ? '1' : '0');
+    const response = await fetch(url, { credentials: 'same-origin' });
+    const payload = await response.json();
+    if (!response.ok) throw new Error(payload.error || ('HTTP ' + response.status));
+    status.textContent = payload.enabled
+      ? payload.traces.length + ' retained run(s)'
+      : 'retrieval module is not enabled';
+    for (const trace of payload.traces) {
+      const details = document.createElement('details');
+      const label = document.createElement('summary');
+      const pre = document.createElement('pre');
+      label.textContent = summary(trace);
+      pre.textContent = JSON.stringify(trace, null, 2);
+      details.append(label, pre);
+      root.append(details);
+    }
+  } catch (error) {
+    status.textContent = String(error);
+    status.className = 'error';
+  }
+}
+
+document.getElementById('refresh').addEventListener('click', load);
+inputs.addEventListener('change', load);
+load();
+</script>
+</body>
+</html>`;

--- a/src/modules/retrieval-trace-page.ts
+++ b/src/modules/retrieval-trace-page.ts
@@ -1,22 +1,59 @@
-/** Minimal dependency-free viewer for the authenticated retrieval trace endpoint. */
-export const RETRIEVAL_TRACE_PAGE_HTML = String.raw`<!doctype html>
+/** Dependency-free operator viewer for the authenticated retrieval trace endpoint. */
+export const RETRIEVAL_TRACE_PAGE_HTML = `<!doctype html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Retrieval traces</title>
 <style>
-  :root { color-scheme: dark; font: 15px/1.45 ui-monospace, SFMono-Regular, Menlo, monospace; }
-  body { max-width: 1100px; margin: 2rem auto; padding: 0 1rem; background: #0c0e14; color: #d8deea; }
+  :root { color-scheme: dark; font: 15px/1.5 Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+  * { box-sizing: border-box; }
+  body { max-width: 1240px; margin: 2rem auto; padding: 0 1rem 4rem; background: #0c0e14; color: #d8deea; }
   header { display: flex; gap: 1rem; align-items: center; flex-wrap: wrap; margin-bottom: 1rem; }
-  h1 { font: 600 1.4rem/1.2 system-ui, sans-serif; margin: 0 auto 0 0; }
+  h1 { font-size: 1.45rem; line-height: 1.2; margin: 0 auto 0 0; }
+  h2 { font-size: 1rem; margin: 0; }
   button, label { font: inherit; }
-  button { padding: .35rem .7rem; background: #1c2434; color: inherit; border: 1px solid #3a4863; border-radius: .35rem; }
+  button { cursor: pointer; padding: .42rem .78rem; background: #1c2434; color: inherit; border: 1px solid #3a4863; border-radius: .45rem; }
+  button:hover { background: #263249; }
+  code, pre, .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
   .note { color: #9ca9bd; margin: .5rem 0 1.25rem; }
-  details { border: 1px solid #283247; border-radius: .45rem; margin: .65rem 0; background: #111722; }
-  summary { cursor: pointer; padding: .7rem .85rem; color: #e7bf76; }
-  pre { white-space: pre-wrap; overflow-wrap: anywhere; margin: 0; padding: .85rem; border-top: 1px solid #283247; color: #c8d4e8; }
-  .error { color: #ff8e8e; }
+  .error { color: #ff9b9b; }
+  .trace { border: 1px solid #283247; border-radius: .65rem; margin: .8rem 0; background: #111722; overflow: hidden; }
+  .trace > summary { cursor: pointer; padding: .8rem .95rem; color: #e7bf76; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+  .trace[open] > summary { border-bottom: 1px solid #283247; }
+  .trace-body { padding: 1rem; display: grid; gap: 1.15rem; }
+  .trace-meta { display: flex; flex-wrap: wrap; gap: .45rem .75rem; color: #aebbd0; }
+  .section { display: grid; gap: .65rem; }
+  .section-heading { display: flex; align-items: baseline; gap: .55rem; }
+  .count { color: #8fa0b9; font-size: .88rem; }
+  .lesson-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(100%, 330px), 1fr)); gap: .65rem; }
+  .lesson-card { border: 1px solid #33415b; border-radius: .55rem; background: #151d2a; padding: .8rem; min-width: 0; }
+  .lesson-card.selected { border-color: #4f8e78; background: #14231f; box-shadow: inset 3px 0 #63b392; }
+  .lesson-head { display: flex; align-items: center; gap: .5rem; flex-wrap: wrap; margin-bottom: .55rem; }
+  .lesson-id { color: #e7bf76; font-weight: 700; }
+  .confidence { color: #aebbd0; margin-left: auto; }
+  .lesson-content { margin: .45rem 0 .7rem; white-space: pre-wrap; overflow-wrap: anywhere; }
+  .chips { display: flex; flex-wrap: wrap; gap: .3rem; }
+  .chip, .badge { display: inline-block; border: 1px solid #3a4863; border-radius: 999px; padding: .12rem .45rem; color: #b9c7dc; background: #111722; font-size: .78rem; }
+  .badge.selected { color: #a9e6cd; border-color: #4f8e78; background: #183027; font-weight: 700; }
+  .candidate-list { display: grid; gap: .5rem; }
+  .candidate { border: 1px solid #2f3b52; border-radius: .5rem; background: #131a26; overflow: hidden; }
+  .candidate.selected { border-color: #4f8e78; }
+  .candidate > summary { cursor: pointer; padding: .7rem .8rem; display: grid; grid-template-columns: auto auto 1fr auto; gap: .5rem; align-items: baseline; }
+  .candidate-preview { color: #b7c2d3; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
+  .candidate-body { border-top: 1px solid #2f3b52; padding: .8rem; }
+  .matches { display: grid; gap: .35rem; margin-top: .7rem; }
+  .match { color: #9facc0; font-size: .85rem; padding-left: .65rem; border-left: 2px solid #34445f; overflow-wrap: anywhere; }
+  .decision { display: grid; gap: .5rem; border: 1px solid #283247; border-radius: .5rem; padding: .75rem; background: #0f141e; }
+  .empty { color: #8998ae; border: 1px dashed #344158; border-radius: .5rem; padding: .75rem; }
+  .raw { border: 1px solid #283247; border-radius: .5rem; background: #0f141e; }
+  .raw > summary { cursor: pointer; padding: .65rem .8rem; color: #9facc0; }
+  pre { white-space: pre-wrap; overflow-wrap: anywhere; margin: 0; padding: .85rem; border-top: 1px solid #283247; color: #c8d4e8; max-height: 65vh; overflow: auto; }
+  @media (max-width: 700px) {
+    body { margin-top: 1rem; }
+    .candidate > summary { grid-template-columns: auto 1fr auto; }
+    .candidate-preview { grid-column: 1 / -1; }
+  }
 </style>
 </head>
 <body>
@@ -25,7 +62,7 @@ export const RETRIEVAL_TRACE_PAGE_HTML = String.raw`<!doctype html>
   <label><input id="inputs" type="checkbox"> include exact conversation inputs</label>
   <button id="refresh" type="button">refresh</button>
 </header>
-<p class="note">Newest first. In-memory only; reset on Host restart. “Raw output” is selector text returned to the application, not hidden chain-of-thought.</p>
+<p class="note">Newest first. In-memory only; reset on Host restart. "Raw output" is selector text returned to the application, not hidden chain-of-thought.</p>
 <div id="status" class="note"></div>
 <main id="traces"></main>
 <script>
@@ -33,14 +70,164 @@ const root = document.getElementById('traces');
 const status = document.getElementById('status');
 const inputs = document.getElementById('inputs');
 
-function summary(trace) {
-  const selected = trace.injected && trace.injected.lessonIds ? trace.injected.lessonIds.join(', ') : '';
-  return '#' + trace.id + '  ' + (trace.outcome || 'running') + '  ' + trace.startedAt +
-    (selected ? '  selected: ' + selected : '');
+function element(tag, className, text) {
+  const node = document.createElement(tag);
+  if (className) node.className = className;
+  if (text !== undefined) node.textContent = String(text);
+  return node;
+}
+
+function percentage(value) {
+  return Number.isFinite(value) ? Math.round(value * 100) + '%' : 'unknown';
+}
+
+function localTime(value) {
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? String(value) : date.toLocaleString();
+}
+
+function appendChips(parent, values) {
+  const chips = element('div', 'chips');
+  for (const value of values || []) chips.append(element('span', 'chip', value));
+  parent.append(chips);
+}
+
+function lessonCard(lesson, selected) {
+  const card = element('article', 'lesson-card' + (selected ? ' selected' : ''));
+  const head = element('div', 'lesson-head');
+  head.append(element('code', 'lesson-id', lesson.id || 'unknown lesson'));
+  if (selected) head.append(element('span', 'badge selected', 'SELECTED'));
+  head.append(element('span', 'confidence', percentage(lesson.confidence) + ' confidence'));
+  card.append(head, element('p', 'lesson-content', lesson.content || '(no lesson content recorded)'));
+  appendChips(card, lesson.tags);
+  return card;
+}
+
+function matchText(match) {
+  const location = match.field === 'tag' ? 'tag ' + (match.tag || '') : 'content';
+  return match.concept + ' -> ' + location + ' matched "' + match.keyword + '"';
+}
+
+function candidateCard(candidate, selectedIds) {
+  const selected = selectedIds.has(candidate.id);
+  const details = element('details', 'candidate' + (selected ? ' selected' : ''));
+  if (selected) details.open = true;
+  const summary = element('summary');
+  summary.append(element('code', 'lesson-id', candidate.id));
+  if (selected) summary.append(element('span', 'badge selected', 'SELECTED'));
+  summary.append(element('span', 'candidate-preview', candidate.content || '(no content)'));
+  summary.append(element('span', 'confidence', percentage(candidate.confidence)));
+
+  const body = element('div', 'candidate-body');
+  body.append(element('p', 'lesson-content', candidate.content || '(no lesson content recorded)'));
+  appendChips(body, candidate.tags);
+  const matches = element('div', 'matches');
+  const seen = new Set();
+  for (const match of candidate.matches || []) {
+    const text = matchText(match);
+    if (!seen.has(text)) {
+      seen.add(text);
+      matches.append(element('div', 'match', text));
+    }
+  }
+  if (matches.childElementCount) body.append(matches);
+  details.append(summary, body);
+  return details;
+}
+
+function renderSelected(trace, body) {
+  const section = element('section', 'section');
+  const lessons = trace.injected && Array.isArray(trace.injected.lessons) ? trace.injected.lessons : [];
+  const ids = trace.injected && Array.isArray(trace.injected.lessonIds) ? trace.injected.lessonIds : [];
+  const heading = element('div', 'section-heading');
+  heading.append(element('h2', '', 'Selected lessons'), element('span', 'count', lessons.length + ' injected'));
+  section.append(heading);
+  if (lessons.length) {
+    const grid = element('div', 'lesson-grid');
+    for (const lesson of lessons) grid.append(lessonCard(lesson, true));
+    section.append(grid);
+  } else if (ids.length) {
+    const fallback = element('div', 'empty', 'Selected IDs: ' + ids.join(', ') + ' (structured snapshots unavailable)');
+    section.append(fallback);
+  } else {
+    section.append(element('div', 'empty', 'No lessons were injected for this run.'));
+  }
+  body.append(section);
+}
+
+function renderCandidates(trace, body) {
+  const section = element('section', 'section');
+  const candidates = Array.isArray(trace.candidates) ? trace.candidates : [];
+  const selectedIds = new Set(trace.injected && Array.isArray(trace.injected.lessonIds) ? trace.injected.lessonIds : []);
+  const heading = element('div', 'section-heading');
+  heading.append(element('h2', '', 'Candidate lessons'), element('span', 'count', candidates.length + ' mechanically matched'));
+  section.append(heading);
+  if (candidates.length) {
+    const list = element('div', 'candidate-list');
+    for (const candidate of candidates) list.append(candidateCard(candidate, selectedIds));
+    section.append(list);
+  } else {
+    section.append(element('div', 'empty', 'No candidate lessons matched this run.'));
+  }
+  body.append(section);
+}
+
+function renderDecision(trace, body) {
+  const decision = element('section', 'decision');
+  decision.append(element('h2', '', 'Decision details'));
+  const concepts = trace.conceptExtraction && Array.isArray(trace.conceptExtraction.parsedValues)
+    ? trace.conceptExtraction.parsedValues : [];
+  const relevant = Array.isArray(trace.relevantLessonIds) ? trace.relevantLessonIds : [];
+  const conceptLine = element('div');
+  conceptLine.append(element('strong', '', 'Concepts: '));
+  conceptLine.append(document.createTextNode(concepts.length ? concepts.join(', ') : 'none'));
+  const relevanceLine = element('div');
+  relevanceLine.append(element('strong', '', 'Relevant IDs: '));
+  relevanceLine.append(document.createTextNode(relevant.length ? relevant.join(', ') : 'none'));
+  const injectionLine = element('div');
+  injectionLine.append(element('strong', '', 'Injection: '));
+  const namespace = trace.injected && trace.injected.namespace ? trace.injected.namespace : 'none';
+  const position = trace.injected && trace.injected.position ? trace.injected.position : 'none';
+  injectionLine.append(document.createTextNode(namespace + ' / ' + position));
+  decision.append(conceptLine, relevanceLine, injectionLine);
+  body.append(decision);
+}
+
+function traceSummary(trace) {
+  const selected = trace.injected && Array.isArray(trace.injected.lessonIds) ? trace.injected.lessonIds : [];
+  return '#' + trace.id + '  ' + (trace.agentName || 'unknown agent') + '  ' +
+    (trace.outcome || 'running') + '  ' + localTime(trace.startedAt) +
+    '  selected: ' + selected.length;
+}
+
+function renderTrace(trace, index) {
+  const details = element('details', 'trace');
+  if (index === 0) details.open = true;
+  details.append(element('summary', '', traceSummary(trace)));
+  const body = element('div', 'trace-body');
+  const meta = element('div', 'trace-meta');
+  const reasoning = trace.config && trace.config.requestedReasoning;
+  meta.append(
+    element('span', '', 'agent: ' + (trace.agentName || 'unknown')),
+    element('span', '', 'model: ' + ((trace.config && trace.config.model) || 'unknown')),
+    element('span', '', 'reasoning effort: ' + (reasoning ? reasoning.effort : 'default')),
+    element('span', '', 'cache: ' + (trace.cache && trace.cache.hit ? 'hit' : 'miss')),
+    element('span', '', 'duration: ' + (Number.isFinite(trace.durationMs) ? trace.durationMs + ' ms' : 'running'))
+  );
+  body.append(meta);
+  renderSelected(trace, body);
+  renderCandidates(trace, body);
+  renderDecision(trace, body);
+  const raw = element('details', 'raw');
+  raw.append(element('summary', '', 'Raw JSON (diagnostic)'), element('pre', '', JSON.stringify(trace, null, 2)));
+  body.append(raw);
+  details.append(body);
+  return details;
 }
 
 async function load() {
-  status.textContent = 'loading…';
+  status.className = 'note';
+  status.textContent = 'loading...';
   root.replaceChildren();
   try {
     const url = '/debug/retrieval?limit=100&includeInputs=' + (inputs.checked ? '1' : '0');
@@ -50,15 +237,9 @@ async function load() {
     status.textContent = payload.enabled
       ? payload.traces.length + ' retained run(s)'
       : 'retrieval module is not enabled';
-    for (const trace of payload.traces) {
-      const details = document.createElement('details');
-      const label = document.createElement('summary');
-      const pre = document.createElement('pre');
-      label.textContent = summary(trace);
-      pre.textContent = JSON.stringify(trace, null, 2);
-      details.append(label, pre);
-      root.append(details);
-    }
+    payload.traces.forEach(function(trace, index) {
+      root.append(renderTrace(trace, index));
+    });
   } catch (error) {
     status.textContent = String(error);
     status.className = 'error';

--- a/src/modules/retrieval-trace.ts
+++ b/src/modules/retrieval-trace.ts
@@ -1,0 +1,904 @@
+import type { ContextInjection } from '@animalabs/context-manager';
+import type { Lesson } from './lessons-module.js';
+import type { RetrievalReasoningConfig } from './retrieval-module.js';
+
+export const RETRIEVAL_TRACE_SCHEMA_VERSION = 1;
+export const DEFAULT_RETRIEVAL_TRACE_CAPACITY = 100;
+export const DEFAULT_RETRIEVAL_TRACE_BYTE_BUDGET = 8 * 1024 * 1024;
+
+const MIN_RETRIEVAL_TRACE_BYTE_BUDGET = 1024;
+const PROVIDER_SERIALIZATION_LIMITS = {
+  maxDepth: 8,
+  maxNodes: 512,
+  maxArrayItems: 64,
+  maxObjectKeys: 64,
+  maxStringBytes: 16 * 1024,
+  maxTotalStringBytes: 128 * 1024,
+} as const;
+
+export type RetrievalTraceOutcome =
+  | 'not-started'
+  | 'no-lessons-module'
+  | 'no-eligible-lessons'
+  | 'no-recent-context'
+  | 'cache-hit'
+  | 'no-concepts'
+  | 'no-candidates'
+  | 'no-relevant-lessons'
+  | 'injected'
+  | 'error';
+
+export interface RetrievalLessonTrace {
+  id: string;
+  content: string;
+  confidence: number;
+  tags: string[];
+  evidence: string[];
+  created: number;
+  updated: number;
+  deprecated: boolean;
+  deprecationReason?: string;
+}
+
+export interface RetrievalCandidateMatch {
+  concept: string;
+  keyword: string;
+  field: 'content' | 'tag';
+  tag?: string;
+}
+
+export interface RetrievalCandidateTrace extends RetrievalLessonTrace {
+  matches: RetrievalCandidateMatch[];
+}
+
+export interface RetrievalStageTrace {
+  systemPrompt: string;
+  /** Exact user input. Omitted from default HTTP views. */
+  input?: string;
+  rawOutput?: string;
+  /** Provider-returned content blocks, including any opaque/redacted reasoning blocks. */
+  responseContent?: unknown[];
+  responseContentTruncation?: RetrievalProviderTruncation;
+  parsedValues?: string[];
+  parseMode?: 'json' | 'array-extraction' | 'fallback' | 'invalid';
+  error?: string;
+}
+
+export type RetrievalProviderTruncationReason =
+  | 'max-depth'
+  | 'max-nodes'
+  | 'max-array-items'
+  | 'max-object-keys'
+  | 'max-string-bytes'
+  | 'max-total-string-bytes'
+  | 'non-json-value'
+  | 'serialization-error';
+
+export interface RetrievalProviderTruncation {
+  truncated: true;
+  reasons: RetrievalProviderTruncationReason[];
+  retainedNodes: number;
+  retainedStringBytes: number;
+  limits: typeof PROVIDER_SERIALIZATION_LIMITS;
+}
+
+export interface RetrievalTrace {
+  schemaVersion: 1;
+  id: number;
+  startedAt: string;
+  completedAt?: string;
+  durationMs?: number;
+  agentName: string;
+  config: {
+    model: string;
+    requestedReasoning?: RetrievalReasoningConfig;
+    providerParams?: Record<string, unknown>;
+    providerParamsTruncation?: RetrievalProviderTruncation;
+    minConfidence: number;
+    maxCandidates: number;
+    maxInjectedLessons: number;
+  };
+  context?: {
+    hash: string;
+    messageCount: number;
+    messageIds: string[];
+    /** Rendered recent conversation. Omitted from default HTTP views. */
+    input?: string;
+  };
+  cache: {
+    hit: boolean;
+    sourceTraceId?: number;
+    sourceTraceEvicted?: boolean;
+    sourceTraceTruncated?: boolean;
+  };
+  conceptExtraction?: RetrievalStageTrace;
+  candidates: RetrievalCandidateTrace[];
+  relevance?: RetrievalStageTrace & {
+    ran: boolean;
+    skippedReason?: string;
+  };
+  relevantLessonIds: string[];
+  injected: {
+    lessonIds: string[];
+    lessons: RetrievalLessonTrace[];
+    namespace?: string;
+    position?: ContextInjection['position'];
+    block?: string;
+  };
+  outcome?: RetrievalTraceOutcome;
+  error?: string;
+  truncation?: {
+    truncated: true;
+    kind: 'tombstone';
+    reason: 'trace-exceeded-byte-budget';
+    originalBytes: number;
+    byteBudget: number;
+  };
+}
+
+export interface RetrievalTraceListOptions {
+  limit?: number;
+  includeInputs?: boolean;
+}
+
+/** Structural interface used by WebUiModule to avoid importing RetrievalModule. */
+export interface RetrievalTraceSource {
+  getRetrievalTraces(options?: RetrievalTraceListOptions): RetrievalTrace[];
+}
+
+export interface RetrievalTraceBeginOptions {
+  agentName: string;
+  model: string;
+  requestedReasoning?: RetrievalReasoningConfig;
+  providerParams?: Record<string, unknown>;
+  minConfidence: number;
+  maxCandidates: number;
+  maxInjectedLessons: number;
+}
+
+export interface RetrievalTraceStoreOptions {
+  capacity?: number;
+  byteBudget?: number;
+}
+
+function errorMessage(error: unknown): string {
+  try {
+    const value = error instanceof Error ? error.message : error;
+    return truncateUtf8(
+      typeof value === 'string' ? value : String(value),
+      PROVIDER_SERIALIZATION_LIMITS.maxStringBytes,
+    );
+  } catch {
+    return 'unavailable error';
+  }
+}
+
+interface ProviderSerializationState {
+  nodes: number;
+  stringBytes: number;
+  reasons: Set<RetrievalProviderTruncationReason>;
+}
+
+const textEncoder = new TextEncoder();
+const arrayBufferByteLengthGetter = Object.getOwnPropertyDescriptor(
+  ArrayBuffer.prototype,
+  'byteLength',
+)?.get;
+const typedArrayByteLengthGetter = Object.getOwnPropertyDescriptor(
+  Object.getPrototypeOf(Uint8Array.prototype) as object,
+  'byteLength',
+)?.get;
+const dataViewByteLengthGetter = Object.getOwnPropertyDescriptor(
+  DataView.prototype,
+  'byteLength',
+)?.get;
+const mapSizeGetter = Object.getOwnPropertyDescriptor(Map.prototype, 'size')?.get;
+const setSizeGetter = Object.getOwnPropertyDescriptor(Set.prototype, 'size')?.get;
+const bigIntToString = BigInt.prototype.toString;
+const dateToISOString = Date.prototype.toISOString;
+
+function utf8Bytes(value: string): number {
+  return textEncoder.encode(value).byteLength;
+}
+
+function truncateUtf8(value: string, maxBytes: number): string {
+  if (maxBytes <= 0) return '';
+  if (utf8Bytes(value) <= maxBytes) return value;
+  const suffix = '...[truncated]';
+  const suffixBytes = utf8Bytes(suffix);
+  if (suffixBytes >= maxBytes) return suffix.slice(0, maxBytes);
+
+  let low = 0;
+  let high = value.length;
+  const contentBudget = maxBytes - suffixBytes;
+  while (low < high) {
+    const mid = Math.ceil((low + high) / 2);
+    if (utf8Bytes(value.slice(0, mid)) <= contentBudget) low = mid;
+    else high = mid - 1;
+  }
+  if (low > 0) {
+    const code = value.charCodeAt(low - 1);
+    if (code >= 0xd800 && code <= 0xdbff) low--;
+  }
+  return value.slice(0, low) + suffix;
+}
+
+function boundedProviderString(value: string, state: ProviderSerializationState): string {
+  const valueBytes = utf8Bytes(value);
+  const remainingTotal = Math.max(
+    0,
+    PROVIDER_SERIALIZATION_LIMITS.maxTotalStringBytes - state.stringBytes,
+  );
+  if (valueBytes > PROVIDER_SERIALIZATION_LIMITS.maxStringBytes) {
+    state.reasons.add('max-string-bytes');
+  }
+  if (valueBytes > remainingTotal) state.reasons.add('max-total-string-bytes');
+  const retained = truncateUtf8(
+    value,
+    Math.min(PROVIDER_SERIALIZATION_LIMITS.maxStringBytes, remainingTotal),
+  );
+  state.stringBytes += utf8Bytes(retained);
+  return retained;
+}
+
+function intrinsicNonnegativeInteger(
+  value: object,
+  getter: (() => unknown) | undefined,
+): number | undefined {
+  if (!getter) return undefined;
+  try {
+    const metadata = Reflect.apply(getter, value, []);
+    return typeof metadata === 'number'
+      && Number.isSafeInteger(metadata)
+      && metadata >= 0
+      ? metadata
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function jsonSafeValue(
+  value: unknown,
+  state: ProviderSerializationState,
+  ancestors = new WeakSet<object>(),
+  depth = 0,
+): unknown {
+  if (state.nodes >= PROVIDER_SERIALIZATION_LIMITS.maxNodes) {
+    state.reasons.add('max-nodes');
+    return { type: 'truncated', reason: 'max-nodes', unavailable: true };
+  }
+  state.nodes++;
+
+  if (value === null || typeof value === 'boolean') return value;
+  if (typeof value === 'string') return boundedProviderString(value, state);
+  if (typeof value === 'number') {
+    return Number.isFinite(value)
+      ? value
+      : { type: 'number', value: String(value), unavailable: true };
+  }
+  if (typeof value === 'bigint') {
+    return {
+      type: 'bigint',
+      value: boundedProviderString(Reflect.apply(bigIntToString, value, []), state),
+      unavailable: true,
+    };
+  }
+  if (typeof value === 'undefined' || typeof value === 'symbol' || typeof value === 'function') {
+    return { type: typeof value, unavailable: true };
+  }
+  if (depth >= PROVIDER_SERIALIZATION_LIMITS.maxDepth) {
+    state.reasons.add('max-depth');
+    return { type: 'max-depth', unavailable: true };
+  }
+
+  const object = value as object;
+  if (value instanceof ArrayBuffer) {
+    state.reasons.add('non-json-value');
+    const byteLength = intrinsicNonnegativeInteger(value, arrayBufferByteLengthGetter);
+    return {
+      type: 'array-buffer',
+      ...(byteLength !== undefined ? { byteLength } : {}),
+      unavailable: true,
+    };
+  }
+  if (ArrayBuffer.isView(value)) {
+    state.reasons.add('non-json-value');
+    const getter = value instanceof DataView
+      ? dataViewByteLengthGetter
+      : typedArrayByteLengthGetter;
+    const byteLength = intrinsicNonnegativeInteger(value, getter);
+    return {
+      type: 'array-buffer-view',
+      ...(byteLength !== undefined ? { byteLength } : {}),
+      unavailable: true,
+    };
+  }
+  if (value instanceof Map) {
+    state.reasons.add('non-json-value');
+    const size = intrinsicNonnegativeInteger(value, mapSizeGetter);
+    return { type: 'map', ...(size !== undefined ? { size } : {}), unavailable: true };
+  }
+  if (value instanceof Set) {
+    state.reasons.add('non-json-value');
+    const size = intrinsicNonnegativeInteger(value, setSizeGetter);
+    return { type: 'set', ...(size !== undefined ? { size } : {}), unavailable: true };
+  }
+  if (ancestors.has(object)) return { type: 'circular', unavailable: true };
+  ancestors.add(object);
+  try {
+    if (Array.isArray(value)) {
+      const result: unknown[] = [];
+      const retainedLength = Math.min(value.length, PROVIDER_SERIALIZATION_LIMITS.maxArrayItems);
+      if (value.length > retainedLength) state.reasons.add('max-array-items');
+      for (let i = 0; i < retainedLength; i++) {
+        if (state.nodes >= PROVIDER_SERIALIZATION_LIMITS.maxNodes) {
+          state.reasons.add('max-nodes');
+          result.push({ type: 'truncated', reason: 'max-nodes', unavailable: true });
+          break;
+        }
+        result.push(jsonSafeValue(value[i], state, ancestors, depth + 1));
+      }
+      if (value.length > retainedLength) {
+        result.push({
+          type: 'truncated',
+          reason: 'max-array-items',
+          omittedItems: value.length - retainedLength,
+          unavailable: true,
+        });
+      }
+      return result;
+    }
+    if (value instanceof Date) {
+      try {
+        return boundedProviderString(Reflect.apply(dateToISOString, value, []), state);
+      } catch {
+        return { type: 'date', unavailable: true };
+      }
+    }
+
+    const result: Record<string, unknown> = Object.create(null) as Record<string, unknown>;
+    const retainedKeys: string[] = [];
+    let omittedKeys = false;
+    try {
+      for (const key in object as Record<string, unknown>) {
+        if (!Object.prototype.hasOwnProperty.call(object, key)) continue;
+        if (retainedKeys.length >= PROVIDER_SERIALIZATION_LIMITS.maxObjectKeys) {
+          omittedKeys = true;
+          break;
+        }
+        retainedKeys.push(key);
+      }
+    } catch {
+      return { type: 'unreadable', unavailable: true };
+    }
+    if (omittedKeys) state.reasons.add('max-object-keys');
+    for (const originalKey of retainedKeys) {
+      if (state.nodes >= PROVIDER_SERIALIZATION_LIMITS.maxNodes) {
+        state.reasons.add('max-nodes');
+        result.__truncated__ = { type: 'truncated', reason: 'max-nodes', unavailable: true };
+        break;
+      }
+      let key = boundedProviderString(originalKey, state);
+      for (let suffix = 2; Object.prototype.hasOwnProperty.call(result, key); suffix++) {
+        key = `${truncateUtf8(key, 256)}#${suffix}`;
+      }
+      try {
+        result[key] = jsonSafeValue(
+          (object as Record<string, unknown>)[originalKey],
+          state,
+          ancestors,
+          depth + 1,
+        );
+      } catch {
+        result[key] = { type: 'unreadable', unavailable: true };
+      }
+    }
+    if (omittedKeys) {
+      result.__truncated__ = {
+        type: 'truncated',
+        reason: 'max-object-keys',
+        omittedKeysAtLeast: 1,
+        unavailable: true,
+      };
+    }
+    return result;
+  } finally {
+    ancestors.delete(object);
+  }
+}
+
+function snapshotProviderValue(value: unknown): {
+  value: unknown;
+  truncation?: RetrievalProviderTruncation;
+} {
+  const state: ProviderSerializationState = { nodes: 0, stringBytes: 0, reasons: new Set() };
+  try {
+    const snapshot = jsonSafeValue(value, state);
+    const reasons = [...state.reasons];
+    return {
+      value: snapshot,
+      ...(reasons.length > 0 ? {
+        truncation: {
+          truncated: true,
+          reasons,
+          retainedNodes: state.nodes,
+          retainedStringBytes: state.stringBytes,
+          limits: PROVIDER_SERIALIZATION_LIMITS,
+        },
+      } : {}),
+    };
+  } catch {
+    return {
+      value: { type: 'unreadable', unavailable: true },
+      truncation: {
+        truncated: true,
+        reasons: ['serialization-error'],
+        retainedNodes: state.nodes,
+        retainedStringBytes: state.stringBytes,
+        limits: PROVIDER_SERIALIZATION_LIMITS,
+      },
+    };
+  }
+}
+
+function snapshotResponseContent(content: readonly unknown[]): {
+  content: unknown[];
+  truncation?: RetrievalProviderTruncation;
+} {
+  const snapshot = snapshotProviderValue(content);
+  return {
+    content: Array.isArray(snapshot.value) ? snapshot.value : [snapshot.value],
+    ...(snapshot.truncation ? { truncation: snapshot.truncation } : {}),
+  };
+}
+
+function lessonSnapshot(lesson: Lesson): RetrievalLessonTrace {
+  return {
+    id: lesson.id,
+    content: lesson.content,
+    confidence: lesson.confidence,
+    tags: [...lesson.tags],
+    evidence: [...lesson.evidence],
+    created: lesson.created,
+    updated: lesson.updated,
+    deprecated: lesson.deprecated,
+    ...(lesson.deprecationReason !== undefined
+      ? { deprecationReason: lesson.deprecationReason }
+      : {}),
+  };
+}
+
+function candidateMatches(concepts: string[], lesson: Lesson): RetrievalCandidateMatch[] {
+  const matches: RetrievalCandidateMatch[] = [];
+  const content = lesson.content.toLowerCase();
+  const tags = lesson.tags.map(tag => ({ original: tag, lower: tag.toLowerCase() }));
+
+  for (const concept of concepts) {
+    for (const keyword of concept.toLowerCase().split(/\s+/)) {
+      if (content.includes(keyword)) {
+        matches.push({ concept, keyword, field: 'content' });
+      }
+      for (const tag of tags) {
+        if (tag.lower.includes(keyword)) {
+          matches.push({ concept, keyword, field: 'tag', tag: tag.original });
+        }
+      }
+    }
+  }
+
+  return matches;
+}
+
+/**
+ * Mutable handle for one retrieval run. Every mutation is guarded so tracing
+ * can never make retrieval fail; a malformed trace is less important than the
+ * inference it observes.
+ */
+export class RetrievalTraceRun {
+  private finished = false;
+
+  constructor(
+    private readonly store: RetrievalTraceStore,
+    private readonly trace: RetrievalTrace,
+  ) {}
+
+  get id(): number {
+    return this.trace.id;
+  }
+
+  private update(fn: (trace: RetrievalTrace) => void): void {
+    if (this.finished) return;
+    try {
+      this.store.update(this.trace, fn);
+    } catch {
+      // Observability is strictly fail-open.
+    }
+  }
+
+  setContext(hash: string, input: string, messageCount: number, messageIds: string[]): void {
+    this.update(trace => {
+      trace.context = { hash, input, messageCount, messageIds: [...messageIds] };
+    });
+  }
+
+  recordCacheHit(
+    sourceTraceId: number | undefined,
+    lessonIds: string[],
+    lessons: Lesson[],
+    injections: ContextInjection[],
+  ): void {
+    this.update(trace => {
+      trace.cache = { hit: true };
+      if (sourceTraceId !== undefined) {
+        const sourceStatus = this.store.sourceStatus(sourceTraceId);
+        if (sourceStatus === 'exact') trace.cache.sourceTraceId = sourceTraceId;
+        else if (sourceStatus === 'truncated') {
+          trace.cache.sourceTraceId = sourceTraceId;
+          trace.cache.sourceTraceTruncated = true;
+        } else trace.cache.sourceTraceEvicted = true;
+      }
+      trace.injected.lessonIds = [...lessonIds];
+      trace.injected.lessons = lessons.map(lessonSnapshot);
+      recordInjectionShape(trace, injections);
+    });
+  }
+
+  startConceptExtraction(systemPrompt: string, input: string): void {
+    this.update(trace => {
+      trace.conceptExtraction = { systemPrompt, input };
+    });
+  }
+
+  finishConceptExtraction(
+    rawOutput: string,
+    parsedValues: string[],
+    parseMode: RetrievalStageTrace['parseMode'],
+    responseContent: readonly unknown[] = [],
+  ): void {
+    this.update(trace => {
+      const snapshot = snapshotResponseContent(responseContent);
+      if (!trace.conceptExtraction) trace.conceptExtraction = { systemPrompt: '' };
+      trace.conceptExtraction.rawOutput = rawOutput;
+      trace.conceptExtraction.responseContent = snapshot.content;
+      if (snapshot.truncation) {
+        trace.conceptExtraction.responseContentTruncation = snapshot.truncation;
+      }
+      trace.conceptExtraction.parsedValues = [...parsedValues];
+      trace.conceptExtraction.parseMode = parseMode;
+    });
+  }
+
+  recordCandidates(concepts: string[], lessons: Lesson[]): void {
+    this.update(trace => {
+      trace.candidates = lessons.map(lesson => ({
+        ...lessonSnapshot(lesson),
+        matches: candidateMatches(concepts, lesson),
+      }));
+    });
+  }
+
+  recordRelevanceSkipped(reason: string): void {
+    this.update(trace => {
+      trace.relevance = {
+        ran: false,
+        skippedReason: reason,
+        systemPrompt: '',
+      };
+    });
+  }
+
+  startRelevance(systemPrompt: string, input: string): void {
+    this.update(trace => {
+      trace.relevance = { ran: true, systemPrompt, input };
+    });
+  }
+
+  finishRelevance(
+    rawOutput: string,
+    parsedIds: string[],
+    parseMode: RetrievalStageTrace['parseMode'],
+    responseContent: readonly unknown[] = [],
+  ): void {
+    this.update(trace => {
+      const snapshot = snapshotResponseContent(responseContent);
+      if (!trace.relevance) trace.relevance = { ran: true, systemPrompt: '' };
+      trace.relevance.rawOutput = rawOutput;
+      trace.relevance.responseContent = snapshot.content;
+      if (snapshot.truncation) trace.relevance.responseContentTruncation = snapshot.truncation;
+      trace.relevance.parsedValues = [...parsedIds];
+      trace.relevance.parseMode = parseMode;
+    });
+  }
+
+  recordRelevant(lessons: Lesson[]): void {
+    this.update(trace => {
+      trace.relevantLessonIds = lessons.map(lesson => lesson.id);
+    });
+  }
+
+  recordInjection(lessons: Lesson[], injections: ContextInjection[]): void {
+    this.update(trace => {
+      trace.injected = {
+        lessonIds: lessons.map(lesson => lesson.id),
+        lessons: lessons.map(lessonSnapshot),
+      };
+      recordInjectionShape(trace, injections);
+    });
+  }
+
+  recordStageError(stage: 'conceptExtraction' | 'relevance', error: unknown): void {
+    this.update(trace => {
+      const existing = trace[stage];
+      if (stage === 'relevance') {
+        trace.relevance = {
+          ran: true,
+          systemPrompt: existing?.systemPrompt ?? '',
+          ...(existing?.input ? { input: existing.input } : {}),
+          error: errorMessage(error),
+        };
+      } else {
+        trace.conceptExtraction = {
+          systemPrompt: existing?.systemPrompt ?? '',
+          ...(existing?.input ? { input: existing.input } : {}),
+          error: errorMessage(error),
+        };
+      }
+    });
+  }
+
+  finish(outcome: RetrievalTraceOutcome, error?: unknown): void {
+    if (this.finished) return;
+    this.finished = true;
+    try {
+      this.store.finish(this.trace, outcome, error);
+    } catch {
+      // Observability is strictly fail-open.
+    }
+  }
+}
+
+export class RetrievalTraceStore {
+  private readonly traces: RetrievalTrace[] = [];
+  private readonly sizes = new Map<RetrievalTrace, number>();
+  private readonly capacity: number;
+  private readonly byteBudget: number;
+  private payloadBytes = 0;
+  private nextId = 1;
+
+  constructor(options: RetrievalTraceStoreOptions | number = {}) {
+    const normalized = typeof options === 'number' ? { capacity: options } : options;
+    const requestedCapacity = normalized.capacity ?? DEFAULT_RETRIEVAL_TRACE_CAPACITY;
+    const requestedByteBudget = normalized.byteBudget ?? DEFAULT_RETRIEVAL_TRACE_BYTE_BUDGET;
+    this.capacity = Number.isFinite(requestedCapacity)
+      ? Math.max(1, Math.min(DEFAULT_RETRIEVAL_TRACE_CAPACITY, Math.trunc(requestedCapacity)))
+      : DEFAULT_RETRIEVAL_TRACE_CAPACITY;
+    if (!Number.isFinite(requestedByteBudget)
+        || requestedByteBudget < MIN_RETRIEVAL_TRACE_BYTE_BUDGET) {
+      throw new RangeError(
+        `Retrieval trace byteBudget must be at least ${MIN_RETRIEVAL_TRACE_BYTE_BUDGET}.`,
+      );
+    }
+    this.byteBudget = Math.trunc(requestedByteBudget);
+  }
+
+  begin(options: RetrievalTraceBeginOptions): RetrievalTraceRun {
+    const providerParams = options.providerParams
+      ? snapshotProviderValue(options.providerParams)
+      : undefined;
+    const trace: RetrievalTrace = {
+      schemaVersion: RETRIEVAL_TRACE_SCHEMA_VERSION,
+      id: this.nextId++,
+      startedAt: new Date().toISOString(),
+      agentName: options.agentName,
+      config: {
+        model: options.model,
+        ...(options.requestedReasoning
+          ? { requestedReasoning: { ...options.requestedReasoning } }
+          : {}),
+        ...(providerParams ? {
+          providerParams: providerParams.value as Record<string, unknown>,
+          ...(providerParams.truncation
+            ? { providerParamsTruncation: providerParams.truncation }
+            : {}),
+        } : {}),
+        minConfidence: options.minConfidence,
+        maxCandidates: options.maxCandidates,
+        maxInjectedLessons: options.maxInjectedLessons,
+      },
+      cache: { hit: false },
+      candidates: [],
+      relevantLessonIds: [],
+      injected: { lessonIds: [], lessons: [] },
+    };
+    this.commit(trace);
+    return new RetrievalTraceRun(this, trace);
+  }
+
+  has(id: number): boolean {
+    return this.traces.some(trace => trace.id === id);
+  }
+
+  sourceStatus(id: number): 'exact' | 'truncated' | 'evicted' {
+    const source = this.traces.find(trace => trace.id === id);
+    if (!source) return 'evicted';
+    return source.truncation ? 'truncated' : 'exact';
+  }
+
+  get retainedBytes(): number {
+    return this.totalEncodedBytes();
+  }
+
+  update(trace: RetrievalTrace, fn: (trace: RetrievalTrace) => void): void {
+    if (!this.sizes.has(trace) || trace.truncation) return;
+    try {
+      fn(trace);
+    } finally {
+      this.enforceBounds(trace);
+    }
+  }
+
+  finish(trace: RetrievalTrace, outcome: RetrievalTraceOutcome, error?: unknown): void {
+    if (!this.sizes.has(trace)) return;
+    try {
+      trace.outcome = outcome;
+      if (error !== undefined && !trace.truncation) trace.error = errorMessage(error);
+      trace.completedAt = new Date().toISOString();
+      trace.durationMs = Math.max(0, Date.now() - Date.parse(trace.startedAt));
+    } finally {
+      this.enforceBounds(trace);
+    }
+  }
+
+  private commit(trace: RetrievalTrace): void {
+    this.traces.push(trace);
+    const size = encodedTraceBytes(trace);
+    this.sizes.set(trace, size);
+    this.payloadBytes += size;
+    this.enforceBounds(trace);
+  }
+
+  private enforceBounds(mutatedTrace?: RetrievalTrace): void {
+    if (mutatedTrace && this.sizes.has(mutatedTrace)) {
+      this.refreshSize(mutatedTrace);
+    }
+    for (const retained of [...this.traces]) {
+      const size = this.sizes.get(retained) ?? Number.POSITIVE_INFINITY;
+      if (size > this.byteBudget && !retained.truncation) {
+        this.replaceWithTombstone(retained, size);
+      }
+    }
+
+    while (this.traces.length > this.capacity || this.totalEncodedBytes() > this.byteBudget) {
+      const evicted = new Set<number>();
+      do {
+        const oldest = this.traces.shift();
+        if (!oldest) break;
+        const evictedId = oldest.id;
+        evicted.add(evictedId);
+        const size = this.sizes.get(oldest) ?? 0;
+        this.sizes.delete(oldest);
+        if (Number.isFinite(size)) this.payloadBytes -= size;
+        else this.recalculatePayloadBytes();
+        // A still-running RetrievalTraceRun may retain this object. Strip its
+        // payload as part of eviction so concurrent active runs cannot bypass
+        // the store's memory bound; the ID remains available for provenance.
+        for (const key of Object.keys(oldest)) Reflect.deleteProperty(oldest, key);
+        Object.assign(oldest, { id: evictedId });
+      } while (this.traces.length > this.capacity || this.totalEncodedBytes() > this.byteBudget);
+      if (evicted.size === 0) break;
+      this.rewriteEvictedProvenance(evicted);
+    }
+  }
+
+  private replaceWithTombstone(trace: RetrievalTrace, originalBytes: number): void {
+    const sourceId = trace.id;
+    const tombstone: RetrievalTrace = {
+      schemaVersion: RETRIEVAL_TRACE_SCHEMA_VERSION,
+      id: trace.id,
+      startedAt: trace.startedAt,
+      ...(trace.completedAt ? { completedAt: trace.completedAt } : {}),
+      ...(trace.durationMs !== undefined ? { durationMs: trace.durationMs } : {}),
+      agentName: truncateUtf8(trace.agentName, 128),
+      config: {
+        model: truncateUtf8(trace.config.model, 128),
+        minConfidence: trace.config.minConfidence,
+        maxCandidates: trace.config.maxCandidates,
+        maxInjectedLessons: trace.config.maxInjectedLessons,
+      },
+      cache: { hit: trace.cache.hit },
+      candidates: [],
+      relevantLessonIds: [],
+      injected: { lessonIds: [], lessons: [] },
+      ...(trace.outcome ? { outcome: trace.outcome } : {}),
+      truncation: {
+        truncated: true,
+        kind: 'tombstone',
+        reason: 'trace-exceeded-byte-budget',
+        originalBytes,
+        byteBudget: this.byteBudget,
+      },
+    };
+    for (const key of Object.keys(trace)) Reflect.deleteProperty(trace, key);
+    Object.assign(trace, tombstone);
+    this.refreshSize(trace);
+
+    for (const retained of this.traces) {
+      if (retained === trace || retained.cache.sourceTraceId !== sourceId) continue;
+      retained.cache.sourceTraceTruncated = true;
+      delete retained.cache.sourceTraceEvicted;
+      this.refreshSize(retained);
+    }
+  }
+
+  private rewriteEvictedProvenance(evicted: Set<number>): void {
+    for (const retained of this.traces) {
+      if (retained.cache.sourceTraceId === undefined
+          || !evicted.has(retained.cache.sourceTraceId)) continue;
+      delete retained.cache.sourceTraceId;
+      delete retained.cache.sourceTraceTruncated;
+      retained.cache.sourceTraceEvicted = true;
+      this.refreshSize(retained);
+    }
+  }
+
+  private refreshSize(trace: RetrievalTrace): void {
+    const previous = this.sizes.get(trace) ?? 0;
+    const next = encodedTraceBytes(trace);
+    this.sizes.set(trace, next);
+    if (Number.isFinite(previous) && Number.isFinite(next)) {
+      this.payloadBytes += next - previous;
+    } else {
+      this.recalculatePayloadBytes();
+    }
+  }
+
+  private recalculatePayloadBytes(): void {
+    this.payloadBytes = 0;
+    for (const size of this.sizes.values()) this.payloadBytes += size;
+  }
+
+  private totalEncodedBytes(): number {
+    return 2 + this.payloadBytes + Math.max(0, this.traces.length - 1);
+  }
+
+  list(options: RetrievalTraceListOptions = {}): RetrievalTrace[] {
+    const requestedLimit = options.limit ?? 20;
+    const finiteLimit = Number.isFinite(requestedLimit) ? Math.trunc(requestedLimit) : 20;
+    const limit = Math.max(1, Math.min(this.capacity, finiteLimit));
+    const selected = this.traces.slice(-limit).reverse().map(trace => structuredClone(trace));
+    if (options.includeInputs) return selected;
+
+    for (const trace of selected) {
+      if (trace.context) delete trace.context.input;
+      if (trace.conceptExtraction) delete trace.conceptExtraction.input;
+      if (trace.relevance) delete trace.relevance.input;
+    }
+    return selected;
+  }
+}
+
+function encodedTraceBytes(trace: RetrievalTrace): number {
+  try {
+    return utf8Bytes(JSON.stringify(trace));
+  } catch {
+    return Number.POSITIVE_INFINITY;
+  }
+}
+
+function recordInjectionShape(trace: RetrievalTrace, injections: ContextInjection[]): void {
+  const injection = injections[0];
+  if (!injection) return;
+  trace.injected.namespace = injection.namespace;
+  trace.injected.position = injection.position;
+  trace.injected.block = injectionText(injections);
+}
+
+function injectionText(injections: ContextInjection[]): string | undefined {
+  for (const injection of injections) {
+    for (const block of injection.content) {
+      if (block.type === 'text') return block.text;
+    }
+  }
+  return undefined;
+}

--- a/src/modules/web-ui-module.ts
+++ b/src/modules/web-ui-module.ts
@@ -1417,7 +1417,7 @@ export class WebUiModule implements Module {
    * MCPL calls — the preview leaves the system state untouched. This omits the
    * dynamically-gathered injections (lessons/retrieval/MCPL context). Pass
    * `?injections=1` to gather them for full fidelity, which is NOT transparent:
-   * it can run inference (e.g. RetrievalModule's Haiku calls) and fire MCPL
+   * it can run inference (e.g. RetrievalModule's configured model calls) and fire MCPL
    * `beforeInference` hooks (whose paired `afterInference` is never sent).
    */
   private async handleDebugContext(url: URL): Promise<Response> {

--- a/src/modules/web-ui-module.ts
+++ b/src/modules/web-ui-module.ts
@@ -21,6 +21,8 @@
  */
 
 import { CURVE_PAGE_HTML } from './web-ui-curve-page.js';
+import { RETRIEVAL_TRACE_PAGE_HTML } from './retrieval-trace-page.js';
+import type { RetrievalTraceSource } from './retrieval-trace.js';
 import type {
   AgentFramework,
   Module,
@@ -975,6 +977,8 @@ export class WebUiModule implements Module {
 
   private async handleHttp(req: Request, server: ReturnType<typeof Bun.serve>): Promise<Response> {
     const url = new URL(req.url);
+    const isRetrievalTraceRoute = url.pathname === '/debug/retrieval'
+      || url.pathname === '/debug/retrieval/view';
 
     // Observer feature gate: live only when grants exist. With no grants
     // every path below reduces to the historical basic-auth-only behavior.
@@ -1014,6 +1018,7 @@ export class WebUiModule implements Module {
     // authenticate at all.
     const session = sharedServer!.observerSessions.lookup(sessionTokenFromRequest(req));
     const basicOk = this.checkAuth(req) || (session?.full ?? false);
+    const operatorAuthenticated = this.config.basicAuth !== undefined && basicOk;
     const sessionScopes = basicOk ? null : session?.scopes ?? null;
     const httpAllowed = (scope: ObserverScope): boolean =>
       basicOk || (sessionScopes?.has(scope) ?? false);
@@ -1042,12 +1047,12 @@ export class WebUiModule implements Module {
       && url.pathname !== '/healthz'
       && !url.pathname.startsWith('/files/');
     if (!basicOk && !(observersActive && isStatic) && !sessionScopes) {
-      return this.unauthorized();
+      return this.unauthorized(isRetrievalTraceRoute);
     }
 
     // Per-route scope gates for observer sessions (basic auth passes all).
     if ((url.pathname.startsWith('/debug/') || url.pathname === '/curve') && !httpAllowed('debug')) {
-      return this.unauthorized();
+      return this.unauthorized(isRetrievalTraceRoute);
     }
     if (url.pathname === '/healthz' && !httpAllowed('health')) {
       return this.unauthorized();
@@ -1057,6 +1062,23 @@ export class WebUiModule implements Module {
       // observer scope model (they are the agent's working files, not wire
       // events). Revisit if a 'files' scope is ever warranted.
       return this.unauthorized();
+    }
+
+    // Retrieval traces can include lesson contents, raw selector output, and
+    // opt-in recent conversation. Keep them operator-only: a password-authenticated
+    // full session is equivalent to Basic Auth, but observer `debug` scope is not.
+    if (isRetrievalTraceRoute && !operatorAuthenticated) return this.unauthorized(true);
+
+    if (url.pathname === '/debug/retrieval/view') {
+      return new Response(RETRIEVAL_TRACE_PAGE_HTML, {
+        headers: {
+          'content-type': 'text/html; charset=utf-8',
+          'cache-control': 'no-store',
+        },
+      });
+    }
+    if (url.pathname === '/debug/retrieval') {
+      return this.handleRetrievalTraces(url);
     }
 
     // Debug: the membrane-normalized request that WOULD be emitted if the
@@ -1579,6 +1601,40 @@ export class WebUiModule implements Module {
         status: 500, headers: { 'content-type': 'application/json' },
       });
     }
+  }
+
+  private handleRetrievalTraces(url: URL): Response {
+    try {
+      const app = sharedServer?.app;
+      if (!app) return this.retrievalJson({ error: 'app not bound yet' }, { status: 503 });
+
+      const module = app.framework.getAllModules().find(candidate => candidate.name === 'retrieval') as
+        | (RetrievalTraceSource & { name: string })
+        | undefined;
+      if (!module || typeof module.getRetrievalTraces !== 'function') {
+        return this.retrievalJson(
+          { schemaVersion: 1, enabled: false, includeInputs: false, traces: [] },
+        );
+      }
+
+      const requestedLimit = Number(url.searchParams.get('limit') ?? '20');
+      const limit = Number.isFinite(requestedLimit) ? Math.trunc(requestedLimit) : 20;
+      const includeInputs = url.searchParams.get('includeInputs') === '1';
+      const traces = module.getRetrievalTraces({ limit, includeInputs });
+      return this.retrievalJson({ schemaVersion: 1, enabled: true, includeInputs, traces });
+    } catch (error) {
+      let message = 'unavailable error';
+      try {
+        message = error instanceof Error ? error.message : String(error);
+      } catch { /* keep the safe fallback */ }
+      return this.retrievalJson({ error: message }, { status: 500 });
+    }
+  }
+
+  private retrievalJson(value: unknown, init: ResponseInit = {}): Response {
+    const headers = new Headers(init.headers);
+    headers.set('cache-control', 'no-store');
+    return Response.json(value, { ...init, headers });
   }
 
   /**
@@ -3273,10 +3329,12 @@ export class WebUiModule implements Module {
     return userOk && passOk;
   }
 
-  private unauthorized(): Response {
+  private unauthorized(noStore = false): Response {
+    const headers = new Headers({ 'www-authenticate': 'Basic realm="connectome-host"' });
+    if (noStore) headers.set('cache-control', 'no-store');
     return new Response('Unauthorized', {
       status: 401,
-      headers: { 'www-authenticate': 'Basic realm="connectome-host"' },
+      headers,
     });
   }
 }

--- a/src/recipe.ts
+++ b/src/recipe.ts
@@ -421,10 +421,19 @@ export interface RecipeModules {
   /**
    * Lesson retrieval-injection (requires `lessons`). OPT-IN — defaults to off
    * and is deliberately not part of the standard recipe: it injects
-   * context-dependent content into every compile and spends two Haiku calls
-   * per turn. Enable only for agents that actually curate a lesson library.
+   * context-dependent content into every compile and spends up to two
+   * configured retrieval-model calls. Enable only for agents that actually
+   * curate a lesson library.
    */
-  retrieval?: boolean | { model?: string; maxInjected?: number };
+  retrieval?: boolean | {
+    model?: string;
+    maxInjected?: number;
+    /**
+     * Optional OpenAI Responses/Codex reasoning effort for both retrieval calls.
+     * Requires an explicit retrieval model.
+     */
+    reasoningEffort?: 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max';
+  };
   wake?: boolean | import('@animalabs/agent-framework').GateConfig;
   workspace?: boolean | { mounts: RecipeWorkspaceMount[]; configMount?: boolean };
   /**
@@ -718,7 +727,7 @@ export const DEFAULT_RECIPE: Recipe = {
   },
   modules: {
     // subagents + lessons + retrieval deliberately omitted — all opt-in only
-    // (retrieval additionally adds per-turn context churn + Haiku costs);
+    // (retrieval additionally adds per-turn context churn + retrieval-model costs);
     // see the RecipeModules field docs.
     wake: true,
     workspace: true,
@@ -1252,6 +1261,43 @@ export function validateRecipe(raw: unknown): Recipe {
         if (m.mode !== undefined && m.mode !== 'read-write' && m.mode !== 'read-only') {
           throw new Error(`workspace.mounts[${i}].mode must be "read-write" or "read-only"`);
         }
+      }
+    }
+
+    // Validate retrieval provider reasoning when configured.
+    const retrieval = mods.retrieval;
+    if (retrieval !== undefined && typeof retrieval !== 'boolean') {
+      if (!retrieval || typeof retrieval !== 'object' || Array.isArray(retrieval)) {
+        throw new Error('Recipe modules.retrieval must be a boolean or object.');
+      }
+      const retrievalConfig = retrieval as Record<string, unknown>;
+      if (retrievalConfig.reasoningContext !== undefined) {
+        throw new Error(
+          'modules.retrieval.reasoningContext is not supported: retrieval model calls ' +
+          'are independent one-shot requests with no earlier reasoning items.',
+        );
+      }
+      const efforts = ['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'];
+      if (retrievalConfig.reasoningEffort !== undefined &&
+          (typeof retrievalConfig.reasoningEffort !== 'string'
+            || !efforts.includes(retrievalConfig.reasoningEffort))) {
+        throw new Error(`Invalid modules.retrieval.reasoningEffort ${JSON.stringify(retrievalConfig.reasoningEffort)}.`);
+      }
+      if (retrievalConfig.reasoningEffort !== undefined
+          && agent.provider !== 'openai-responses'
+          && agent.provider !== 'openai-codex') {
+        throw new Error(
+          'modules.retrieval.reasoningEffort requires agent.provider ' +
+          '"openai-responses" or "openai-codex".',
+        );
+      }
+      if (retrievalConfig.reasoningEffort !== undefined
+          && (typeof retrievalConfig.model !== 'string'
+            || !retrievalConfig.model.trim())) {
+        throw new Error(
+          'modules.retrieval.model must be a non-empty string when ' +
+          'modules.retrieval.reasoningEffort is configured.',
+        );
       }
     }
 

--- a/src/retrieval-config.ts
+++ b/src/retrieval-config.ts
@@ -1,0 +1,39 @@
+import type { Membrane } from '@animalabs/membrane';
+import type { RecipeAgent, RecipeModules } from './recipe.js';
+import type { RetrievalModuleConfig } from './modules/retrieval-module.js';
+
+type RetrievalRecipeConfig = Exclude<RecipeModules['retrieval'], boolean | undefined>;
+
+/** Translate the recipe's retrieval block into the module's runtime config. */
+export function buildRetrievalModuleConfig(
+  membrane: Membrane,
+  retrieval: RecipeModules['retrieval'],
+  provider: RecipeAgent['provider'] = 'anthropic',
+): RetrievalModuleConfig {
+  const config: RetrievalRecipeConfig = typeof retrieval === 'object' ? retrieval : {};
+  if (config.reasoningEffort
+      && provider !== 'openai-responses'
+      && provider !== 'openai-codex') {
+    throw new Error(
+      'modules.retrieval.reasoningEffort requires agent.provider ' +
+      '"openai-responses" or "openai-codex".',
+    );
+  }
+  if (config.reasoningEffort
+      && (typeof config.model !== 'string' || !config.model.trim())) {
+    throw new Error(
+      'modules.retrieval.model must be a non-empty string when ' +
+      'modules.retrieval.reasoningEffort is configured.',
+    );
+  }
+  const retrievalReasoning = config.reasoningEffort
+    ? { effort: config.reasoningEffort }
+    : undefined;
+
+  return {
+    membrane,
+    retrievalModel: config.model,
+    retrievalReasoning,
+    maxInjectedLessons: config.maxInjected,
+  };
+}

--- a/test/retrieval-auth-loopback.test.ts
+++ b/test/retrieval-auth-loopback.test.ts
@@ -1,0 +1,49 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { ModuleContext } from '@animalabs/agent-framework';
+import {
+  WebUiModule,
+  __getSharedServerPortForTests,
+  __resetSharedServerForTests,
+} from '../src/modules/web-ui-module.js';
+
+describe('retrieval operator authentication on credential-free loopback', () => {
+  let webUiModule: WebUiModule | undefined;
+  let root: string;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    root = mkdtempSync(join(tmpdir(), 'retrieval-auth-loopback-'));
+    const staticRoot = join(root, 'web');
+    mkdirSync(staticRoot);
+    writeFileSync(join(staticRoot, 'index.html'), '<!doctype html><title>loopback</title>');
+    webUiModule = new WebUiModule({
+      port: 0,
+      host: '127.0.0.1',
+      staticDir: staticRoot,
+    });
+    await webUiModule.start({} as ModuleContext);
+    const port = __getSharedServerPortForTests();
+    if (!port) throw new Error('webui server not bound; did start() succeed?');
+    baseUrl = `http://127.0.0.1:${port}`;
+  });
+
+  afterAll(async () => {
+    await webUiModule?.stop();
+    await __resetSharedServerForTests();
+    if (root) rmSync(root, { recursive: true, force: true });
+  });
+
+  test('denies both retrieval routes without changing ordinary loopback routes', async () => {
+    expect((await fetch(`${baseUrl}/`)).status).toBe(200);
+    expect((await fetch(`${baseUrl}/debug/context`)).status).toBe(503);
+
+    for (const path of ['/debug/retrieval', '/debug/retrieval/view']) {
+      const response = await fetch(`${baseUrl}${path}`);
+      expect(response.status).toBe(401);
+      expect(response.headers.get('cache-control')).toBe('no-store');
+    }
+  });
+});

--- a/test/retrieval-config.test.ts
+++ b/test/retrieval-config.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from 'bun:test';
+import type { Membrane } from '@animalabs/membrane';
+import { validateRecipe } from '../src/recipe.js';
+import { buildRetrievalModuleConfig } from '../src/retrieval-config.js';
+
+const membrane = {} as Membrane;
+
+function recipe(retrieval: unknown, provider: string = 'openai-codex') {
+  return {
+    name: 'retrieval-config-test',
+    agent: { systemPrompt: 'sys', provider },
+    modules: { retrieval },
+  };
+}
+
+describe('retrieval recipe config', () => {
+  test('accepts and maps provider reasoning settings', () => {
+    const parsed = validateRecipe(recipe({
+      model: 'test-model',
+      maxInjected: 7,
+      reasoningEffort: 'minimal',
+    }));
+
+    expect(parsed.modules?.retrieval).toEqual({
+      model: 'test-model',
+      maxInjected: 7,
+      reasoningEffort: 'minimal',
+    });
+    expect(buildRetrievalModuleConfig(membrane, parsed.modules!.retrieval!, 'openai-codex')).toEqual({
+      membrane,
+      retrievalModel: 'test-model',
+      maxInjectedLessons: 7,
+      retrievalReasoning: { effort: 'minimal' },
+    });
+  });
+
+  test('preserves boolean shorthand and omits unconfigured reasoning', () => {
+    expect(validateRecipe(recipe(true)).modules?.retrieval).toBe(true);
+    expect(validateRecipe(recipe(false)).modules?.retrieval).toBe(false);
+    expect(buildRetrievalModuleConfig(membrane, { model: 'test-model' }, 'anthropic')).toEqual({
+      membrane,
+      retrievalModel: 'test-model',
+    });
+  });
+
+  test('rejects malformed retrieval reasoning settings', () => {
+    expect(() => validateRecipe(recipe(null))).toThrow(/modules\.retrieval must be a boolean or object/);
+    expect(() => validateRecipe(recipe([]))).toThrow(/modules\.retrieval must be a boolean or object/);
+    expect(() => validateRecipe(recipe({ reasoningEffort: 'ultra' }))).toThrow(/reasoningEffort/);
+    expect(() => validateRecipe(recipe({ reasoningEffort: ['high'] }))).toThrow(/reasoningEffort/);
+    expect(() => validateRecipe(recipe({ reasoningContext: 'current_turn' }))).toThrow(
+      /independent one-shot requests/,
+    );
+    expect(() => validateRecipe(recipe({ reasoningEffort: 'high' }, 'anthropic'))).toThrow(
+      /requires agent\.provider/,
+    );
+    expect(() => buildRetrievalModuleConfig(
+      membrane,
+      { reasoningEffort: 'high' },
+      'anthropic',
+    )).toThrow(/requires agent\.provider/);
+    expect(() => validateRecipe(recipe({ reasoningEffort: 'high' }))).toThrow(
+      /model must be a non-empty string/,
+    );
+    expect(() => validateRecipe(recipe({ model: '  ', reasoningEffort: 'high' }))).toThrow(
+      /model must be a non-empty string/,
+    );
+    expect(() => buildRetrievalModuleConfig(
+      membrane,
+      { reasoningEffort: 'high' },
+      'openai-codex',
+    )).toThrow(/model must be a non-empty string/);
+  });
+});

--- a/test/retrieval-module.test.ts
+++ b/test/retrieval-module.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from 'bun:test';
+import type { Membrane, NormalizedRequest } from '@animalabs/membrane';
+import { RetrievalModule } from '../src/modules/retrieval-module.js';
+import { buildRetrievalModuleConfig } from '../src/retrieval-config.js';
+import type { Lesson } from '../src/modules/lessons-module.js';
+
+function lesson(id: string, content: string): Lesson {
+  return {
+    id,
+    content,
+    confidence: 0.9,
+    tags: ['memory'],
+    evidence: [],
+    created: 1,
+    updated: 1,
+    deprecated: false,
+  };
+}
+
+function harness(responses: Array<string | Error>, lessons: Lesson[]) {
+  const calls: NormalizedRequest[] = [];
+  const membrane = {
+    complete: async (request: NormalizedRequest) => {
+      calls.push(structuredClone(request));
+      const next = responses.shift();
+      if (next instanceof Error) throw next;
+      if (next === undefined) throw new Error('unexpected retrieval call');
+      return { content: [{ type: 'text', text: next }] };
+    },
+  } as unknown as Membrane;
+
+  const installContext = (mod: RetrievalModule) => {
+    (mod as unknown as { ctx: unknown }).ctx = {
+      getModule: (name: string) => name === 'lessons' ? { getLessons: () => lessons } : null,
+      queryMessages: () => ({
+        messages: [{
+          participant: 'user',
+          content: [{ type: 'text', text: 'Please recall the relevant memory context.' }],
+        }],
+        totalCount: 1,
+      }),
+    };
+  };
+
+  return { calls, membrane, installContext };
+}
+
+describe('RetrievalModule provider-specific reasoning', () => {
+  test('passes configured reasoning to concept extraction and relevance validation', async () => {
+    const lessons = [1, 2, 3, 4].map(n => lesson(`l${n}`, `memory detail ${n}`));
+    const h = harness(['["memory"]', '["l1", "l3"]'], lessons);
+    const mod = new RetrievalModule(buildRetrievalModuleConfig(h.membrane, {
+      model: 'gpt-5.6-sol',
+      reasoningEffort: 'xhigh',
+    }, 'openai-codex'));
+    h.installContext(mod);
+
+    const injections = await mod.gatherContext('sol');
+
+    expect(h.calls).toHaveLength(2);
+    for (const request of h.calls) {
+      expect(request.config.model).toBe('gpt-5.6-sol');
+      expect(request.providerParams).toEqual({
+        reasoning: { effort: 'xhigh' },
+      });
+    }
+    const text = (injections[0].content[0] as { type: 'text'; text: string }).text;
+    expect(text).toContain('memory detail 1');
+    expect(text).toContain('memory detail 3');
+    expect(text).not.toContain('memory detail 2');
+  });
+
+  test('omits providerParams when retrieval reasoning is not configured', async () => {
+    const h = harness(['[]'], [lesson('l1', 'memory detail')]);
+    const mod = new RetrievalModule({ membrane: h.membrane, retrievalModel: 'gpt-5.4-mini' });
+    h.installContext(mod);
+
+    expect(await mod.gatherContext('sol')).toEqual([]);
+    expect(h.calls).toHaveLength(1);
+    expect(h.calls[0].providerParams).toBeUndefined();
+  });
+
+  test('skips relevance validation for three or fewer candidates and caches non-empty results', async () => {
+    const h = harness(['["memory"]'], [lesson('l1', 'memory alpha'), lesson('l2', 'memory beta')]);
+    const mod = new RetrievalModule({
+      membrane: h.membrane,
+      retrievalModel: 'gpt-5.6-sol',
+      retrievalReasoning: { effort: 'xhigh' },
+    });
+    h.installContext(mod);
+
+    const first = await mod.gatherContext('sol');
+    const second = await mod.gatherContext('sol');
+
+    expect(first).toHaveLength(1);
+    expect(second).toEqual(first);
+    expect(h.calls).toHaveLength(1);
+    expect(h.calls[0].providerParams).toEqual({ reasoning: { effort: 'xhigh' } });
+  });
+
+  test('fails open when the concept extraction provider call fails', async () => {
+    const h = harness([new Error('provider unavailable')], [lesson('l1', 'memory detail')]);
+    const mod = new RetrievalModule({
+      membrane: h.membrane,
+      retrievalModel: 'gpt-5.6-sol',
+      retrievalReasoning: { effort: 'xhigh' },
+    });
+    h.installContext(mod);
+
+    expect(await mod.gatherContext('sol')).toEqual([]);
+    expect(h.calls).toHaveLength(1);
+  });
+});

--- a/test/retrieval-module.test.ts
+++ b/test/retrieval-module.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, test } from 'bun:test';
 import type { Membrane, NormalizedRequest } from '@animalabs/membrane';
 import { RetrievalModule } from '../src/modules/retrieval-module.js';
+import { RetrievalTraceStore } from '../src/modules/retrieval-trace.js';
 import { buildRetrievalModuleConfig } from '../src/retrieval-config.js';
 import type { Lesson } from '../src/modules/lessons-module.js';
+
+const TEST_AGENT = 'test-agent';
+const TEST_RETRIEVAL_MODEL = 'test-retrieval-model';
 
 function lesson(id: string, content: string): Lesson {
   return {
@@ -50,16 +54,16 @@ describe('RetrievalModule provider-specific reasoning', () => {
     const lessons = [1, 2, 3, 4].map(n => lesson(`l${n}`, `memory detail ${n}`));
     const h = harness(['["memory"]', '["l1", "l3"]'], lessons);
     const mod = new RetrievalModule(buildRetrievalModuleConfig(h.membrane, {
-      model: 'gpt-5.6-sol',
+      model: TEST_RETRIEVAL_MODEL,
       reasoningEffort: 'xhigh',
     }, 'openai-codex'));
     h.installContext(mod);
 
-    const injections = await mod.gatherContext('sol');
+    const injections = await mod.gatherContext(TEST_AGENT);
 
     expect(h.calls).toHaveLength(2);
     for (const request of h.calls) {
-      expect(request.config.model).toBe('gpt-5.6-sol');
+      expect(request.config.model).toBe(TEST_RETRIEVAL_MODEL);
       expect(request.providerParams).toEqual({
         reasoning: { effort: 'xhigh' },
       });
@@ -75,7 +79,7 @@ describe('RetrievalModule provider-specific reasoning', () => {
     const mod = new RetrievalModule({ membrane: h.membrane, retrievalModel: 'gpt-5.4-mini' });
     h.installContext(mod);
 
-    expect(await mod.gatherContext('sol')).toEqual([]);
+    expect(await mod.gatherContext(TEST_AGENT)).toEqual([]);
     expect(h.calls).toHaveLength(1);
     expect(h.calls[0].providerParams).toBeUndefined();
   });
@@ -84,13 +88,13 @@ describe('RetrievalModule provider-specific reasoning', () => {
     const h = harness(['["memory"]'], [lesson('l1', 'memory alpha'), lesson('l2', 'memory beta')]);
     const mod = new RetrievalModule({
       membrane: h.membrane,
-      retrievalModel: 'gpt-5.6-sol',
+      retrievalModel: TEST_RETRIEVAL_MODEL,
       retrievalReasoning: { effort: 'xhigh' },
     });
     h.installContext(mod);
 
-    const first = await mod.gatherContext('sol');
-    const second = await mod.gatherContext('sol');
+    const first = await mod.gatherContext(TEST_AGENT);
+    const second = await mod.gatherContext(TEST_AGENT);
 
     expect(first).toHaveLength(1);
     expect(second).toEqual(first);
@@ -102,12 +106,716 @@ describe('RetrievalModule provider-specific reasoning', () => {
     const h = harness([new Error('provider unavailable')], [lesson('l1', 'memory detail')]);
     const mod = new RetrievalModule({
       membrane: h.membrane,
-      retrievalModel: 'gpt-5.6-sol',
+      retrievalModel: TEST_RETRIEVAL_MODEL,
       retrievalReasoning: { effort: 'xhigh' },
     });
     h.installContext(mod);
 
-    expect(await mod.gatherContext('sol')).toEqual([]);
+    expect(await mod.gatherContext(TEST_AGENT)).toEqual([]);
     expect(h.calls).toHaveLength(1);
+    expect(mod.getRetrievalTraces()[0]).toMatchObject({
+      outcome: 'error',
+      error: 'provider unavailable',
+      conceptExtraction: { error: 'provider unavailable' },
+    });
+  });
+
+  test('fails open and records the relevance stage when its provider call fails', async () => {
+    const lessons = [1, 2, 3, 4].map(n => lesson(`l${n}`, `memory detail ${n}`));
+    const h = harness(['["memory"]', new Error('relevance unavailable')], lessons);
+    const mod = new RetrievalModule({
+      membrane: h.membrane,
+      retrievalModel: TEST_RETRIEVAL_MODEL,
+      retrievalReasoning: { effort: 'high' },
+    });
+    h.installContext(mod);
+
+    expect(await mod.gatherContext(TEST_AGENT)).toEqual([]);
+    expect(h.calls).toHaveLength(2);
+    expect(mod.getRetrievalTraces()[0]).toMatchObject({
+      outcome: 'error',
+      error: 'relevance unavailable',
+      relevance: { ran: true, error: 'relevance unavailable' },
+    });
+  });
+});
+
+describe('RetrievalModule observability', () => {
+  test('records a completed error trace and rethrows when getModule throws', async () => {
+    const mod = new RetrievalModule({ membrane: {} as Membrane });
+    (mod as unknown as { ctx: unknown }).ctx = {
+      getModule: () => { throw new Error('getModule failed'); },
+    };
+
+    await expect(mod.gatherContext(TEST_AGENT)).rejects.toThrow('getModule failed');
+    expect(mod.getRetrievalTraces()[0]).toMatchObject({
+      outcome: 'error',
+      error: 'getModule failed',
+    });
+    expect(mod.getRetrievalTraces()[0].completedAt).toBeDefined();
+  });
+
+  test('records a completed error trace and rethrows when getLessons throws', async () => {
+    const mod = new RetrievalModule({ membrane: {} as Membrane });
+    (mod as unknown as { ctx: unknown }).ctx = {
+      getModule: () => ({ getLessons: () => { throw new Error('getLessons failed'); } }),
+    };
+
+    await expect(mod.gatherContext(TEST_AGENT)).rejects.toThrow('getLessons failed');
+    expect(mod.getRetrievalTraces()[0]).toMatchObject({
+      outcome: 'error',
+      error: 'getLessons failed',
+    });
+    expect(mod.getRetrievalTraces()[0].completedAt).toBeDefined();
+  });
+
+  test('records a completed error trace and rethrows when queryMessages throws', async () => {
+    const mod = new RetrievalModule({ membrane: {} as Membrane });
+    (mod as unknown as { ctx: unknown }).ctx = {
+      getModule: () => ({ getLessons: () => [lesson('l1', 'memory detail')] }),
+      queryMessages: () => { throw new Error('queryMessages failed'); },
+    };
+
+    await expect(mod.gatherContext(TEST_AGENT)).rejects.toThrow('queryMessages failed');
+    expect(mod.getRetrievalTraces()[0]).toMatchObject({
+      outcome: 'error',
+      error: 'queryMessages failed',
+    });
+    expect(mod.getRetrievalTraces()[0].completedAt).toBeDefined();
+  });
+
+  test('records candidates, selector outputs, selected IDs, and the exact injection', async () => {
+    const lessons = [1, 2, 3, 4].map(n => lesson(`l${n}`, `memory detail ${n}`));
+    const h = harness(['["memory"]', '["l1", "l3"]'], lessons);
+    const mod = new RetrievalModule(buildRetrievalModuleConfig(h.membrane, {
+      model: TEST_RETRIEVAL_MODEL,
+      maxInjected: 5,
+      reasoningEffort: 'xhigh',
+    }, 'openai-codex'));
+    h.installContext(mod);
+
+    const injections = await mod.gatherContext(TEST_AGENT);
+
+    const [trace] = mod.getRetrievalTraces({ includeInputs: true });
+    expect(trace.outcome).toBe('injected');
+    expect(trace.agentName).toBe(TEST_AGENT);
+    expect(trace.config).toMatchObject({
+      model: TEST_RETRIEVAL_MODEL,
+      requestedReasoning: { effort: 'xhigh' },
+      providerParams: { reasoning: { effort: 'xhigh' } },
+      maxInjectedLessons: 5,
+    });
+    expect(trace.context?.input).toContain('Please recall the relevant memory context.');
+    expect(trace.conceptExtraction).toMatchObject({
+      rawOutput: '["memory"]',
+      responseContent: [{ type: 'text', text: '["memory"]' }],
+      parsedValues: ['memory'],
+      parseMode: 'json',
+    });
+    expect(trace.candidates.map(candidate => candidate.id)).toEqual(['l1', 'l2', 'l3', 'l4']);
+    expect(trace.candidates[0].matches).toContainEqual({
+      concept: 'memory', keyword: 'memory', field: 'content',
+    });
+    expect(trace.relevance).toMatchObject({
+      ran: true,
+      rawOutput: '["l1", "l3"]',
+      responseContent: [{ type: 'text', text: '["l1", "l3"]' }],
+      parsedValues: ['l1', 'l3'],
+      parseMode: 'json',
+    });
+    expect(trace.relevantLessonIds).toEqual(['l1', 'l3']);
+    expect(trace.injected.lessonIds).toEqual(['l1', 'l3']);
+    expect(trace.injected.namespace).toBe(injections[0].namespace);
+    expect(trace.injected.position).toBe(injections[0].position);
+    expect(trace.injected.block).toBe((injections[0].content[0] as { type: 'text'; text: string }).text);
+    expect(trace.injected.block).toContain('## Retrieved Knowledge');
+    expect(trace.injected.block).toContain('memory detail 1');
+    expect(trace.injected.block).not.toContain('memory detail 2');
+
+    const [safeView] = mod.getRetrievalTraces();
+    expect(safeView.context?.input).toBeUndefined();
+    expect(safeView.conceptExtraction?.input).toBeUndefined();
+    expect(safeView.relevance?.input).toBeUndefined();
+    expect(safeView.candidates[0].content).toBe('memory detail 1');
+  });
+
+  test('retains complete point-in-time lesson snapshots', async () => {
+    const source: Lesson = {
+      id: 'complete-lesson',
+      content: 'memory detail',
+      confidence: 0.87,
+      tags: ['memory', 'original-tag'],
+      evidence: ['message-1', 'message-2'],
+      created: 101,
+      updated: 202,
+      deprecated: false,
+      deprecationReason: 'retained optional field',
+    };
+    const expected = structuredClone(source);
+    const h = harness(['["memory"]'], [source]);
+    const mod = new RetrievalModule({ membrane: h.membrane });
+    h.installContext(mod);
+
+    expect(await mod.gatherContext(TEST_AGENT)).toHaveLength(1);
+    source.content = 'mutated content';
+    source.tags.push('mutated-tag');
+    source.evidence.push('mutated-evidence');
+    source.updated = 999;
+    source.deprecationReason = 'mutated reason';
+
+    const trace = mod.getRetrievalTraces()[0];
+    expect(trace.candidates[0]).toMatchObject(expected);
+    expect(trace.injected.lessons[0]).toEqual(expected);
+
+    trace.injected.lessons[0].tags.push('caller mutation');
+    trace.injected.lessons[0].evidence.push('caller mutation');
+    expect(mod.getRetrievalTraces()[0].injected.lessons[0]).toEqual(expected);
+  });
+
+  test('records cache reuse with a source trace and no extra model calls', async () => {
+    const lessons = [1, 2, 3, 4].map(n => lesson(`l${n}`, `memory detail ${n}`));
+    const h = harness(['["memory"]', '["l2"]'], lessons);
+    const mod = new RetrievalModule({ membrane: h.membrane, retrievalModel: TEST_RETRIEVAL_MODEL });
+    h.installContext(mod);
+
+    await mod.gatherContext(TEST_AGENT);
+    await mod.gatherContext(TEST_AGENT);
+
+    expect(h.calls).toHaveLength(2);
+    const [cached, source] = mod.getRetrievalTraces({ limit: 2 });
+    expect(source.outcome).toBe('injected');
+    expect(cached.outcome).toBe('cache-hit');
+    expect(cached.cache).toEqual({ hit: true, sourceTraceId: source.id });
+    expect(cached.injected.lessonIds).toEqual(['l2']);
+    expect(cached.injected.lessons).toEqual(source.injected.lessons);
+    expect(cached.injected.lessons[0].content).toBe('memory detail 2');
+    expect(cached.injected.block).toContain('memory detail 2');
+  });
+
+  test('cache-hit snapshots stay complete after source eviction', async () => {
+    const source: Lesson = {
+      ...lesson('l1', 'memory detail'),
+      evidence: ['message-1'],
+      created: 10,
+      updated: 20,
+      deprecationReason: 'optional metadata',
+    };
+    const expected = structuredClone(source);
+    const h = harness(['["memory"]'], [source]);
+    const mod = new RetrievalModule({ membrane: h.membrane });
+    h.installContext(mod);
+
+    await mod.gatherContext(TEST_AGENT);
+    for (let i = 0; i < 105; i++) await mod.gatherContext(TEST_AGENT);
+
+    const cached = mod.getRetrievalTraces({ limit: 100 })[0];
+    expect(cached.outcome).toBe('cache-hit');
+    expect(cached.cache).toEqual({ hit: true, sourceTraceEvicted: true });
+    expect(cached.injected.lessons[0]).toEqual(expected);
+  });
+
+  test('records skipped validation and relevance fallback without changing behavior', async () => {
+    const few = harness(['["memory"]'], [lesson('l1', 'memory one'), lesson('l2', 'memory two')]);
+    const fewMod = new RetrievalModule({ membrane: few.membrane });
+    few.installContext(fewMod);
+    await fewMod.gatherContext(TEST_AGENT);
+    expect(fewMod.getRetrievalTraces()[0].relevance).toMatchObject({
+      ran: false,
+      skippedReason: 'three-or-fewer-candidates',
+    });
+    expect(fewMod.getRetrievalTraces()[0].relevance?.parsedValues).toBeUndefined();
+
+    const manyLessons = [1, 2, 3, 4].map(n => lesson(`l${n}`, `memory ${n}`));
+    const many = harness(['["memory"]', 'not valid json'], manyLessons);
+    const manyMod = new RetrievalModule({ membrane: many.membrane });
+    many.installContext(manyMod);
+    const injections = await manyMod.gatherContext(TEST_AGENT);
+    expect(injections).toHaveLength(1);
+    expect(manyMod.getRetrievalTraces()[0].relevance).toMatchObject({
+      ran: true,
+      rawOutput: 'not valid json',
+      parsedValues: [],
+      parseMode: 'fallback',
+    });
+    expect(manyMod.getRetrievalTraces()[0].relevantLessonIds).toEqual(['l1', 'l2', 'l3', 'l4']);
+  });
+
+  test('trace-only message IDs cannot make retrieval fail', async () => {
+    const h = harness(['["memory"]'], [lesson('l1', 'memory detail')]);
+    const mod = new RetrievalModule({ membrane: h.membrane });
+    const message = {
+      participant: 'user',
+      content: [{ type: 'text', text: 'memory please' }],
+    } as Record<string, unknown>;
+    Object.defineProperty(message, 'id', { get: () => { throw new Error('trace-only id getter'); } });
+    (mod as unknown as { ctx: unknown }).ctx = {
+      getModule: (name: string) => name === 'lessons' ? { getLessons: () => [lesson('l1', 'memory detail')] } : null,
+      queryMessages: () => ({ messages: [message], totalCount: 1 }),
+    };
+
+    const injections = await mod.gatherContext(TEST_AGENT);
+    expect(injections).toHaveLength(1);
+    expect(mod.getRetrievalTraces({ includeInputs: true })[0].context?.messageIds).toEqual([]);
+  });
+
+  test('malformed mixed wrapper retains historical fail-open behavior', async () => {
+    const h = harness(['prose ["memory", 3]'], [lesson('l1', 'memory detail')]);
+    const mod = new RetrievalModule({ membrane: h.membrane });
+    h.installContext(mod);
+
+    expect(await mod.gatherContext(TEST_AGENT)).toEqual([]);
+    const [trace] = mod.getRetrievalTraces();
+    expect(trace.outcome).toBe('error');
+    expect(trace.conceptExtraction).toMatchObject({
+      parseMode: 'array-extraction',
+      parsedValues: ['memory'],
+    });
+  });
+
+  test('candidate provenance mirrors historical empty-keyword matching', async () => {
+    const h = harness(['["   "]'], [lesson('l1', 'unrelated detail')]);
+    const mod = new RetrievalModule({ membrane: h.membrane });
+    h.installContext(mod);
+
+    expect(await mod.gatherContext(TEST_AGENT)).toHaveLength(1);
+    expect(mod.getRetrievalTraces()[0].candidates[0].matches).toContainEqual({
+      concept: '   ', keyword: '', field: 'content',
+    });
+  });
+
+  test('provider blocks preserve JSON safety markers for unusual values', async () => {
+    const opaque: Record<string, unknown> = {
+      type: 'redacted_thinking',
+      bytes: 42n,
+      nonfinite: Number.POSITIVE_INFINITY,
+    };
+    opaque.self = opaque;
+    Object.defineProperty(opaque, 'unreadable', {
+      enumerable: true,
+      get: () => { throw new Error('unreadable provider property'); },
+    });
+    const membrane = {
+      complete: async () => ({
+        content: [{ type: 'text', text: '["memory"]' }, opaque],
+      }),
+    } as unknown as Membrane;
+    const mod = new RetrievalModule({ membrane });
+    (mod as unknown as { ctx: unknown }).ctx = {
+      getModule: (name: string) => name === 'lessons' ? { getLessons: () => [lesson('l1', 'memory detail')] } : null,
+      queryMessages: () => ({
+        messages: [{ participant: 'user', content: [{ type: 'text', text: 'memory' }] }],
+        totalCount: 1,
+      }),
+    };
+
+    expect(await mod.gatherContext(TEST_AGENT)).toHaveLength(1);
+    const serialized = JSON.stringify(mod.getRetrievalTraces({ includeInputs: true }));
+    expect(serialized).toContain('"type":"bigint"');
+    expect(serialized).toContain('"type":"circular"');
+    expect(serialized).toContain('"type":"number"');
+    expect(serialized).toContain('"type":"unreadable"');
+  });
+
+  test('canonicalizes non-JSON provider parameters before byte accounting', () => {
+    const binary = new ArrayBuffer(2 * 1024 * 1024);
+    const broad = Object.fromEntries(Array.from({ length: 100 }, (_, i) => [`key-${i}`, i]));
+    const store = new RetrievalTraceStore({ byteBudget: 4096 });
+    const run = store.begin({
+      agentName: TEST_AGENT,
+      model: TEST_RETRIEVAL_MODEL,
+      providerParams: {
+        binary,
+        view: new Uint8Array(binary),
+        map: new Map([['binary', binary]]),
+        set: new Set([binary]),
+        broad,
+      } as unknown as Record<string, unknown>,
+      minConfidence: 0.3,
+      maxCandidates: 20,
+      maxInjectedLessons: 5,
+    });
+    run.finish('no-concepts');
+
+    const [trace] = store.list({ includeInputs: true });
+    expect(trace.truncation).toBeUndefined();
+    expect(trace.config.providerParams).toMatchObject({
+      binary: { type: 'array-buffer', byteLength: binary.byteLength, unavailable: true },
+      view: { type: 'array-buffer-view', byteLength: binary.byteLength, unavailable: true },
+      map: { type: 'map', size: 1, unavailable: true },
+      set: { type: 'set', size: 1, unavailable: true },
+    });
+    expect(trace.config.providerParamsTruncation?.reasons).toContain('non-json-value');
+    expect(trace.config.providerParamsTruncation?.reasons).toContain('max-object-keys');
+    expect(store.retainedBytes).toBeLessThanOrEqual(4096);
+  });
+
+  test('uses intrinsic primitive metadata for shadowed binary and collection values', () => {
+    const hiddenMetadata = new ArrayBuffer(2 * 1024 * 1024);
+    const binary = new ArrayBuffer(8);
+    const typedArray = new Uint8Array(16);
+    const dataView = new DataView(new ArrayBuffer(24));
+    const map = new Map([['value', 1]]);
+    const set = new Set(['value']);
+    Object.defineProperty(binary, 'byteLength', { value: hiddenMetadata });
+    Object.defineProperty(typedArray, 'byteLength', { value: hiddenMetadata });
+    Object.defineProperty(dataView, 'byteLength', { value: hiddenMetadata });
+    Object.defineProperty(map, 'size', { value: hiddenMetadata });
+    Object.defineProperty(set, 'size', { value: hiddenMetadata });
+
+    const byteBudget = 4096;
+    const store = new RetrievalTraceStore({ byteBudget });
+    const run = store.begin({
+      agentName: TEST_AGENT,
+      model: TEST_RETRIEVAL_MODEL,
+      providerParams: { binary, typedArray, dataView, map, set },
+      minConfidence: 0.3,
+      maxCandidates: 20,
+      maxInjectedLessons: 5,
+    });
+    run.finish('no-concepts');
+
+    const traces = store.list({ includeInputs: true });
+    const [trace] = traces;
+    expect(trace.truncation).toBeUndefined();
+    expect(trace.config.providerParams).toMatchObject({
+      binary: { type: 'array-buffer', byteLength: 8, unavailable: true },
+      typedArray: { type: 'array-buffer-view', byteLength: 16, unavailable: true },
+      dataView: { type: 'array-buffer-view', byteLength: 24, unavailable: true },
+      map: { type: 'map', size: 1, unavailable: true },
+      set: { type: 'set', size: 1, unavailable: true },
+    });
+    expect(trace.config.providerParamsTruncation?.reasons).toEqual(['non-json-value']);
+    expect(store.retainedBytes).toBeLessThanOrEqual(byteBudget);
+    expect(new TextEncoder().encode(JSON.stringify(traces)).byteLength)
+      .toBeLessThanOrEqual(byteBudget);
+  });
+
+  test('bounds oversized BigInt decimal output with truthful string-limit reasons', () => {
+    const byteBudget = 32 * 1024;
+    const store = new RetrievalTraceStore({ byteBudget });
+    const run = store.begin({
+      agentName: TEST_AGENT,
+      model: TEST_RETRIEVAL_MODEL,
+      providerParams: { hugeInteger: 1n << 600_000n },
+      minConfidence: 0.3,
+      maxCandidates: 20,
+      maxInjectedLessons: 5,
+    });
+    run.finish('no-concepts');
+
+    const traces = store.list({ includeInputs: true });
+    const [trace] = traces;
+    const marker = trace.config.providerParams?.hugeInteger as {
+      type: string;
+      value: string;
+      unavailable: boolean;
+    };
+    expect(trace.truncation).toBeUndefined();
+    expect(marker.type).toBe('bigint');
+    expect(marker.unavailable).toBe(true);
+    expect(marker.value.endsWith('...[truncated]')).toBe(true);
+    expect(new TextEncoder().encode(marker.value).byteLength).toBeLessThanOrEqual(16 * 1024);
+    expect(trace.config.providerParamsTruncation?.reasons).toContain('max-string-bytes');
+    expect(trace.config.providerParamsTruncation?.reasons).toContain('max-total-string-bytes');
+    expect(store.retainedBytes).toBeLessThanOrEqual(byteBudget);
+    expect(new TextEncoder().encode(JSON.stringify(traces)).byteLength)
+      .toBeLessThanOrEqual(byteBudget);
+  });
+
+  test('bounds non-string Error.message values before retention', () => {
+    const hiddenMessage = new ArrayBuffer(2 * 1024 * 1024);
+    const error = new Error('ordinary');
+    Object.defineProperty(error, 'message', { value: hiddenMessage });
+    const byteBudget = 1024;
+    const store = new RetrievalTraceStore({ byteBudget });
+    const run = store.begin({
+      agentName: TEST_AGENT,
+      model: TEST_RETRIEVAL_MODEL,
+      minConfidence: 0.3,
+      maxCandidates: 20,
+      maxInjectedLessons: 5,
+    });
+    run.finish('error', error);
+
+    const traces = store.list({ includeInputs: true });
+    const [trace] = traces;
+    expect(trace.truncation).toBeUndefined();
+    expect(trace.error).toBe('[object ArrayBuffer]');
+    expect(store.retainedBytes).toBeLessThanOrEqual(byteBudget);
+    expect(new TextEncoder().encode(JSON.stringify(traces)).byteLength)
+      .toBeLessThanOrEqual(byteBudget);
+  });
+
+  test('retains enumerable __proto__ input as an accounted own data property', () => {
+    const providerParams: Record<string, unknown> = {};
+    Object.defineProperty(providerParams, '__proto__', {
+      value: 1n << 600_000n,
+      enumerable: true,
+    });
+    const byteBudget = 1024;
+    const store = new RetrievalTraceStore({ byteBudget });
+    const run = store.begin({
+      agentName: TEST_AGENT,
+      model: TEST_RETRIEVAL_MODEL,
+      providerParams,
+      minConfidence: 0.3,
+      maxCandidates: 20,
+      maxInjectedLessons: 5,
+    });
+    run.finish('no-concepts');
+
+    const traces = store.list({ includeInputs: true });
+    const [trace] = traces;
+    expect(trace.truncation).toMatchObject({
+      kind: 'tombstone',
+      reason: 'trace-exceeded-byte-budget',
+      byteBudget,
+    });
+    expect(store.retainedBytes).toBeLessThanOrEqual(byteBudget);
+    expect(new TextEncoder().encode(JSON.stringify(traces)).byteLength)
+      .toBeLessThanOrEqual(byteBudget);
+  });
+
+  test('uses intrinsic bounded Date output and fails safe for invalid dates', () => {
+    let customCalled = false;
+    const validDate = new Date('2026-07-31T12:34:56.789Z');
+    Object.defineProperty(validDate, 'toISOString', {
+      value: () => {
+        customCalled = true;
+        return 'x'.repeat(2 * 1024 * 1024);
+      },
+    });
+    const invalidDate = new Date(Number.NaN);
+    Object.defineProperty(invalidDate, 'toISOString', {
+      value: () => new ArrayBuffer(2 * 1024 * 1024),
+    });
+
+    const byteBudget = 4096;
+    const store = new RetrievalTraceStore({ byteBudget });
+    const run = store.begin({
+      agentName: TEST_AGENT,
+      model: TEST_RETRIEVAL_MODEL,
+      providerParams: { validDate, invalidDate },
+      minConfidence: 0.3,
+      maxCandidates: 20,
+      maxInjectedLessons: 5,
+    });
+    run.finish('no-concepts');
+
+    const traces = store.list({ includeInputs: true });
+    const [trace] = traces;
+    expect(customCalled).toBe(false);
+    expect(trace.truncation).toBeUndefined();
+    expect(trace.config.providerParams).toMatchObject({
+      validDate: '2026-07-31T12:34:56.789Z',
+      invalidDate: { type: 'date', unavailable: true },
+    });
+    expect(store.retainedBytes).toBeLessThanOrEqual(byteBudget);
+    expect(new TextEncoder().encode(JSON.stringify(traces)).byteLength)
+      .toBeLessThanOrEqual(byteBudget);
+  });
+
+  test('provider block snapshots bound breadth and strings with explicit reasons', async () => {
+    const opaque = {
+      type: 'opaque',
+      huge: '🔒'.repeat(50_000),
+      items: Array.from({ length: 10_000 }, () => 'x'.repeat(4_000)),
+    };
+    const membrane = {
+      complete: async () => ({
+        content: [{ type: 'text', text: '["memory"]' }, opaque],
+      }),
+    } as unknown as Membrane;
+    const mod = new RetrievalModule({ membrane });
+    (mod as unknown as { ctx: unknown }).ctx = {
+      getModule: () => ({ getLessons: () => [lesson('l1', 'memory detail')] }),
+      queryMessages: () => ({
+        messages: [{ participant: 'user', content: [{ type: 'text', text: 'memory' }] }],
+        totalCount: 1,
+      }),
+    };
+
+    expect(await mod.gatherContext(TEST_AGENT)).toHaveLength(1);
+    const stage = mod.getRetrievalTraces({ includeInputs: true })[0].conceptExtraction;
+    expect(stage?.responseContentTruncation?.truncated).toBe(true);
+    expect(stage?.responseContentTruncation?.reasons).toContain('max-array-items');
+    expect(stage?.responseContentTruncation?.reasons).toContain('max-string-bytes');
+    expect(stage?.responseContentTruncation?.reasons).toContain('max-total-string-bytes');
+    expect(new TextEncoder().encode(JSON.stringify(stage?.responseContent)).byteLength)
+      .toBeLessThan(256 * 1024);
+  });
+
+  test('in-flight retrieval is visible before the provider returns', async () => {
+    let release!: (value: unknown) => void;
+    const membrane = {
+      complete: () => new Promise(resolve => { release = resolve; }),
+    } as unknown as Membrane;
+    const mod = new RetrievalModule({ membrane });
+    (mod as unknown as { ctx: unknown }).ctx = {
+      getModule: (name: string) => name === 'lessons' ? { getLessons: () => [lesson('l1', 'memory detail')] } : null,
+      queryMessages: () => ({
+        messages: [{ participant: 'user', content: [{ type: 'text', text: 'memory' }] }],
+        totalCount: 1,
+      }),
+    };
+
+    const pending = mod.gatherContext(TEST_AGENT);
+    await new Promise(resolve => setTimeout(resolve, 0));
+    const [running] = mod.getRetrievalTraces({ includeInputs: true });
+    expect(running.outcome).toBeUndefined();
+    expect(running.completedAt).toBeUndefined();
+    expect(running.conceptExtraction?.input).toContain('memory');
+
+    release({ content: [{ type: 'text', text: '["memory"]' }] });
+    expect(await pending).toHaveLength(1);
+    expect(mod.getRetrievalTraces()[0].outcome).toBe('injected');
+  });
+
+  test('cache links are marked evicted rather than left dangling', async () => {
+    const h = harness(['["memory"]'], [lesson('l1', 'memory detail')]);
+    const mod = new RetrievalModule({ membrane: h.membrane });
+    h.installContext(mod);
+
+    await mod.gatherContext(TEST_AGENT);
+    for (let i = 0; i < 105; i++) await mod.gatherContext(TEST_AGENT);
+
+    const traces = mod.getRetrievalTraces({ limit: 100 });
+    expect(traces).toHaveLength(100);
+    expect(traces.every(trace => trace.outcome === 'cache-hit')).toBe(true);
+    expect(traces.every(trace => trace.cache.sourceTraceId === undefined)).toBe(true);
+    expect(traces.every(trace => trace.cache.sourceTraceEvicted === true)).toBe(true);
+  });
+
+  test('preserves the numeric capacity constructor contract', () => {
+    const store = new RetrievalTraceStore(2);
+    for (let i = 0; i < 3; i++) {
+      const run = store.begin({
+        agentName: TEST_AGENT,
+        model: TEST_RETRIEVAL_MODEL,
+        minConfidence: 0.3,
+        maxCandidates: 20,
+        maxInjectedLessons: 5,
+      });
+      run.finish('not-started');
+    }
+    expect(store.list({ limit: 100 }).map(trace => trace.id)).toEqual([3, 2]);
+  });
+
+  test('retains only the newest 100 runs', async () => {
+    const mod = new RetrievalModule({ membrane: {} as Membrane });
+    for (let i = 0; i < 105; i++) await mod.gatherContext(TEST_AGENT);
+    const traces = mod.getRetrievalTraces({ limit: 100 });
+    expect(traces).toHaveLength(100);
+    expect(traces[0].id).toBe(105);
+    expect(traces.at(-1)?.id).toBe(6);
+    expect(traces.every(trace => trace.outcome === 'not-started')).toBe(true);
+  });
+
+  test('evicts oldest traces to stay within the UTF-8 byte budget', () => {
+    const byteBudget = 2800;
+    const store = new RetrievalTraceStore({ byteBudget });
+    for (let i = 0; i < 3; i++) {
+      const run = store.begin({
+        agentName: TEST_AGENT,
+        model: TEST_RETRIEVAL_MODEL,
+        minConfidence: 0.3,
+        maxCandidates: 20,
+        maxInjectedLessons: 5,
+      });
+      run.setContext(`hash-${i}`, `context-${i}-` + 'x'.repeat(1300), 1, [`m${i}`]);
+      run.finish('no-concepts');
+    }
+
+    const traces = store.list({ limit: 100, includeInputs: true });
+    expect(traces.length).toBeLessThan(3);
+    expect(traces[0].id).toBe(3);
+    expect(traces[0].truncation).toBeUndefined();
+    expect(store.retainedBytes).toBeLessThanOrEqual(byteBudget);
+    expect(new TextEncoder().encode(JSON.stringify(traces)).byteLength)
+      .toBeLessThanOrEqual(byteBudget);
+  });
+
+  test('marks a byte-tombstoned cache source honestly', () => {
+    const byteBudget = 4096;
+    const store = new RetrievalTraceStore({ byteBudget });
+    const source = store.begin({
+      agentName: TEST_AGENT,
+      model: TEST_RETRIEVAL_MODEL,
+      minConfidence: 0.3,
+      maxCandidates: 20,
+      maxInjectedLessons: 5,
+    });
+    source.setContext('large-source', 'x'.repeat(20_000), 1, ['message-1']);
+    source.finish('injected');
+
+    const cached = store.begin({
+      agentName: TEST_AGENT,
+      model: TEST_RETRIEVAL_MODEL,
+      minConfidence: 0.3,
+      maxCandidates: 20,
+      maxInjectedLessons: 5,
+    });
+    cached.recordCacheHit(source.id, ['l1'], [lesson('l1', 'memory detail')], []);
+    cached.finish('cache-hit');
+
+    const [cacheTrace, sourceTrace] = store.list({ limit: 2 });
+    expect(sourceTrace.truncation?.kind).toBe('tombstone');
+    expect(cacheTrace.cache).toEqual({
+      hit: true, sourceTraceId: source.id, sourceTraceTruncated: true,
+    });
+    expect(cacheTrace.injected.lessons[0]).toMatchObject(lesson('l1', 'memory detail'));
+    expect(store.retainedBytes).toBeLessThanOrEqual(byteBudget);
+  });
+
+  test('replaces one oversized trace with an explicit bounded tombstone', () => {
+    const byteBudget = 1200;
+    const store = new RetrievalTraceStore({ byteBudget });
+    const run = store.begin({
+      agentName: TEST_AGENT,
+      model: TEST_RETRIEVAL_MODEL,
+      minConfidence: 0.3,
+      maxCandidates: 20,
+      maxInjectedLessons: 5,
+    });
+    run.setContext('large-context', '🔒'.repeat(20_000), 1, ['message-1']);
+    run.finish('no-concepts');
+
+    const traces = store.list({ limit: 100, includeInputs: true });
+    expect(traces).toHaveLength(1);
+    expect(traces[0]).toMatchObject({
+      outcome: 'no-concepts',
+      truncation: {
+        truncated: true,
+        kind: 'tombstone',
+        reason: 'trace-exceeded-byte-budget',
+        byteBudget,
+      },
+    });
+    expect(traces[0].context).toBeUndefined();
+    expect(store.retainedBytes).toBeLessThanOrEqual(byteBudget);
+  });
+
+  test('evicted active runs cannot reintroduce payload beyond the byte budget', () => {
+    const byteBudget = 2200;
+    const store = new RetrievalTraceStore({ byteBudget });
+    const begin = () => store.begin({
+      agentName: TEST_AGENT,
+      model: TEST_RETRIEVAL_MODEL,
+      minConfidence: 0.3,
+      maxCandidates: 20,
+      maxInjectedLessons: 5,
+    });
+    const older = begin();
+    older.setContext('older', 'x'.repeat(1300), 1, ['older-message']);
+    const newer = begin();
+    newer.setContext('newer', 'y'.repeat(1300), 1, ['newer-message']);
+
+    expect(store.list({ limit: 100, includeInputs: true }).map(trace => trace.id)).toEqual([2]);
+    older.setContext('evicted', 'z'.repeat(100_000), 1, ['evicted-message']);
+    older.finish('error', new Error('late active failure'));
+    newer.finish('no-concepts');
+
+    expect(store.list({ limit: 100, includeInputs: true }).map(trace => trace.id)).toEqual([2]);
+    expect(store.retainedBytes).toBeLessThanOrEqual(byteBudget);
   });
 });

--- a/test/web-ui-module.test.ts
+++ b/test/web-ui-module.test.ts
@@ -38,6 +38,7 @@ const BASIC_USER = 'admin';
 const BASIC_PASS = 'open-sesame';
 
 let handle: ServerHandle;
+let webUiModule: WebUiModule;
 
 function basicAuthHeader(user: string, pass: string): string {
   return `Basic ${Buffer.from(`${user}:${pass}`).toString('base64')}`;
@@ -59,13 +60,13 @@ beforeAll(async () => {
 
   // Bun.serve supports port=0 → OS picks a free port; we read it back from
   // the server. Avoids collisions when the test harness retries.
-  const mod = new WebUiModule({
+  webUiModule = new WebUiModule({
     port: 0,
     host: '127.0.0.1',
     basicAuth: { username: BASIC_USER, password: BASIC_PASS },
     staticDir: staticRoot,
   });
-  await mod.start({} as ModuleContext);
+  await webUiModule.start({} as ModuleContext);
 
   const port = __getSharedServerPortForTests();
   if (!port) throw new Error('webui server not bound; did start() succeed?');
@@ -74,7 +75,7 @@ beforeAll(async () => {
     port,
     staticRoot,
     cleanup: async () => {
-      await mod.stop();
+      await webUiModule.stop();
       await __resetSharedServerForTests();
       rmSync(tmp, { recursive: true, force: true });
       rmSync(sibling, { recursive: true, force: true });
@@ -123,6 +124,108 @@ describe('WebUiModule HTTP', () => {
     expect(res.status).toBe(200);
     const body = await res.text();
     expect(body).toContain('console.log');
+  });
+
+  test('retrieval trace routes require auth and expose the in-memory viewer', async () => {
+    const unauthenticated = await fetch(`http://127.0.0.1:${handle.port}/debug/retrieval`);
+    expect(unauthenticated.status).toBe(401);
+
+    const headers = { authorization: basicAuthHeader(BASIC_USER, BASIC_PASS) };
+    const unbound = await fetch(`http://127.0.0.1:${handle.port}/debug/retrieval`, { headers });
+    expect(unbound.status).toBe(503);
+    expect(await unbound.json()).toEqual({ error: 'app not bound yet' });
+
+    const viewer = await fetch(`http://127.0.0.1:${handle.port}/debug/retrieval/view`, { headers });
+    expect(viewer.status).toBe(200);
+    expect(viewer.headers.get('cache-control')).toBe('no-store');
+    expect(await viewer.text()).toContain('Retrieval traces');
+  });
+
+  test('bound retrieval JSON is no-store, redacted by default, and inputs require exact 1', async () => {
+    let observedOptions: { limit?: number; includeInputs?: boolean } | undefined;
+    const retrieval = {
+      name: 'retrieval',
+      getRetrievalTraces: (options: { limit?: number; includeInputs?: boolean } = {}) => {
+        observedOptions = options;
+        return [{
+          schemaVersion: 1,
+          id: 1,
+          startedAt: '2026-07-31T00:00:00.000Z',
+          agentName: 'sol',
+          config: { model: 'gpt-5.6-sol', minConfidence: 0.3, maxCandidates: 20, maxInjectedLessons: 5 },
+          context: {
+            hash: 'abc', messageCount: 1, messageIds: ['m1'],
+            ...(options.includeInputs ? { input: 'private recent conversation' } : {}),
+          },
+          cache: { hit: false },
+          candidates: [], relevantLessonIds: [],
+          injected: { lessonIds: [], lessons: [] },
+          outcome: 'no-concepts',
+        }];
+      },
+    };
+    const framework = {
+      getAllAgents: () => [],
+      getAllModules: () => [retrieval],
+      getSessionUsage: () => { throw new Error('no usage in HTTP harness'); },
+      onTrace: () => {},
+    };
+    webUiModule.setApp({ framework } as never);
+
+    const headers = { authorization: basicAuthHeader(BASIC_USER, BASIC_PASS) };
+    try {
+      const defaultRes = await fetch(
+        `http://127.0.0.1:${handle.port}/debug/retrieval?limit=7`, { headers },
+      );
+      expect(defaultRes.status).toBe(200);
+      expect(defaultRes.headers.get('cache-control')).toBe('no-store');
+      const defaultBody = await defaultRes.json() as Record<string, unknown>;
+      expect(defaultBody.enabled).toBe(true);
+      expect(defaultBody.includeInputs).toBe(false);
+      expect(JSON.stringify(defaultBody)).not.toContain('private recent conversation');
+      expect(observedOptions).toEqual({ limit: 7, includeInputs: false });
+
+      for (const alias of ['true', 'yes', '01']) {
+        const res = await fetch(
+          `http://127.0.0.1:${handle.port}/debug/retrieval?includeInputs=${alias}`, { headers },
+        );
+        const body = await res.json() as Record<string, unknown>;
+        expect(body.includeInputs).toBe(false);
+        expect(JSON.stringify(body)).not.toContain('private recent conversation');
+      }
+
+      const exactRes = await fetch(
+        `http://127.0.0.1:${handle.port}/debug/retrieval?includeInputs=1`, { headers },
+      );
+      const exactBody = await exactRes.json() as Record<string, unknown>;
+      expect(exactBody.includeInputs).toBe(true);
+      expect(JSON.stringify(exactBody)).toContain('private recent conversation');
+      expect(observedOptions).toEqual({ limit: 20, includeInputs: true });
+    } finally {
+      await webUiModule.stop();
+    }
+  });
+
+  test('bound app without retrieval reports tracing disabled', async () => {
+    const framework = {
+      getAllAgents: () => [],
+      getAllModules: () => [],
+      getSessionUsage: () => { throw new Error('no usage in HTTP harness'); },
+      onTrace: () => {},
+    };
+    webUiModule.setApp({ framework } as never);
+    try {
+      const res = await fetch(`http://127.0.0.1:${handle.port}/debug/retrieval`, {
+        headers: { authorization: basicAuthHeader(BASIC_USER, BASIC_PASS) },
+      });
+      expect(res.status).toBe(200);
+      expect(res.headers.get('cache-control')).toBe('no-store');
+      expect(await res.json()).toEqual({
+        schemaVersion: 1, enabled: false, includeInputs: false, traces: [],
+      });
+    } finally {
+      await webUiModule.stop();
+    }
   });
 
   // Path containment: a request for /../<sibling-of-staticRoot>/secret.txt

--- a/test/web-ui-module.test.ts
+++ b/test/web-ui-module.test.ts
@@ -127,22 +127,58 @@ describe('WebUiModule HTTP', () => {
   });
 
   test('retrieval trace routes require auth and expose the in-memory viewer', async () => {
-    const unauthenticated = await fetch(`http://127.0.0.1:${handle.port}/debug/retrieval`);
-    expect(unauthenticated.status).toBe(401);
+    for (const path of ['/debug/retrieval', '/debug/retrieval/view']) {
+      const unauthenticated = await fetch(`http://127.0.0.1:${handle.port}${path}`);
+      expect(unauthenticated.status).toBe(401);
+      expect(unauthenticated.headers.get('cache-control')).toBe('no-store');
+    }
 
     const headers = { authorization: basicAuthHeader(BASIC_USER, BASIC_PASS) };
     const unbound = await fetch(`http://127.0.0.1:${handle.port}/debug/retrieval`, { headers });
     expect(unbound.status).toBe(503);
+    expect(unbound.headers.get('cache-control')).toBe('no-store');
     expect(await unbound.json()).toEqual({ error: 'app not bound yet' });
 
     const viewer = await fetch(`http://127.0.0.1:${handle.port}/debug/retrieval/view`, { headers });
     expect(viewer.status).toBe(200);
     expect(viewer.headers.get('cache-control')).toBe('no-store');
-    expect(await viewer.text()).toContain('Retrieval traces');
+    const viewerHtml = await viewer.text();
+    expect(viewerHtml).toContain('Retrieval traces');
+    expect(viewerHtml).toContain('Selected lessons');
+    expect(viewerHtml).toContain('Candidate lessons');
+    expect(viewerHtml).toContain('Raw JSON (diagnostic)');
+    expect(viewerHtml).toContain("'agent: ' + (trace.agentName || 'unknown')");
+    expect(viewerHtml).toContain("reasoning ? reasoning.effort : 'default'");
+    expect(viewerHtml).not.toContain('reasoning.context');
+    expect(viewerHtml).toContain('node.textContent = String(text)');
+    expect(viewerHtml).not.toContain('.innerHTML');
+    expect(viewerHtml).not.toContain('\\u201C');
+    expect(viewerHtml).not.toContain('\\u201D');
+
+    const signIn = await fetch(`http://127.0.0.1:${handle.port}/auth/basic`, {
+      headers,
+      redirect: 'manual',
+    });
+    const cookie = (signIn.headers.get('set-cookie') ?? '').split(';', 1)[0];
+    expect(signIn.status).toBe(302);
+    expect(cookie.startsWith('fkm_obs=')).toBe(true);
+
+    const sessionJson = await fetch(`http://127.0.0.1:${handle.port}/debug/retrieval`, {
+      headers: { cookie },
+    });
+    expect(sessionJson.status).toBe(503);
+    expect(sessionJson.headers.get('cache-control')).toBe('no-store');
+    const sessionViewer = await fetch(
+      `http://127.0.0.1:${handle.port}/debug/retrieval/view`,
+      { headers: { cookie } },
+    );
+    expect(sessionViewer.status).toBe(200);
+    expect(sessionViewer.headers.get('cache-control')).toBe('no-store');
   });
 
   test('bound retrieval JSON is no-store, redacted by default, and inputs require exact 1', async () => {
     let observedOptions: { limit?: number; includeInputs?: boolean } | undefined;
+    const malicious = '</script><img src=x onerror="globalThis.pwned=true">';
     const retrieval = {
       name: 'retrieval',
       getRetrievalTraces: (options: { limit?: number; includeInputs?: boolean } = {}) => {
@@ -151,14 +187,25 @@ describe('WebUiModule HTTP', () => {
           schemaVersion: 1,
           id: 1,
           startedAt: '2026-07-31T00:00:00.000Z',
-          agentName: 'sol',
-          config: { model: 'gpt-5.6-sol', minConfidence: 0.3, maxCandidates: 20, maxInjectedLessons: 5 },
+          agentName: 'test-agent',
+          config: {
+            model: 'test-retrieval-model',
+            requestedReasoning: { effort: 'high' },
+            minConfidence: 0.3,
+            maxCandidates: 20,
+            maxInjectedLessons: 5,
+          },
           context: {
             hash: 'abc', messageCount: 1, messageIds: ['m1'],
             ...(options.includeInputs ? { input: 'private recent conversation' } : {}),
           },
           cache: { hit: false },
-          candidates: [], relevantLessonIds: [],
+          candidates: [{
+            id: 'malicious-lesson', content: malicious, confidence: 0.9,
+            tags: [malicious], evidence: [], created: 1, updated: 1,
+            deprecated: false, matches: [],
+          }],
+          relevantLessonIds: [],
           injected: { lessonIds: [], lessons: [] },
           outcome: 'no-concepts',
         }];
@@ -183,7 +230,20 @@ describe('WebUiModule HTTP', () => {
       expect(defaultBody.enabled).toBe(true);
       expect(defaultBody.includeInputs).toBe(false);
       expect(JSON.stringify(defaultBody)).not.toContain('private recent conversation');
+      const returnedTraces = defaultBody.traces as Array<{
+        candidates: Array<{ content: string }>;
+      }>;
+      expect(returnedTraces[0].candidates[0].content).toBe(malicious);
       expect(observedOptions).toEqual({ limit: 7, includeInputs: false });
+
+      const viewerRes = await fetch(
+        `http://127.0.0.1:${handle.port}/debug/retrieval/view`, { headers },
+      );
+      const viewerHtml = await viewerRes.text();
+      // Static viewer markup does not inline trace data; dynamic values use text sinks.
+      expect(viewerHtml).not.toContain(malicious);
+      expect(viewerHtml).toContain('textContent');
+      expect(viewerHtml).not.toContain('.innerHTML');
 
       for (const alias of ['true', 'yes', '01']) {
         const res = await fetch(
@@ -223,6 +283,29 @@ describe('WebUiModule HTTP', () => {
       expect(await res.json()).toEqual({
         schemaVersion: 1, enabled: false, includeInputs: false, traces: [],
       });
+    } finally {
+      await webUiModule.stop();
+    }
+  });
+
+  test('retrieval JSON errors are also no-store', async () => {
+    const framework = {
+      getAllAgents: () => [],
+      getAllModules: () => [{
+        name: 'retrieval',
+        getRetrievalTraces: () => { throw new Error('trace listing failed'); },
+      }],
+      getSessionUsage: () => { throw new Error('no usage in HTTP harness'); },
+      onTrace: () => {},
+    };
+    webUiModule.setApp({ framework } as never);
+    try {
+      const res = await fetch(`http://127.0.0.1:${handle.port}/debug/retrieval`, {
+        headers: { authorization: basicAuthHeader(BASIC_USER, BASIC_PASS) },
+      });
+      expect(res.status).toBe(500);
+      expect(res.headers.get('cache-control')).toBe('no-store');
+      expect(await res.json()).toEqual({ error: 'trace listing failed' });
     } finally {
       await webUiModule.stop();
     }

--- a/test/web-ui-observers.test.ts
+++ b/test/web-ui-observers.test.ts
@@ -287,7 +287,7 @@ describe('WebUiModule observer flow (e2e)', () => {
 
   test('grant appears (hot-reload): static public, observer WS flow end-to-end', async () => {
     saveObserversFile(observersPath, {
-      observers: [{ key: kp.id, label: 'e2e-device', scopes: ['health', 'ops'] }],
+      observers: [{ key: kp.id, label: 'e2e-device', scopes: ['health', 'ops', 'debug'] }],
     });
     await new Promise((r) => setTimeout(r, 3600)); // registry poll is 3s
 
@@ -319,7 +319,7 @@ describe('WebUiModule observer flow (e2e)', () => {
     ws.send(JSON.stringify({ type: 'observer-hello', identity: helloFor(kp, host) }));
     const ack = await got('observer-ack');
     expect(ack.label).toBe('e2e-device');
-    expect((ack.scopes as string[]).sort()).toEqual(['health', 'ops']);
+    expect((ack.scopes as string[]).sort()).toEqual(['debug', 'health', 'ops']);
 
     // Read-only: mutating messages are refused.
     ws.send(JSON.stringify({ type: 'user-message', content: 'hi' }));
@@ -340,11 +340,14 @@ describe('WebUiModule observer flow (e2e)', () => {
     });
     expect(String(branchErr.message)).toContain('forbidden');
 
-    // Session cookie: health allowed, debug denied (not in scopes).
+    // Session cookie: ordinary debug is allowed by scope, but retrieval traces
+    // remain operator-only because they can expose lessons and opt-in inputs.
     const cookie = `fkm_obs=${ack.sessionToken}`;
-    // healthz returns 503 (app not bound in this harness) — auth passed.
+    // 503 means authorization passed but this harness has no bound app.
     expect((await fetch(`${base()}/healthz`, { headers: { cookie } })).status).toBe(503);
-    expect((await fetch(`${base()}/debug/context`, { headers: { cookie } })).status).toBe(401);
+    expect((await fetch(`${base()}/debug/context`, { headers: { cookie } })).status).toBe(503);
+    expect((await fetch(`${base()}/debug/retrieval`, { headers: { cookie } })).status).toBe(401);
+    expect((await fetch(`${base()}/debug/retrieval/view`, { headers: { cookie } })).status).toBe(401);
     // Basic auth still works for everything.
     expect((await fetch(`${base()}/healthz`, { headers: { authorization: BASIC } })).status).toBe(503);
 


### PR DESCRIPTION
**Important: this PR depends on #70. Please review and merge #70 first. Until #70 is merged and this branch is rebased onto the updated main, this PR’s diff will also include #70’s reasoning changes.**

## Summary

- add bounded, process-memory retrieval traces for active and completed runs
- expose operator-only JSON and readable viewer routes at `/debug/retrieval` and `/debug/retrieval/view`
- show mechanical candidates, match provenance, relevance decisions, cache provenance, selected lesson snapshots, and the exact injected block
- label each trace with the invoking agent name
- redact exact conversation/model inputs by default; disclose them only with literal `includeInputs=1`

## Security and retention

- retrieval routes require configured password-derived operator authentication, including on loopback
- observer cookies cannot access them
- responses use `Cache-Control: no-store`
- traces are restart-ephemeral and bounded by both count and UTF-8 JSON size
- arbitrary provider values are converted to bounded JSON-safe snapshots
- the viewer renders through text sinks and does not claim access to hidden chain-of-thought

Each Host process has its own trace store and viewer. This endpoint does not aggregate fleet children.

## Screenshots

<img width="1702" height="1122" alt="{7BF9D0AF-BCEC-408B-85EB-34B5F5079446}" src="https://github.com/user-attachments/assets/aec7f31a-57d8-4232-85be-7c0b4da532ab" />

<img width="1693" height="1111" alt="{2FE54E32-7245-45C8-9F76-BBE02BAD7D15}" src="https://github.com/user-attachments/assets/8ff82a79-996a-4c65-9b09-e3014c4adc66" />

## Validation

- focused retrieval/WebUI suite: 50 passed
- full Host suite: 548 passed
- TypeScript
- Web production build
- diff hygiene
- fresh independent read-only review

Co-authored with OpenAI Codex; authored and maintained by [Sol](https://git.io/start).

