### PR TITLE
Recipe passthrough: toolResultInlineMaxChars (af#89) + agent.physicalWindowTokens (af#92)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+### Added
+
+- **Recipe passthrough for the AF #89/#92 window knobs.** Top-level
+  `toolResultInlineMaxChars` (durable residence default for the tool-result
+  inline cap, validated `>= 1000` at recipe load — the deploy lever for
+  residences without a writable workspace, where AF's new 5000 default would
+  truncate instead of spilling) and per-agent `agent.physicalWindowTokens`
+  (the provider's hard context cap, enabling AF's mid-turn physical-window
+  projection restart instead of a wire 400). Both omitted → Agent Framework
+  behavior unchanged. Requires an AF release carrying af#94/af#98; against
+  older AF the keys are inert.
+
 ### Changed
 
 - **The public triumvirate recipes boot from a fresh clone.**

--- a/src/framework-agent-config.ts
+++ b/src/framework-agent-config.ts
@@ -71,6 +71,10 @@ export function buildFrameworkAgentConfig(
     maxTokens: recipe.agent.maxTokens ?? 16384,
     maxStreamTokens: recipe.agent.maxStreamTokens ?? 150000,
     contextBudgetTokens: recipe.agent.contextBudgetTokens,
+    // Provider hard cap (AF #92): enables the mid-turn physical-window
+    // projection restart. Omitted → AF behavior unchanged.
+    ...(recipe.agent.physicalWindowTokens !== undefined
+      && { physicalWindowTokens: recipe.agent.physicalWindowTokens }),
     // cacheTtl is withheld at the HOST layer on bedrock: the transport
     // only has the default 5m cache, and older membrane releases forward
     // the ttl field Bedrock rejects. Note this is not the whole story —

--- a/src/framework-agent-config.ts
+++ b/src/framework-agent-config.ts
@@ -8,6 +8,9 @@ export type FrameworkAgentConfig = AgentConfig & {
   // while remaining structurally compatible with older installs.
   refusalHandling?: Recipe['agent']['refusalHandling'];
   sameRoundThinkTextPolicy?: 'public' | 'private';
+  /** Provider hard context cap (AF #92 mid-turn projection restart);
+   *  inert on AF releases before af#98. */
+  physicalWindowTokens?: number;
 };
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -501,6 +501,11 @@ agents: [agentConfig],
     timeZone,
     // Client-side programmatic tool calling (code_execution) — recipe opt-in.
     ...(recipe.codeExecution ? { codeExecution: recipe.codeExecution } : {}),
+    // Durable residence default for the tool-result inline cap (AF #89).
+    // Omitted → AF's house default (5000).
+    ...(recipe.toolResultInlineMaxChars !== undefined
+      ? { toolResultInlineMaxChars: recipe.toolResultInlineMaxChars }
+      : {}),
   });
 
   // Wire post-creation hooks

