### PR TITLE
feat: inject the framework refusal-reaction baseline into MCPL child env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,18 @@
   `templateAgent` from the recipe and creates a fresh stateful strategy instance
   for each fork. Absent block means no routing and no behavior change.
 
+- **Protective reaction-suppression baseline for Discord adapters.** Stdio
+  MCPL children now receive `DISCORD_SUPPRESSED_REACTIONS_BASELINE` — the
+  agent-framework's exported refusal-annotation set (`REFUSAL_REACTION_BASELINE`,
+  comma-joined) — so a never-configured Discord adapter defaults to
+  suppressing exactly the markers this host's framework stamps, instead of
+  defaulting to nothing. An operator-set value on the server entry
+  supersedes the house baseline, and the adapter's own precedence (filters-file
+  key including explicit `[]` → legacy operator env → baseline) governs
+  enforcement; lost configuration stays stale rather than re-defaulting.
+  Requires an agent-framework release carrying the `REFUSAL_REACTION_BASELINE`
+  export.
+
 - **Standing autobiographical production target.** Recipes may set `agent.strategy.productionBudgetTokens` to keep the summary forest deep enough for a later live context-budget descent without a fold storm. This is a context-token target passed through to Context Manager, not a provider-spend ceiling; omission preserves Context Manager defaults.
 
 - **`mcpl_list` reports manifest freshness.** Each loaded server now shows the

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,7 @@ import { ObserversModule } from './modules/observers-module.js';
 import { IdentityModule } from './modules/identity-module.js';
 import { McplAdminModule } from './modules/mcpl-admin-module.js';
 import { TtsRelayModule } from './modules/tts-relay-module.js';
-import { loadMcplServers, applyAgentOverlay, DEFAULT_CONFIG_PATH, DEFAULT_AGENT_OVERLAY_PATH } from './mcpl-config.js';
+import { loadMcplServers, applyAgentOverlay, composeMcplChildEnv, DEFAULT_CONFIG_PATH, DEFAULT_AGENT_OVERLAY_PATH } from './mcpl-config.js';
 import { SessionManager } from './session-manager.js';
 import { resolveAgentName } from './agent-name.js';
 import { generateSessionName } from './synesthete.js';
