### PR TITLE
feat(mcpl): show live policy state in mcpl_list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### Added
+
+- **`mcpl_list` reports the live MCPL policy boundary.** Each server now shows
+  connected/retrying state, whether its initial policy was established, its
+  effective grant, host-masked and deny-by-default capability paths, and the
+  separate host-owned `host/command` authority. During a rolling upgrade,
+  fields unavailable from an older agent-framework render as `unknown` rather
+  than as a misleading empty grant.
+
 ## 0.7.3 — 2026-08-01
 
 ### Changed

--- a/src/modules/mcpl-admin-module.ts
+++ b/src/modules/mcpl-admin-module.ts
@@ -118,8 +118,9 @@ export class McplAdminModule implements Module {
       {
         name: 'mcpl_list',
         description:
-          'List all MCPL servers: id, live connection status, tool count, command/url, ' +
-          'and where each is defined (recipe/file vs your own agent overlay).',
+          'List all MCPL servers: connection/retry state, whether policy was established, ' +
+          'the effective grant, masked/denied capability paths, host-command authority, ' +
+          'tool count, target, and config source.',
         inputSchema: { type: 'object', properties: {} },
       },
       {
@@ -227,7 +228,19 @@ export class McplAdminModule implements Module {
 
   private handleList(): ToolResult {
     const framework = this.requireFramework();
-    const live = framework.listMcplServers();
+    // These fields land in agent-framework 0.8's MCPL grant work. Keep them
+    // optional here so connectome-host remains truthful ("unknown") if it is
+    // temporarily run against an older framework package during rollout.
+    const live = framework.listMcplServers() as Array<
+      ReturnType<AgentFramework['listMcplServers']>[number] & {
+        retrying?: boolean;
+        policyEstablished?: boolean;
+        effectiveGrant?: string[];
+        maskedCapabilities?: string[];
+        deniedCapabilities?: string[];
+        allowHostCommands?: boolean;
+      }
+    >;
     const overlay = readAgentOverlay(this.overlayPath);
     const fileServers = readMcplServersFile(this.configPath);
 
@@ -237,8 +250,19 @@ export class McplAdminModule implements Module {
         ? 'agent-overlay'
         : s.id in fileServers ? 'file/recipe' : 'recipe';
       const target = s.command ?? s.url ?? '?';
+      const connectionState = s.connected ? 'CONNECTED' : s.retrying ? 'RETRYING' : 'DISCONNECTED';
+      const policyState = s.policyEstablished === undefined
+        ? 'unknown'
+        : s.policyEstablished ? 'established' : 'not-established';
+      const hostCommands = s.allowHostCommands === undefined
+        ? 'unknown'
+        : s.allowHostCommands ? 'allow' : 'deny';
       lines.push(
-        `${s.id}: ${s.connected ? 'CONNECTED' : 'DISCONNECTED'} — ${s.toolCount} tools, ` +
+        `${s.id}: ${connectionState} — policy=${policyState}, ` +
+        `grant=${formatCapabilityList(s.effectiveGrant)}, ` +
+        `masked=${formatCapabilityList(s.maskedCapabilities)}, ` +
+        `denied=${formatCapabilityList(s.deniedCapabilities)}, ` +
+        `hostCommands=${hostCommands}; ${s.toolCount} tools, ` +
         `prefix=${s.toolPrefix}, source=${source}, ${target}`,
       );
     }
@@ -377,4 +401,9 @@ export class McplAdminModule implements Module {
 
     return ok(`Unloaded server "${id}" — its tools are gone from your toolset. ${persistNote}`);
   }
+}
+
+function formatCapabilityList(paths: string[] | undefined): string {
+  if (paths === undefined) return 'unknown';
+  return `[${paths.join(',')}]`;
 }

--- a/test/mcpl-admin-module.test.ts
+++ b/test/mcpl-admin-module.test.ts
@@ -15,8 +15,14 @@ import { readAgentOverlay, saveAgentOverlay } from '../src/mcpl-config.js';
 interface StubServer {
   id: string;
   connected: boolean;
+  retrying: boolean;
   toolPrefix: string;
   toolCount: number;
+  policyEstablished: boolean;
+  effectiveGrant: string[];
+  maskedCapabilities: string[];
+  deniedCapabilities: string[];
+  allowHostCommands: boolean;
   command?: string;
   url?: string;
 }
@@ -32,8 +38,14 @@ function makeStubFramework() {
       servers.set(config.id, {
         id: config.id,
         connected: true,
+        retrying: false,
         toolPrefix: config.toolPrefix ?? `mcpl--${config.id}`,
         toolCount: 1,
+        policyEstablished: true,
+        effectiveGrant: ['channels.incoming'],
+        maskedCapabilities: ['channels.streaming'],
+        deniedCapabilities: ['contextHooks.beforeInference.inject.system'],
+        allowHostCommands: false,
         command: config.command,
         url: config.url,
       });
@@ -49,8 +61,14 @@ function makeStubFramework() {
       servers.set(id, {
         id,
         connected: true,
+        retrying: false,
         toolPrefix: `mcpl--${id}`,
         toolCount: 1,
+        policyEstablished: true,
+        effectiveGrant: ['channels.incoming'],
+        maskedCapabilities: ['channels.streaming'],
+        deniedCapabilities: ['contextHooks.beforeInference.inject.system'],
+        allowHostCommands: false,
         command: config?.command ?? prev?.command,
       });
     },
@@ -207,6 +225,11 @@ describe('mcpl_list', () => {
     const text = String(result.data);
     expect(text).toContain('discord: CONNECTED');
     expect(text).toContain('mytool: CONNECTED');
+    expect(text).toContain('policy=established');
+    expect(text).toContain('grant=[channels.incoming]');
+    expect(text).toContain('masked=[channels.streaming]');
+    expect(text).toContain('denied=[contextHooks.beforeInference.inject.system]');
+    expect(text).toContain('hostCommands=deny');
     expect(text).toContain('source=agent-overlay');
     expect(text).toContain('gone: UNLOADED');
   });


### PR DESCRIPTION
Companion to agent-framework #81 (stacked on AF #79).

Extends the existing text mcpl_list without redesigning its source/tombstone behavior. Each live line now shows:

- CONNECTED / RETRYING / DISCONNECTED
- policy established vs not established
- effective grant
- masked and deny-by-default capability paths
- host-command allow/deny

During the package rollout, absent fields from an older agent-framework render as unknown rather than a false empty grant.

Verification:
- focused mcpl-admin module tests: 10 passed
- full bun test: 508 passed, 0 failed