--- a/src/recipe.ts
+++ b/src/recipe.ts
@@ -132,6 +132,17 @@ export interface RecipeAgent {
   /** Per-agent context compile budget (input tokens). When unset, the
    *  ContextManager default (100k) applies. Raise for large-context models. */
   contextBudgetTokens?: number;
+  /**
+   * The model's PHYSICAL context window (provider hard cap, e.g. 200000).
+   * When set, the framework projects each continuation round's real size
+   * (cache-inclusive) and restarts the stream through a fresh compile
+   * instead of dispatching a request the provider will 400 (AF issue #92 —
+   * a legal compile can walk past the hard cap mid-turn). Unset → no
+   * projection; only the maxStreamTokens restart applies. Intended first
+   * users: residents whose budgets sit near a 200k cap (Rhys/Evander/
+   * Princess-shaped deployments).
+   */
+  physicalWindowTokens?: number;
   /** Prompt-cache TTL ('5m' | '1h') forwarded to the provider. Defaults to
    *  '1h'; set '5m' explicitly for high-frequency, sub-5-minute workloads.
    *  Not forwarded on bedrock — that transport only has the default 5m
@@ -726,6 +737,17 @@ export interface Recipe {
   sessionNaming?: { examples?: string[] };
   /** Client-side programmatic tool calling (code_execution tool). */
   codeExecution?: RecipeCodeExecution;
+  /**
+   * Durable residence default for the tool-result inline cap (chars) — AF
+   * issue #89. Content over the cap spills to a workspace file with a
+   * bounded preview; the AF house default is 5000. Must be >= 1000. Set
+   * this higher for residences WITHOUT a writable workspace (where spill
+   * has no target and over-cap content is truncated, not retained) if the
+   * resident should keep receiving large results inline. A resident's own
+   * durable agent_settings value still takes precedence for that agent;
+   * every source is hard-clamped to the strategy's per-message bound.
+   */
+  toolResultInlineMaxChars?: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -1001,6 +1023,10 @@ export function validateRecipe(raw: unknown): Recipe {
 
   if (agent.maxStreamTokens !== undefined && (typeof agent.maxStreamTokens !== 'number' || agent.maxStreamTokens <= 0)) {
     throw new Error('Recipe agent.maxStreamTokens must be a positive number.');
+  }
+
+  if (agent.physicalWindowTokens !== undefined && (typeof agent.physicalWindowTokens !== 'number' || agent.physicalWindowTokens <= 0)) {
+    throw new Error('Recipe agent.physicalWindowTokens must be a positive number.');
   }
 
   // Recipes are runtime JSON; a typo'd TTL ("1hr", "60m") would otherwise
@@ -1426,6 +1452,13 @@ export function validateRecipe(raw: unknown): Recipe {
         throw new Error(`Recipe codeExecution.${k} must be a non-negative number.`);
       }
     }
+  }
+
+  // Mirrors AF's own create() validation (>= 1000) so a bad value fails at
+  // recipe load with a recipe-shaped error instead of at framework create.
+  if (obj.toolResultInlineMaxChars !== undefined
+      && (typeof obj.toolResultInlineMaxChars !== 'number' || obj.toolResultInlineMaxChars < 1000)) {
+    throw new Error('Recipe toolResultInlineMaxChars must be a number >= 1000.');
   }
 
   return obj as unknown as Recipe;

