### PR TITLE
workspace: expose per-mount file-size limit

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -274,6 +274,7 @@ async function createFramework(
           watch: m.watch ?? 'never', // FKM: no chokidar watchers by default
         };
         if (m.ignore) mount.ignore = m.ignore;
+        if (m.maxFileSize !== undefined) mount.maxFileSize = m.maxFileSize;
         if (m.wakeOnChange !== undefined) mount.wakeOnChange = m.wakeOnChange;
         if (m.autoMaterialize !== undefined) mount.autoMaterialize = m.autoMaterialize;
         return mount;

--- a/src/recipe.ts
+++ b/src/recipe.ts
@@ -392,8 +392,9 @@ export interface RecipeCredentialFileField {
 
 /**
  * Subset of MountConfig exposed to recipes.
- * Intentionally omits watchDebounceMs, followSymlinks, and maxFileSize —
- * these are implementation details best left to framework defaults.
+ * Intentionally omits watchDebounceMs and followSymlinks. The maximum file
+ * size is operator-configurable because binary service artifacts may
+ * legitimately exceed the conservative framework default.
  */
 export interface RecipeWorkspaceMount {
   name: string;
@@ -401,6 +402,8 @@ export interface RecipeWorkspaceMount {
   mode?: 'read-write' | 'read-only';
   watch?: 'always' | 'on-agent-action' | 'never';
   ignore?: string[];
+  /** Maximum file size in bytes (defaults to the framework's 5 MiB limit). */
+  maxFileSize?: number;
   /**
    * Request inference when files in this mount change. Pair with
    * `watch: 'always'` so chokidar actually observes the mount.


### PR DESCRIPTION
## Problem
`WorkspaceModule` supports `MountConfig.maxFileSize`, but Connectome recipes intentionally omitted and stripped that field. Operator attempts to raise the conservative 5 MiB default were silently ignored. This blocks legitimate binary service artifacts such as Orrery's 2k PNG grids even after `identity--request saveAs` safely transports them.

## Change
- Expose optional `maxFileSize` on `RecipeWorkspaceMount`.
- Pass it through to `WorkspaceModule` when explicitly configured.
- Preserve the framework's 5 MiB default when omitted.

## Evidence
- `bun test test/identity-and-surfaces.test.ts test/recipe-path-resolution.test.ts`: 19/19 pass.
- `git diff --check`: clean.

This keeps the size boundary operator-controlled; the identity utility does not bypass workspace policy.