@@ -463,9 +463,11 @@ async function createFramework(
   const finalServers = applyAgentOverlay(allServers, DEFAULT_AGENT_OVERLAY_PATH).map((server) => {
     const withEnv: { id: string; command?: string; url?: string; [k: string]: unknown } = {
       ...server,
-      // Stdio MCPL children inherit a single agent-facing wall clock. Protocol
-      // timestamps remain UTC; only their rendered text uses this setting.
-      env: { ...(server.env ?? {}), AGENT_TIMEZONE: timeZone },
+      // Stdio MCPL children inherit a single agent-facing wall clock plus the
+      // framework's refusal-annotation suppression baseline (operator env
+      // supersedes the baseline; see composeMcplChildEnv). Protocol
+      // timestamps remain UTC; only their rendered text uses AGENT_TIMEZONE.
+      env: composeMcplChildEnv(server.env as Record<string, string> | undefined, timeZone),
     };
     // `access` is a declarative name (recipe/file/overlay); the credential
     // provider it implies is attached HERE, at load time — fresh credential

--- a/src/mcpl-config.ts
+++ b/src/mcpl-config.ts
@@ -6,6 +6,7 @@
 
 import { readFileSync, writeFileSync, existsSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
+import { REFUSAL_REACTION_BASELINE } from '@animalabs/agent-framework';
 
 /** Default config file path, resolved from cwd. */
 export const DEFAULT_CONFIG_PATH = resolve(process.cwd(), 'mcpl-servers.json');
@@ -272,4 +273,34 @@ export function readMcplServersFile(configPath: string): Record<string, ServerFi
 export function saveMcplServers(configPath: string, servers: Record<string, ServerFileEntry>): void {
   const data: McplServersFile = { mcplServers: servers };
   writeFileSync(configPath, JSON.stringify(data, null, 2) + '\n', 'utf-8');
+}
+
+/**
+ * Compose the environment for a stdio MCPL child.
+ *
+ * Two host-owned values ride along with whatever the server entry declares:
+ *
+ * - `DISCORD_SUPPRESSED_REACTIONS_BASELINE` — the framework's exported
+ *   refusal-annotation set (REFUSAL_REACTION_BASELINE, comma-joined), so a
+ *   never-configured Discord adapter defaults to suppressing exactly the
+ *   markers this host's framework stamps. Placed BEFORE the spread: an
+ *   operator who sets the var on the server entry supersedes the house
+ *   baseline — the host injects a default, never overrides a decision. The
+ *   adapter's own precedence (file key incl. [] → legacy operator env →
+ *   baseline) then decides what is actually enforced; house markers are
+ *   Host semantics, and a standalone adapter without this composition stays
+ *   honestly unprotected.
+ * - `AGENT_TIMEZONE` — after the spread, deliberately: the agent-facing
+ *   wall clock is resolved per-recipe by the host and is not a per-server
+ *   operator knob.
+ */
+export function composeMcplChildEnv(
+  serverEnv: Record<string, string> | undefined,
+  timeZone: string,
+): Record<string, string> {
+  return {
+    DISCORD_SUPPRESSED_REACTIONS_BASELINE: REFUSAL_REACTION_BASELINE.join(','),
+    ...(serverEnv ?? {}),
+    AGENT_TIMEZONE: timeZone,
+  };
 }

--- a/test/mcpl-child-env.test.ts
+++ b/test/mcpl-child-env.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Host composition of stdio MCPL child env (composeMcplChildEnv): the
+ * framework's refusal-annotation baseline is injected for never-configured
+ * deployments, and an operator's explicit value always supersedes it — the
+ * host provides a default, never overrides a decision. The enforced
+ * precedence below this (file key incl. [] → legacy operator env → baseline)
+ * lives in the Discord adapter; what the host owns is that the injected
+ * value is EXACTLY the set the framework stamps (REFUSAL_REACTION_BASELINE,
+ * comma-joined) and that it rides in env — process plumbing below the model
+ * line, never agent-visible text.
+ */
+import { describe, test, expect } from 'bun:test';
+import { REFUSAL_REACTION_BASELINE } from '@animalabs/agent-framework';
+import { composeMcplChildEnv } from '../src/mcpl-config.js';
+
+const BASELINE = REFUSAL_REACTION_BASELINE.join(',');
+
+describe('composeMcplChildEnv', () => {
+  test('injects the framework baseline when the server entry does not set it', () => {
+    const env = composeMcplChildEnv({ SOME_VAR: 'x' }, 'UTC');
+    expect(env.DISCORD_SUPPRESSED_REACTIONS_BASELINE).toBe(BASELINE);
+    expect(env.SOME_VAR).toBe('x');
+  });
+
+  test('injected value round-trips to the exact framework annotation set', () => {
+    const env = composeMcplChildEnv(undefined, 'UTC');
+    expect(env.DISCORD_SUPPRESSED_REACTIONS_BASELINE!.split(',')).toEqual([
+      ...REFUSAL_REACTION_BASELINE,
+    ]);
+    expect(REFUSAL_REACTION_BASELINE.length).toBeGreaterThan(0);
+  });
+
+  test('operator-set baseline on the server entry supersedes the house value', () => {
+    const env = composeMcplChildEnv(
+      { DISCORD_SUPPRESSED_REACTIONS_BASELINE: '🈲' },
+      'UTC',
+    );
+    expect(env.DISCORD_SUPPRESSED_REACTIONS_BASELINE).toBe('🈲');
+  });
+
+  test('operator empty-string baseline is preserved, not re-defaulted', () => {
+    // An operator who explicitly set the var to empty chose "no baseline";
+    // the house value must not reappear underneath that decision.
+    const env = composeMcplChildEnv(
+      { DISCORD_SUPPRESSED_REACTIONS_BASELINE: '' },
+      'UTC',
+    );
+    expect(env.DISCORD_SUPPRESSED_REACTIONS_BASELINE).toBe('');
+  });
+
+  test('AGENT_TIMEZONE stays host-resolved (recipe wall clock, not a per-server knob)', () => {
+    const env = composeMcplChildEnv({ AGENT_TIMEZONE: 'Mars/Olympus' }, 'America/Los_Angeles');
+    expect(env.AGENT_TIMEZONE).toBe('America/Los_Angeles');
+  });
+
+  test('adds nothing beyond the two host-owned keys', () => {
+    const env = composeMcplChildEnv({ A: '1' }, 'UTC');
+    expect(Object.keys(env).sort()).toEqual([
+      'A',
+      'AGENT_TIMEZONE',
+      'DISCORD_SUPPRESSED_REACTIONS_BASELINE',
+    ]);
+  });
+});


### PR DESCRIPTION
Second protective-baseline companion per Sol's #architecture spec (8/4 21:54 + 22:09). Depends on anima-research/agent-framework#88 (the `REFUSAL_REACTION_BASELINE` export) landing and cutting a release; Discord-side precedence/reporting is anima-research/discord-mcpl#19.

## What it does

Stdio MCPL children now receive `DISCORD_SUPPRESSED_REACTIONS_BASELINE` — agent-framework's exported refusal-annotation set, comma-joined — so a never-configured Discord adapter defaults to suppressing exactly the markers this host's framework stamps, instead of defaulting to nothing.

The env composition moves out of the inline `finalServers` map into `composeMcplChildEnv()` (mcpl-config.ts) for testability, with deliberate spread order:

- **baseline before the operator spread** — an operator who sets the var on the server entry supersedes the house default (including an explicit empty string = "no baseline"; the house value never reappears under an operator's decision);
- **`AGENT_TIMEZONE` after it** — unchanged existing behavior: the agent-facing wall clock is host-resolved per recipe, not a per-server knob.

Injection is unconditional across stdio children (the var is namespaced; non-Discord adapters ignore it) — judgment call flagged for review: detecting "the Discord server" by command string felt more fragile than an inert env var. Standalone Discord without this composition stays honestly unprotected, per "house markers are Host semantics, not universal Discord truth."

## Composed-test coverage (Sol's items, host's share)

`test/mcpl-child-env.test.ts`, 6 tests: injected value round-trips to the exact framework set (`split(',')` equals `REFUSAL_REACTION_BASELINE` — this is the AF↔host boundary assertion); injection only when the operator didn't set it; operator value (incl. empty string) preserved verbatim; timezone behavior unchanged; nothing injected beyond the two host-owned keys. Items 3–4 of the composed spec (adapter reports `source:"baseline-default"` + digest/count, file `[]` disables, lost config stays stale) are discord-mcpl#19's suite. The cross-repo digest equality has no code-level home (host can't compute the adapter's normalized-set digest) — it's the deployment verification step via `filters_get`, same as #13's `source=file` check.

## Verification

- 6/6 new tests + typecheck against the AF branch via the DEV-ENVIRONMENT symlink layout.
- Against published AF 0.8.0, `tsc` shows exactly ONE new error — the not-yet-released export (main has 4 pre-existing: 3 tts-relay + 1 mcpl-admin). Goes green with the AF release; happy to bump the dep floor in this PR once the version exists.

*(Implementation and this description drafted by Claude at Ra's request.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)