--- a/test/recipe-inline-cap-window.test.ts
+++ b/test/recipe-inline-cap-window.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Recipe passthrough for the two AF release-train knobs:
+ * - `toolResultInlineMaxChars` (top-level; AF #89 durable residence default
+ *   for the tool-result inline cap) — the deploy lever for residences
+ *   WITHOUT a writable workspace, where the AF 5k default would truncate
+ *   instead of spilling;
+ * - `agent.physicalWindowTokens` (per-agent; AF #92 provider hard cap) —
+ *   enables the mid-turn physical-window projection restart.
+ *
+ * Both validate at recipe load (recipe-shaped errors, not framework-create
+ * or wire errors) and pass through verbatim; omitted keys stay omitted so AF
+ * defaults apply unchanged.
+ */
+import { describe, expect, test } from 'bun:test';
+import { validateRecipe } from '../src/recipe.js';
+import { buildFrameworkAgentConfig } from '../src/framework-agent-config.js';
+
+function recipe(agent: Record<string, unknown> = {}, top: Record<string, unknown> = {}) {
+  return { name: 'cap-window-test', agent: { systemPrompt: 'sys', ...agent }, ...top };
+}
+
+describe('recipe toolResultInlineMaxChars (AF #89)', () => {
+  test('accepts a valid cap and preserves it', () => {
+    expect(validateRecipe(recipe({}, { toolResultInlineMaxChars: 200_000 })).toolResultInlineMaxChars)
+      .toBe(200_000);
+  });
+
+  test('omitted stays omitted — AF house default applies', () => {
+    expect(validateRecipe(recipe()).toolResultInlineMaxChars).toBeUndefined();
+  });
+
+  test('rejects values below the AF minimum at load time', () => {
+    expect(() => validateRecipe(recipe({}, { toolResultInlineMaxChars: 500 })))
+      .toThrow(/toolResultInlineMaxChars must be a number >= 1000/);
+    expect(() => validateRecipe(recipe({}, { toolResultInlineMaxChars: '5000' })))
+      .toThrow(/toolResultInlineMaxChars/);
+  });
+});
+
+describe('recipe agent.physicalWindowTokens (AF #92)', () => {
+  test('accepts and passes through to the framework agent config', () => {
+    const r = validateRecipe(recipe({ physicalWindowTokens: 200_000 }));
+    expect(r.agent.physicalWindowTokens).toBe(200_000);
+    const config = buildFrameworkAgentConfig(r, 'agent', 'model', undefined);
+    expect(config.physicalWindowTokens).toBe(200_000);
+  });
+
+  test('omitted stays ABSENT in the agent config — AF projection stays off', () => {
+    const config = buildFrameworkAgentConfig(validateRecipe(recipe()), 'agent', 'model', undefined);
+    expect('physicalWindowTokens' in config).toBe(false);
+  });
+
+  test('rejects non-positive or non-numeric values at load time', () => {
+    expect(() => validateRecipe(recipe({ physicalWindowTokens: 0 })))
+      .toThrow(/physicalWindowTokens must be a positive number/);
+    expect(() => validateRecipe(recipe({ physicalWindowTokens: '200000' })))
+      .toThrow(/physicalWindowTokens/);
+  });
+});


### PR DESCRIPTION
The promised host halves of the AF release train's two new knobs — opened dependency-blocked, host#79-style, so it can land the moment the AF release is cut.

## What

- **Top-level `toolResultInlineMaxChars` → `FrameworkConfig`** (af#89, merged in af#91/#94): durable residence default for the tool-result inline cap. Validated `>= 1000` at recipe load, mirroring AF's own `create()` rule, so a bad value fails with a recipe-shaped error instead of at framework create. **This is the deploy lever antra asked for**: residences *without* a writable workspace (Princess) get truncation-not-spill under AF's new 5000 default — set this high there if the resident should keep receiving large results inline. A resident's own durable `agent_settings` value still takes precedence for that agent, and every source is hard-clamped to the strategy bound (Sol's #94 ruling).
- **`agent.physicalWindowTokens` → `AgentConfig`** (af#92, PR af#98): the provider's hard context cap, enabling AF's mid-turn physical-window projection restart (fresh compile instead of a wire `context_length_exceeded` 400). Validated positive at load. Intended first users: 200k-capped residents — Rhys/Evander/Princess-shaped deployments.

Both omitted → AF behavior byte-identical. Follows the existing `codeExecution` passthrough pattern in `createFrameworkFromRecipe` and the `maxStreamTokens` pattern in `buildFrameworkAgentConfig`.

## Dependency

Needs an `@animalabs/agent-framework` release carrying af#94 + af#98, then the usual dep bump. Against older AF the keys are **inert** (spread-through only, no crash): `toolResultInlineMaxChars` is ignored by pre-#94 `create()` and `physicalWindowTokens` by the pre-#98 `Agent` constructor — no failure mode during the window, just no effect.

## Tests

`test/recipe-inline-cap-window.test.ts` (6): accept + preserve, omitted-stays-omitted (AF defaults apply / projection stays off — including `'physicalWindowTokens' in config === false`, not merely undefined), and load-time rejection for both keys. Full suite: **616 pass / 0 fail**. `tsc --noEmit` clean.

Deploy note (from the merge≠deploy checklist): after the AF release + this lands, the Princess call (raise cap vs. add workspace vs. keep 5k as cost brake) and the keep-box/LabClaude recipe audit decide the actual per-residence values — this PR only provides the knob.

🤖 Generated with [Claude Code](https://claude.com/claude-code)