### PR TITLE
chore(deps): agent-framework ^0.9.0, chronicle ^0.3.0, membrane ^0.5.78

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,10 @@
 
 ### Changed
 
-- **Dependency floor: agent-framework `^0.9.0`, chronicle `^0.3.0`,
-  membrane `^0.5.78`.** af 0.9.0 brings `ConversationRouter` (the
-  per-channel conversation-fork machinery the upcoming `conversations`
-  recipe surface targets) and exports `nudgeAgent`, which `/nudge` has
+- **Dependency floor: agent-framework `^0.10.0`, chronicle `^0.3.0`,
+  membrane `^0.5.78`.** af 0.10.0 brings `ConversationRouter` (the
+  per-channel conversation-fork machinery this release’s `conversations`
+  recipe surface targets, and includes the current `hybrid` prose router) and exports `nudgeAgent`, which `/nudge` has
   called since it landed — on every published af before 0.9.0 that call
   was a guaranteed `TypeError`, so the floor also makes `/nudge` actually
   work. Chronicle `^0.3.0` aligns the whole tree on one chronicle copy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@
 
 ### Changed
 
+- **Dependency floor: agent-framework `^0.9.0`, chronicle `^0.3.0`,
+  membrane `^0.5.78`.** af 0.9.0 brings `ConversationRouter` (the
+  per-channel conversation-fork machinery the upcoming `conversations`
+  recipe surface targets) and exports `nudgeAgent`, which `/nudge` has
+  called since it landed — on every published af before 0.9.0 that call
+  was a guaranteed `TypeError`, so the floor also makes `/nudge` actually
+  work. Chronicle `^0.3.0` aligns the whole tree on one chronicle copy
+  (previously context-manager `0.6.3` nested its own `0.3.0` next to the
+  host's `0.2.x`). Operators: run a clean `npm ci` — a stale
+  `node_modules` predating the lock is the known failure mode here.
+
 - **The public triumvirate recipes boot from a fresh clone.**
   `knowledge-miner.json` no longer ships a `syncntn` (Notion) block pointing at
   an org-internal adapter that isn't publicly available — with `NOTION_*` env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,15 @@
 
 - **Hybrid prose routing.** Recipes may set `agent.proseRouting: "hybrid"`: unprefixed text keeps ordinary frozen-locus delivery, while a leading `>>>destination` publication envelope routes through Agent Framework’s existing authorized cross-surface resolver. Source text retains the envelope; recipients see only the body; success/failure returns to resident context.
 
+- **`conversations` recipe block — per-channel conversation forks.** Maps to
+  agent-framework's `ConversationRouter`: the recipe's agent becomes a dormant
+  trunk template, and qualifying incoming channel messages spawn per-channel
+  fork agents seeded from the trunk's current context. Recipe surface: `bind` /
+  `trigger` rules per channel kind (`dm`/`groupDm`/`channel`), `idleTtlMs`
+  (default 12h), `closurePrompt`, and `agentPrefix`. The host fills
+  `templateAgent` from the recipe and creates a fresh stateful strategy instance
+  for each fork. Absent block means no routing and no behavior change.
+
 - **Standing autobiographical production target.** Recipes may set `agent.strategy.productionBudgetTokens` to keep the summary forest deep enough for a later live context-budget descent without a fold storm. This is a context-token target passed through to Context Manager, not a provider-spend ceiling; omission preserves Context Manager defaults.
 
 - **`BEDROCK_BASE_URL` env hook** for the bedrock provider — mirrors

--- a/bun.lock
+++ b/bun.lock
@@ -1,14 +1,14 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
-      "name": "connectome-host",
+      "name": "@animalabs/connectome-host",
       "dependencies": {
-        "@animalabs/agent-framework": "^0.7.0",
-        "@animalabs/chronicle": "^0.2.0",
-        "@animalabs/context-manager": "^0.6.0",
-        "@animalabs/membrane": "^0.5.75",
+        "@animalabs/agent-framework": "^0.10.0",
+        "@animalabs/chronicle": "^0.3.0",
+        "@animalabs/context-manager": "^0.6.3",
+        "@animalabs/membrane": "^0.5.78",
         "@opentui/core": "^0.1.82",
       },
       "devDependencies": {
@@ -19,13 +19,13 @@
     },
   },
   "packages": {
-    "@animalabs/agent-framework": ["@animalabs/agent-framework@0.7.0", "", { "dependencies": { "@animalabs/chronicle": "^0.2.2", "@animalabs/context-manager": "^0.6.0", "@animalabs/membrane": "^0.5.75", "chokidar": "^4.0.3", "discord.js": "^14.25.1", "ws": "^8.18.0" }, "bin": { "agent-framework-mcp": "dist/src/api/mcp-server.js", "agent-framework-recover": "dist/src/recovery/recover-cli.js" } }, "sha512-9FRQsCPaCZuZe0pyj+xq2NvdbSWQxRvdgO8nojVezpysaJL+w/Ba9tahGaOK7ZP12ZqnX3Q88wlttsXY+A47Gw=="],
+    "@animalabs/agent-framework": ["@animalabs/agent-framework@0.10.0", "", { "dependencies": { "@animalabs/chronicle": "^0.3.0", "@animalabs/context-manager": "^0.6.0", "@animalabs/membrane": "^0.5.78", "chokidar": "^4.0.3", "discord.js": "^14.25.1", "ws": "^8.18.0" }, "bin": { "agent-framework-mcp": "dist/src/api/mcp-server.js", "agent-framework-recover": "dist/src/recovery/recover-cli.js" } }, "sha512-ZFCoOF4/T+5aj3uwER49qQ3/XtzNRIVgNg00tNrUg/nCaSdj6XsDo91kqTen1bHCdNK9KB43hui6PDFpjPNOvw=="],
 
-    "@animalabs/chronicle": ["@animalabs/chronicle@0.2.1", "", { "optionalDependencies": { "@animalabs/chronicle-darwin-arm64": "0.2.1", "@animalabs/chronicle-darwin-x64": "0.2.1", "@animalabs/chronicle-linux-arm64-gnu": "0.2.1", "@animalabs/chronicle-linux-x64-gnu": "0.2.1", "@animalabs/chronicle-win32-x64-msvc": "0.2.1" } }, "sha512-rDFc069yfi7BQUusgsXBwBdqljUWLByXSYaTF40AP+tonBh0No3eF9VzKTSy1I8DYg/jAUHIKtVdKDGsVMVubw=="],
+    "@animalabs/chronicle": ["@animalabs/chronicle@0.3.0", "", {}, "sha512-6BBJ9pWb8AnuHTNJTU07Y6Wut3IvdgWFxsy05IdlWcEnR5W23dlaBlaeJq7gDc7TwX05HfsDC+QZFEc69G+s4Q=="],
 
-    "@animalabs/context-manager": ["@animalabs/context-manager@0.6.0", "", { "dependencies": { "@animalabs/chronicle": "^0.2.6", "@animalabs/membrane": "^0.5.69" } }, "sha512-X8PKvHouS0dXt6faHeMyI2FehgyFKPT3vBaqM7QN6o/O/3I5pU8UX+WR1nsixfgw+la83lDC+OHn+lPe1A7DVg=="],
+    "@animalabs/context-manager": ["@animalabs/context-manager@0.6.3", "", { "dependencies": { "@animalabs/chronicle": "^0.3.0", "@animalabs/membrane": "^0.5.69" } }, "sha512-zh60LgZxXzBbGrLpDHBAfGSPSL/H8mxz8nSWLOSh4pjiTOYbD0o0BjAM8CFz4LiaOIXnuSCbRoiv5UKsnrKwDw=="],
 
-    "@animalabs/membrane": ["@animalabs/membrane@0.5.75", "", { "dependencies": { "@anthropic-ai/sdk": "^0.52.0" } }, "sha512-eWtkrbQQga8UWDMH4VzPfZzcwYQLwngUcQ2tMeuERMBJ6WkXQzSJkcQVjM3ZvexvytnLsFTMOATvT58Igl9JuA=="],
+    "@animalabs/membrane": ["@animalabs/membrane@0.5.79", "", { "dependencies": { "@anthropic-ai/sdk": "^0.52.0" } }, "sha512-wVto7V/WHqlG4P2FjyKv+WxqvhDi0NKb7iLlAdFTFnlCPfxrguDrUJoUx9MNCAjDSVjpwsb6c6rrokjnO0E+pw=="],
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.52.0", "", { "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-d4c+fg+xy9e46c8+YnrrgIQR45CZlAi7PwdzIfDXDM6ACxEZli1/fxhURsq30ZpMZy6LvSkr41jGq5aF5TD7rQ=="],
 
@@ -37,7 +37,7 @@
 
     "@discordjs/formatters": ["@discordjs/formatters@0.6.2", "", { "dependencies": { "discord-api-types": "^0.38.33" } }, "sha512-y4UPwWhH6vChKRkGdMB4odasUbHOUwy7KL+OVwF86PvT6QVOwElx+TiI1/6kcmcEe+g5YRXJFiXSXUdabqZOvQ=="],
 
-    "@discordjs/rest": ["@discordjs/rest@2.6.1", "", { "dependencies": { "@discordjs/collection": "^2.1.1", "@discordjs/util": "^1.2.0", "@sapphire/async-queue": "^1.5.3", "@sapphire/snowflake": "^3.5.5", "@vladfrangu/async_event_emitter": "^2.4.6", "discord-api-types": "^0.38.40", "magic-bytes.js": "^1.13.0", "tslib": "^2.6.3", "undici": "6.24.1" } }, "sha512-wwQdgjeaoYFiaG+atbqx6aJDpqW7JHAo0HrQkBTbYzM3/PJ3GweQIpgElNcGZ26DCUOXMyawYd0YF7vtr+fZXg=="],
+    "@discordjs/rest": ["@discordjs/rest@2.6.3", "", { "dependencies": { "@discordjs/collection": "^2.1.1", "@discordjs/util": "^1.2.0", "@sapphire/async-queue": "^1.5.3", "@sapphire/snowflake": "^3.5.5", "@vladfrangu/async_event_emitter": "^2.4.6", "discord-api-types": "^0.38.50", "magic-bytes.js": "^1.13.0", "tslib": "^2.6.3", "undici": "^6.27.0" } }, "sha512-wvOylxNYJkwKjctS/Mn5GP1w9r3/rzyH+ThD1JlAca6zEdlHs8QWBBUQJpU5Q+W6DoIj/Ljh1IPlZs7hTU+UAg=="],
 
     "@discordjs/util": ["@discordjs/util@1.2.0", "", { "dependencies": { "discord-api-types": "^0.38.33" } }, "sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg=="],
 
@@ -117,23 +117,23 @@
 
     "@sapphire/shapeshift": ["@sapphire/shapeshift@4.0.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "lodash": "^4.17.21" } }, "sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg=="],
 
-    "@sapphire/snowflake": ["@sapphire/snowflake@3.5.3", "", {}, "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ=="],
+    "@sapphire/snowflake": ["@sapphire/snowflake@3.5.5", "", {}, "sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ=="],
 
     "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
 
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
-    "@types/node": ["@types/node@22.19.19", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew=="],
+    "@types/node": ["@types/node@22.20.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q=="],
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "@vladfrangu/async_event_emitter": ["@vladfrangu/async_event_emitter@2.4.7", "", {}, "sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g=="],
 
-    "@webgpu/types": ["@webgpu/types@0.1.70", "", {}, "sha512-LFiNHHKMvmAEvwVew3JLJmTdShhbdwRFSImUshGhE2mGE8ybQzIo63l5uRp+YKnNx+8Qno8Kf6gN+DKMreIJCA=="],
+    "@webgpu/types": ["@webgpu/types@0.1.71", "", {}, "sha512-mMy8/ODcKhab808co15eW+yN+HgXoQxRQHTiBV9Mrvl1r0ufnid7YOcI+gi4eUWSWl9ezD6TW2KXccrL8HCh2A=="],
 
     "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
 
-    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+    "ansi-regex": ["ansi-regex@6.3.0", "", {}, "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ=="],
 
     "any-base": ["any-base@1.1.0", "", {}, "sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg=="],
 
@@ -163,9 +163,9 @@
 
     "diff": ["diff@8.0.2", "", {}, "sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg=="],
 
-    "discord-api-types": ["discord-api-types@0.38.48", "", {}, "sha512-WFUE/2o0lBlLeCQonQ+Pu2RqHAqbytBJ2RlXR91gzk05InSS6k9ShzzLYoymrA4c2oRgRKGE7/VqQJNNdGWSxQ=="],
+    "discord-api-types": ["discord-api-types@0.38.53", "", {}, "sha512-HL1zz/UuZ+bbJjA/X8Kbxx9gk8v9rJAbTeWRNYKmIdjwJ7EovjlHgoJTxcLpATfNJ+AonOtMdy3Y5MVIJAAd/A=="],
 
-    "discord.js": ["discord.js@14.26.4", "", { "dependencies": { "@discordjs/builders": "^1.14.1", "@discordjs/collection": "1.5.3", "@discordjs/formatters": "^0.6.2", "@discordjs/rest": "^2.6.1", "@discordjs/util": "^1.2.0", "@discordjs/ws": "^1.2.3", "@sapphire/snowflake": "3.5.3", "discord-api-types": "^0.38.40", "fast-deep-equal": "3.1.3", "lodash.snakecase": "4.1.1", "magic-bytes.js": "^1.13.0", "tslib": "^2.6.3", "undici": "6.24.1" } }, "sha512-4oBp8tc6Kf8IDBwAHhbsMaAqx1b5fob9SNasZT7V6yyyUydoO5i5fGuX7TmvRtR+q/WgKRnRViRoAWnG7fNyvA=="],
+    "discord.js": ["discord.js@14.27.0", "", { "dependencies": { "@discordjs/builders": "^1.14.1", "@discordjs/collection": "1.5.3", "@discordjs/formatters": "^0.6.2", "@discordjs/rest": "^2.6.2", "@discordjs/util": "^1.2.0", "@discordjs/ws": "^1.2.3", "@sapphire/snowflake": "3.5.5", "discord-api-types": "^0.38.49", "fast-deep-equal": "3.1.3", "lodash.snakecase": "4.1.1", "magic-bytes.js": "^1.13.0", "tslib": "^2.6.3", "undici": "^6.27.0" } }, "sha512-qHbFlFG2N7y3LjPySYsL6A1+BnX6bkTVgo842EX0CqVPk/KTMwZkojPHEXKsQUpWZNyz5BISNHK1cPpQw0+m4A=="],
 
     "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
@@ -195,11 +195,11 @@
 
     "lodash.snakecase": ["lodash.snakecase@4.1.1", "", {}, "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw=="],
 
-    "magic-bytes.js": ["magic-bytes.js@1.13.0", "", {}, "sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg=="],
+    "magic-bytes.js": ["magic-bytes.js@1.13.1", "", {}, "sha512-x5sn4UX2k5gCWlcfmoFwG4TPie8+dctESyqOBdhB5p6MsgWXdBKGmt9nXPObj/JI50TTL928lc5Yt1WntMn1bw=="],
 
-    "marked": ["marked@17.0.1", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg=="],
+    "marked": ["marked@17.0.1", "", { "bin": "bin/marked.js" }, "sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg=="],
 
-    "mime": ["mime@3.0.0", "", { "bin": { "mime": "cli.js" } }, "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A=="],
+    "mime": ["mime@3.0.0", "", { "bin": "cli.js" }, "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A=="],
 
     "omggif": ["omggif@1.0.10", "", {}, "sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw=="],
 
@@ -213,9 +213,9 @@
 
     "peek-readable": ["peek-readable@4.1.0", "", {}, "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg=="],
 
-    "pixelmatch": ["pixelmatch@5.3.0", "", { "dependencies": { "pngjs": "^6.0.0" }, "bin": { "pixelmatch": "bin/pixelmatch" } }, "sha512-o8mkY4E/+LNUf6LzX96ht6k6CEDi65k9G2rjMtBe9Oo+VPKSvl+0GKHuH/AlG+GA5LPG/i5hrekkxUc3s2HU+Q=="],
+    "pixelmatch": ["pixelmatch@5.3.0", "", { "dependencies": { "pngjs": "^6.0.0" }, "bin": "bin/pixelmatch" }, "sha512-o8mkY4E/+LNUf6LzX96ht6k6CEDi65k9G2rjMtBe9Oo+VPKSvl+0GKHuH/AlG+GA5LPG/i5hrekkxUc3s2HU+Q=="],
 
-    "planck": ["planck@1.5.0", "", { "peerDependencies": { "stage-js": "^1.0.0-alpha.12" } }, "sha512-dlvqJE+FscZgrGUXJ5ybd0o5bvZ5XXyZNbm08xGsXp9WjXeAyWSFT6n9s/1PQcUBo4546fDXA5RMA4wbDyZw6g=="],
+    "planck": ["planck@1.4.2", "", { "peerDependencies": { "stage-js": "^1.0.0-alpha.12" } }, "sha512-mNbhnV3g8X2rwGxzcesjmN8BDA6qfXgQxXVMkWau9MCRlQY0RLNEkyHlVp6yFy/X6qrzAXyNONCnZ1cGDLrNew=="],
 
     "pngjs": ["pngjs@7.0.0", "", {}, "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow=="],
 
@@ -229,11 +229,11 @@
 
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
-    "sax": ["sax@1.6.0", "", {}, "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA=="],
+    "sax": ["sax@1.6.1", "", {}, "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q=="],
 
     "simple-xml-to-json": ["simple-xml-to-json@1.2.7", "", {}, "sha512-mz9VXphOxQWX3eQ/uXCtm6upltoN0DLx8Zb5T4TFC4FHB7S9FDPGre8CfLWqPWQQH/GrQYd2AXhhVM5LDpYx6Q=="],
 
-    "stage-js": ["stage-js@1.0.2", "", {}, "sha512-EWTRBYlg7Qv9wGUao99/PfRe3KaiQqWmgSvTOXvaWnu1Jk/q/vV8yJVu6bi/3EqDZeMVnCPAjheba6OFc5k1GQ=="],
+    "stage-js": ["stage-js@1.0.1", "", {}, "sha512-cz14aPp/wY0s3bkb/B93BPP5ZAEhgBbRmAT3CCDqert8eCAqIpQ0RB2zpK8Ksxf+Pisl5oTzvPHtL4CVzzeHcw=="],
 
     "string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
@@ -255,7 +255,7 @@
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
-    "undici": ["undici@6.24.1", "", {}, "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA=="],
+    "undici": ["undici@6.28.0", "", {}, "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA=="],
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
@@ -263,7 +263,7 @@
 
     "web-tree-sitter": ["web-tree-sitter@0.25.10", "", { "peerDependencies": { "@types/emscripten": "^1.40.0" }, "optionalPeers": ["@types/emscripten"] }, "sha512-Y09sF44/13XvgVKgO2cNDw5rGk6s26MgoZPXLESvMXeefBf7i6/73eFurre0IsTW6E14Y0ArIzhUMmjoc7xyzA=="],
 
-    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
+    "ws": ["ws@8.21.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw=="],
 
     "xml-parse-from-string": ["xml-parse-from-string@1.0.1", "", {}, "sha512-ErcKwJTF54uRzzNMXq2X5sMIy88zJvfN2DmdoQvy7PAFJ+tPRU6ydWuOKNMyfmOjdyBQTFREi60s0Y0SyI0G0g=="],
 
@@ -275,13 +275,7 @@
 
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
-    "@animalabs/agent-framework/@animalabs/chronicle": ["@animalabs/chronicle@0.2.6", "", { "optionalDependencies": { "@animalabs/chronicle-darwin-arm64": "0.2.6", "@animalabs/chronicle-darwin-x64": "0.2.6", "@animalabs/chronicle-linux-arm64-gnu": "0.2.6", "@animalabs/chronicle-linux-x64-gnu": "0.2.6", "@animalabs/chronicle-win32-x64-msvc": "0.2.6" } }, "sha512-+gbt2GR4SP8MnKxeqkJZf6oZn339fLiBtk6GHyBD/gHQ4e4eFqBpTaTd5eKycKBws0xWGcOqyiJFH4IdBkweUA=="],
-
-    "@animalabs/context-manager/@animalabs/chronicle": ["@animalabs/chronicle@0.2.6", "", { "optionalDependencies": { "@animalabs/chronicle-darwin-arm64": "0.2.6", "@animalabs/chronicle-darwin-x64": "0.2.6", "@animalabs/chronicle-linux-arm64-gnu": "0.2.6", "@animalabs/chronicle-linux-x64-gnu": "0.2.6", "@animalabs/chronicle-win32-x64-msvc": "0.2.6" } }, "sha512-+gbt2GR4SP8MnKxeqkJZf6oZn339fLiBtk6GHyBD/gHQ4e4eFqBpTaTd5eKycKBws0xWGcOqyiJFH4IdBkweUA=="],
-
     "@discordjs/rest/@discordjs/collection": ["@discordjs/collection@2.1.1", "", {}, "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg=="],
-
-    "@discordjs/rest/@sapphire/snowflake": ["@sapphire/snowflake@3.5.5", "", {}, "sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ=="],
 
     "@discordjs/ws/@discordjs/collection": ["@discordjs/collection@2.1.1", "", {}, "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg=="],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.7.4",
       "hasInstallScript": true,
       "dependencies": {
-        "@animalabs/agent-framework": "^0.9.0",
+        "@animalabs/agent-framework": "^0.10.0",
         "@animalabs/chronicle": "^0.3.0",
         "@animalabs/context-manager": "^0.6.3",
         "@animalabs/membrane": "^0.5.78",
@@ -21,82 +21,10 @@
         "typescript": "^5.7.0"
       }
     },
-    "../agent-framework": {
-      "name": "@animalabs/agent-framework",
-      "version": "0.2.0",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "@animalabs/chronicle": "^0.1.0",
-        "@animalabs/context-manager": "^0.2.0",
-        "@animalabs/membrane": "^0.5.43",
-        "chokidar": "^4.0.3",
-        "discord.js": "^14.25.1",
-        "ws": "^8.18.0"
-      },
-      "bin": {
-        "agent-framework-mcp": "dist/src/api/mcp-server.js"
-      },
-      "devDependencies": {
-        "@types/node": "^22.0.0",
-        "@types/ws": "^8.5.13",
-        "discord.js": "^14.25.1",
-        "tsx": "^4.21.0",
-        "typescript": "^5.7.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "../chronicle": {
-      "name": "@animalabs/chronicle",
-      "version": "0.1.1",
-      "extraneous": true,
-      "license": "MIT",
-      "devDependencies": {
-        "@napi-rs/cli": "^2.18.0"
-      }
-    },
-    "../context-manager": {
-      "name": "@animalabs/context-manager",
-      "version": "0.2.0",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "@animalabs/chronicle": "^0.1.0",
-        "@animalabs/membrane": "^0.5.40"
-      },
-      "devDependencies": {
-        "@types/node": "^22.0.0",
-        "typescript": "^5.7.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "../membrane": {
-      "name": "@animalabs/membrane",
-      "version": "0.5.43",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "@anthropic-ai/sdk": "^0.52.0"
-      },
-      "devDependencies": {
-        "@types/node": "^22.0.0",
-        "@vitest/coverage-v8": "^4.0.18",
-        "tsx": "^4.21.0",
-        "typescript": "^5.7.0",
-        "vitest": "^4.0.18"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
     "node_modules/@animalabs/agent-framework": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@animalabs/agent-framework/-/agent-framework-0.9.0.tgz",
-      "integrity": "sha512-JCHNbHEuY7tiAx/bPN+xtV8vTl2xi/an4toKc+1x5peaMur83jJLWOABzk+nNgmQk3nPKwwKSUYHRl/yiF5CCg==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@animalabs/agent-framework/-/agent-framework-0.10.0.tgz",
+      "integrity": "sha512-ZFCoOF4/T+5aj3uwER49qQ3/XtzNRIVgNg00tNrUg/nCaSdj6XsDo91kqTen1bHCdNK9KB43hui6PDFpjPNOvw==",
       "license": "MIT",
       "dependencies": {
         "@animalabs/chronicle": "^0.3.0",
@@ -207,9 +135,9 @@
       }
     },
     "node_modules/@discordjs/rest": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.6.1.tgz",
-      "integrity": "sha512-wwQdgjeaoYFiaG+atbqx6aJDpqW7JHAo0HrQkBTbYzM3/PJ3GweQIpgElNcGZ26DCUOXMyawYd0YF7vtr+fZXg==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.6.3.tgz",
+      "integrity": "sha512-wvOylxNYJkwKjctS/Mn5GP1w9r3/rzyH+ThD1JlAca6zEdlHs8QWBBUQJpU5Q+W6DoIj/Ljh1IPlZs7hTU+UAg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@discordjs/collection": "^2.1.1",
@@ -217,10 +145,10 @@
         "@sapphire/async-queue": "^1.5.3",
         "@sapphire/snowflake": "^3.5.5",
         "@vladfrangu/async_event_emitter": "^2.4.6",
-        "discord-api-types": "^0.38.40",
+        "discord-api-types": "^0.38.50",
         "magic-bytes.js": "^1.13.0",
         "tslib": "^2.6.3",
-        "undici": "6.24.1"
+        "undici": "^6.27.0"
       },
       "engines": {
         "node": ">=18"
@@ -239,16 +167,6 @@
       },
       "funding": {
         "url": "https://github.com/discordjs/discord.js?sponsor"
-      }
-    },
-    "node_modules/@discordjs/rest/node_modules/@sapphire/snowflake": {
-      "version": "3.5.5",
-      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.5.tgz",
-      "integrity": "sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=v14.0.0",
-        "npm": ">=7.0.0"
       }
     },
     "node_modules/@discordjs/util": {
@@ -714,26 +632,28 @@
       }
     },
     "node_modules/@opentui/core": {
-      "version": "0.1.92",
-      "resolved": "https://registry.npmjs.org/@opentui/core/-/core-0.1.92.tgz",
-      "integrity": "sha512-c+KdYAIH3M8n24RYaor+t7AQtKZ3l84L7xdP7DEaN4xtuYH8W08E6Gi+wUal4g+HSai3HS9irox68yFf0VPAxw==",
+      "version": "0.1.107",
+      "resolved": "https://registry.npmjs.org/@opentui/core/-/core-0.1.107.tgz",
+      "integrity": "sha512-gadu9EtNR+sOGyHN0buZryllavkWHRkCcX4yW/1ldp/l7HGS52hvkjYmo+74cuzUcfds/5Rbw2cgiy0Z7RxXmQ==",
       "license": "MIT",
       "dependencies": {
         "bun-ffi-structs": "0.1.2",
         "diff": "8.0.2",
         "jimp": "1.6.0",
         "marked": "17.0.1",
+        "string-width": "7.2.0",
+        "strip-ansi": "7.1.2",
         "yoga-layout": "3.2.1"
       },
       "optionalDependencies": {
         "@dimforge/rapier2d-simd-compat": "^0.17.3",
-        "@opentui/core-darwin-arm64": "0.1.92",
-        "@opentui/core-darwin-x64": "0.1.92",
-        "@opentui/core-linux-arm64": "0.1.92",
-        "@opentui/core-linux-x64": "0.1.92",
-        "@opentui/core-win32-arm64": "0.1.92",
-        "@opentui/core-win32-x64": "0.1.92",
-        "bun-webgpu": "0.1.5",
+        "@opentui/core-darwin-arm64": "0.1.107",
+        "@opentui/core-darwin-x64": "0.1.107",
+        "@opentui/core-linux-arm64": "0.1.107",
+        "@opentui/core-linux-x64": "0.1.107",
+        "@opentui/core-win32-arm64": "0.1.107",
+        "@opentui/core-win32-x64": "0.1.107",
+        "bun-webgpu": "0.1.7",
         "planck": "^1.4.2",
         "three": "0.177.0"
       },
@@ -742,9 +662,9 @@
       }
     },
     "node_modules/@opentui/core-darwin-arm64": {
-      "version": "0.1.92",
-      "resolved": "https://registry.npmjs.org/@opentui/core-darwin-arm64/-/core-darwin-arm64-0.1.92.tgz",
-      "integrity": "sha512-NX/qFRuc7My0pazyOrw9fdTXmU7omXcZzQuHcsaVnwssljaT52UYMrJ7mCKhSo69RhHw0lnGCymTorvz3XBdsA==",
+      "version": "0.1.107",
+      "resolved": "https://registry.npmjs.org/@opentui/core-darwin-arm64/-/core-darwin-arm64-0.1.107.tgz",
+      "integrity": "sha512-Yqt2/9Ntw0IdtPA/qmHvXCE16y4Jq5/btCmuzN9/opzqZ5rYGYYVtiBii3LezGcTZYuJQZthjvh8MLPXXwA2EQ==",
       "cpu": [
         "arm64"
       ],
@@ -755,9 +675,9 @@
       ]
     },
     "node_modules/@opentui/core-darwin-x64": {
-      "version": "0.1.92",
-      "resolved": "https://registry.npmjs.org/@opentui/core-darwin-x64/-/core-darwin-x64-0.1.92.tgz",
-      "integrity": "sha512-Zb4jn33hOf167llINKLniOabQIycs14LPOBZnQ6l4khbeeTPVJdG8gy9PhlAyIQygDKmRTFncVlP0RP+L6C7og==",
+      "version": "0.1.107",
+      "resolved": "https://registry.npmjs.org/@opentui/core-darwin-x64/-/core-darwin-x64-0.1.107.tgz",
+      "integrity": "sha512-p6yeHsIWRLy/J30nZTyUuwgFYEpk8NS0H0Cmh9P8a1+eHA406MMMP4FAC0YpqlF4SHb7R7LNkUSsfCx9yMtS8w==",
       "cpu": [
         "x64"
       ],
@@ -768,9 +688,9 @@
       ]
     },
     "node_modules/@opentui/core-linux-arm64": {
-      "version": "0.1.92",
-      "resolved": "https://registry.npmjs.org/@opentui/core-linux-arm64/-/core-linux-arm64-0.1.92.tgz",
-      "integrity": "sha512-4VA1A91OTMPJ3LkAyaxKEZVJsk5jIc3Kz0gV2vip8p2aGLPpYHHpkFZpXP/FyzsnJzoSGftBeA6ya1GKa5bkXg==",
+      "version": "0.1.107",
+      "resolved": "https://registry.npmjs.org/@opentui/core-linux-arm64/-/core-linux-arm64-0.1.107.tgz",
+      "integrity": "sha512-w6MpRTd06KUH4KdgH4x7rVB2I67KE62w3W3jQVBDEMeJejdJVOSwwUdgaTY9ffoHglcZc3WA2PFH1PCpgzna4A==",
       "cpu": [
         "arm64"
       ],
@@ -781,9 +701,9 @@
       ]
     },
     "node_modules/@opentui/core-linux-x64": {
-      "version": "0.1.92",
-      "resolved": "https://registry.npmjs.org/@opentui/core-linux-x64/-/core-linux-x64-0.1.92.tgz",
-      "integrity": "sha512-tr7va8hfKS1uY+TBmulQBoBlwijzJk56K/U/L9/tbHfW7oJctqxPVwEFHIh1HDcOQ3/UhMMWGvMfeG6cFiK8/A==",
+      "version": "0.1.107",
+      "resolved": "https://registry.npmjs.org/@opentui/core-linux-x64/-/core-linux-x64-0.1.107.tgz",
+      "integrity": "sha512-oxKbIpWZRgY+8KQZ9dXq8lzDEhMVpBMCiZGDiHtK8/DP1MvK5kFE/vtwgUK9YkmT4OSgZsFeojjvyePXV+PcfQ==",
       "cpu": [
         "x64"
       ],
@@ -794,9 +714,9 @@
       ]
     },
     "node_modules/@opentui/core-win32-arm64": {
-      "version": "0.1.92",
-      "resolved": "https://registry.npmjs.org/@opentui/core-win32-arm64/-/core-win32-arm64-0.1.92.tgz",
-      "integrity": "sha512-34YM3uPtDjzUVeSnJWIK2J8mxyduzV7f3mYc4Hub0glNpUdM1jjzF2HvvvnrKK5ElzTsIcno3c3lOYT8yvG1Zg==",
+      "version": "0.1.107",
+      "resolved": "https://registry.npmjs.org/@opentui/core-win32-arm64/-/core-win32-arm64-0.1.107.tgz",
+      "integrity": "sha512-T7hbLgoTkb5eAsP5GJdTRyDl48WI/hMEtj+BGlIITzSaOBSN7ZPCeblcfUz+uXrdF6g3dF1a9uyEQSJlzeGaKA==",
       "cpu": [
         "arm64"
       ],
@@ -807,9 +727,9 @@
       ]
     },
     "node_modules/@opentui/core-win32-x64": {
-      "version": "0.1.92",
-      "resolved": "https://registry.npmjs.org/@opentui/core-win32-x64/-/core-win32-x64-0.1.92.tgz",
-      "integrity": "sha512-uk442kA2Vn0mmJHHqk5sPM+Zai/AN9sgl7egekhoEOUx2VK3gxftKsVlx2YVpCHTvTE/S+vnD2WpQaJk2SNjww==",
+      "version": "0.1.107",
+      "resolved": "https://registry.npmjs.org/@opentui/core-win32-x64/-/core-win32-x64-0.1.107.tgz",
+      "integrity": "sha512-e/uFLPyKK/hFDvDZtTxp6L3Zx0FWuZv5Gf2qIKf/7FAAadD0hala+K41OJAmYWxu1X3cT5XozKCT8gN/S1N08A==",
       "cpu": [
         "x64"
       ],
@@ -843,9 +763,9 @@
       }
     },
     "node_modules/@sapphire/snowflake": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.3.tgz",
-      "integrity": "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==",
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.5.tgz",
+      "integrity": "sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ==",
       "license": "MIT",
       "engines": {
         "node": ">=v14.0.0",
@@ -869,9 +789,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.19.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.11.tgz",
-      "integrity": "sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==",
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -897,9 +817,9 @@
       }
     },
     "node_modules/@webgpu/types": {
-      "version": "0.1.69",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.69.tgz",
-      "integrity": "sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ==",
+      "version": "0.1.71",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.71.tgz",
+      "integrity": "sha512-mMy8/ODcKhab808co15eW+yN+HgXoQxRQHTiBV9Mrvl1r0ufnid7YOcI+gi4eUWSWl9ezD6TW2KXccrL8HCh2A==",
       "license": "BSD-3-Clause",
       "optional": true
     },
@@ -913,6 +833,18 @@
       },
       "engines": {
         "node": ">=6.5"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
     "node_modules/any-base": {
@@ -1000,25 +932,25 @@
       }
     },
     "node_modules/bun-webgpu": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/bun-webgpu/-/bun-webgpu-0.1.5.tgz",
-      "integrity": "sha512-91/K6S5whZKX7CWAm9AylhyKrLGRz6BUiiPiM/kXadSnD4rffljCD/q9cNFftm5YXhx4MvLqw33yEilxogJvwA==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/bun-webgpu/-/bun-webgpu-0.1.7.tgz",
+      "integrity": "sha512-KUxUp+oQIf7pPBMD4Hv1TUu7DWaOZ4ciKulTk9to9+Uc8yHoYrMW7L2SJCJ4FHHkywgf/7aLRgRx0b7i6DvGIQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@webgpu/types": "^0.1.60"
       },
       "optionalDependencies": {
-        "bun-webgpu-darwin-arm64": "^0.1.5",
-        "bun-webgpu-darwin-x64": "^0.1.5",
-        "bun-webgpu-linux-x64": "^0.1.5",
-        "bun-webgpu-win32-x64": "^0.1.5"
+        "bun-webgpu-darwin-arm64": "^0.1.7",
+        "bun-webgpu-darwin-x64": "^0.1.7",
+        "bun-webgpu-linux-x64": "^0.1.7",
+        "bun-webgpu-win32-x64": "^0.1.7"
       }
     },
     "node_modules/bun-webgpu-darwin-arm64": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/bun-webgpu-darwin-arm64/-/bun-webgpu-darwin-arm64-0.1.6.tgz",
-      "integrity": "sha512-lIsDkPzJzPl6yrB5CUOINJFPnTRv6fF/Q8J1mAr43ogSp86WZEg9XZKaT6f3EUJ+9ETogGoMnoj1q0AwHUTbAQ==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/bun-webgpu-darwin-arm64/-/bun-webgpu-darwin-arm64-0.1.7.tgz",
+      "integrity": "sha512-mRrFFyHzPWjsTRidAZBRcu808CPQBOUL0P6b4nxLhp+XHcV/mbUHERZMgW9s58tsojQfSdzschiQa8q+JCgRWA==",
       "cpu": [
         "arm64"
       ],
@@ -1029,9 +961,9 @@
       ]
     },
     "node_modules/bun-webgpu-darwin-x64": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/bun-webgpu-darwin-x64/-/bun-webgpu-darwin-x64-0.1.6.tgz",
-      "integrity": "sha512-uEddf5U7GvKIkM/BV18rUKtYHL6d0KeqBjNHwfqDH9QgEo9KVSKvJXS5I/sMefk5V5pIYE+8tQhtrREevhocng==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/bun-webgpu-darwin-x64/-/bun-webgpu-darwin-x64-0.1.7.tgz",
+      "integrity": "sha512-g0NXGNgvaVCSH/jCWWlfdiquOHkbUN6vP4zqzSkIxWKQeLnqm3oADcok7SO3yIgI7v5mKpRc/ks7NDEKNH+jNQ==",
       "cpu": [
         "x64"
       ],
@@ -1042,9 +974,9 @@
       ]
     },
     "node_modules/bun-webgpu-linux-x64": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/bun-webgpu-linux-x64/-/bun-webgpu-linux-x64-0.1.6.tgz",
-      "integrity": "sha512-Y/f15j9r8ba0xUz+3lATtS74OE+PPzQXO7Do/1eCluJcuOlfa77kMjvBK/ShWnem3Y9xqi59pebTPOGRB+CaJA==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/bun-webgpu-linux-x64/-/bun-webgpu-linux-x64-0.1.7.tgz",
+      "integrity": "sha512-UEP7UZdEhx9otvkZczjsszL8ZVlrODANQvgl+C88/bNVmxDoFi7w1fWzGi1sZyakiETjmtFDq2/xCLhbSZxjqw==",
       "cpu": [
         "x64"
       ],
@@ -1055,9 +987,9 @@
       ]
     },
     "node_modules/bun-webgpu-win32-x64": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/bun-webgpu-win32-x64/-/bun-webgpu-win32-x64-0.1.6.tgz",
-      "integrity": "sha512-MHSFAKqizISb+C5NfDrFe3g0Al5Njnu0j/A+oO2Q+bIWX+fUYjBSowiYE1ZXJx65KuryuB+tiM7Qh6cQbVvkEg==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/bun-webgpu-win32-x64/-/bun-webgpu-win32-x64-0.1.7.tgz",
+      "integrity": "sha512-KZktiFkBz6sN7PEm1NVdeaLP5Q5X/PlSHZqefY4nNuWtf0LNvh54NhZe7yVv/Plz/nGbv92b0KHMBY3ki/pp6g==",
       "cpu": [
         "x64"
       ],
@@ -1092,33 +1024,33 @@
       }
     },
     "node_modules/discord-api-types": {
-      "version": "0.38.47",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.47.tgz",
-      "integrity": "sha512-XgXQodHQBAE6kfD7kMvVo30863iHX1LHSqNq6MGUTDwIFCCvHva13+rwxyxVXDqudyApMNAd32PGjgVETi5rjA==",
+      "version": "0.38.53",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.53.tgz",
+      "integrity": "sha512-HL1zz/UuZ+bbJjA/X8Kbxx9gk8v9rJAbTeWRNYKmIdjwJ7EovjlHgoJTxcLpATfNJ+AonOtMdy3Y5MVIJAAd/A==",
       "license": "MIT",
       "workspaces": [
         "scripts/actions/documentation"
       ]
     },
     "node_modules/discord.js": {
-      "version": "14.26.3",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.26.3.tgz",
-      "integrity": "sha512-XEKtYn28YFsiJ5l4fLRyikdbo6RD5oFyqfVHQlvXz2104JhH/E8slN28dbky05w3DCrJcNVWvhVvcJCTSl/KIg==",
+      "version": "14.27.0",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.27.0.tgz",
+      "integrity": "sha512-qHbFlFG2N7y3LjPySYsL6A1+BnX6bkTVgo842EX0CqVPk/KTMwZkojPHEXKsQUpWZNyz5BISNHK1cPpQw0+m4A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@discordjs/builders": "^1.14.1",
         "@discordjs/collection": "1.5.3",
         "@discordjs/formatters": "^0.6.2",
-        "@discordjs/rest": "^2.6.1",
+        "@discordjs/rest": "^2.6.2",
         "@discordjs/util": "^1.2.0",
         "@discordjs/ws": "^1.2.3",
-        "@sapphire/snowflake": "3.5.3",
-        "discord-api-types": "^0.38.40",
+        "@sapphire/snowflake": "3.5.5",
+        "discord-api-types": "^0.38.49",
         "fast-deep-equal": "3.1.3",
         "lodash.snakecase": "4.1.1",
         "magic-bytes.js": "^1.13.0",
         "tslib": "^2.6.3",
-        "undici": "6.24.1"
+        "undici": "^6.27.0"
       },
       "engines": {
         "node": ">=18"
@@ -1126,6 +1058,12 @@
       "funding": {
         "url": "https://github.com/discordjs/discord.js?sponsor"
       }
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
     },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
@@ -1171,6 +1109,18 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/gifwrap": {
@@ -1275,9 +1225,9 @@
       "license": "MIT"
     },
     "node_modules/magic-bytes.js": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.13.0.tgz",
-      "integrity": "sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.13.1.tgz",
+      "integrity": "sha512-x5sn4UX2k5gCWlcfmoFwG4TPie8+dctESyqOBdhB5p6MsgWXdBKGmt9nXPObj/JI50TTL928lc5Yt1WntMn1bw==",
       "license": "MIT"
     },
     "node_modules/marked": {
@@ -1373,13 +1323,13 @@
       }
     },
     "node_modules/planck": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/planck/-/planck-1.4.3.tgz",
-      "integrity": "sha512-B+lHKhRSeg7vZOfEyEzyQVu7nx8JHcX3QgnAcHXrPW0j04XYKX5eXSiUrxH2Z5QR8OoqvjD6zKIaPMdMYAd0uA==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/planck/-/planck-1.4.2.tgz",
+      "integrity": "sha512-mNbhnV3g8X2rwGxzcesjmN8BDA6qfXgQxXVMkWau9MCRlQY0RLNEkyHlVp6yFy/X6qrzAXyNONCnZ1cGDLrNew==",
       "license": "MIT",
       "optional": true,
       "engines": {
-        "node": ">=24.0"
+        "node": ">=14.0"
       },
       "peerDependencies": {
         "stage-js": "^1.0.0-alpha.12"
@@ -1469,21 +1419,32 @@
       "license": "MIT"
     },
     "node_modules/sax": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
-      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+      "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
       }
     },
     "node_modules/simple-xml-to-json": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/simple-xml-to-json/-/simple-xml-to-json-1.2.4.tgz",
-      "integrity": "sha512-3MY16e0ocMHL7N1ufpdObURGyX+lCo0T/A+y6VCwosLdH1HSda4QZl1Sdt/O+2qWp48WFi26XEp5rF0LoaL0Dg==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/simple-xml-to-json/-/simple-xml-to-json-1.2.7.tgz",
+      "integrity": "sha512-mz9VXphOxQWX3eQ/uXCtm6upltoN0DLx8Zb5T4TFC4FHB7S9FDPGre8CfLWqPWQQH/GrQYd2AXhhVM5LDpYx6Q==",
       "license": "MIT",
       "engines": {
         "node": ">=20.12.2"
+      }
+    },
+    "node_modules/stage-js": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stage-js/-/stage-js-1.0.1.tgz",
+      "integrity": "sha512-cz14aPp/wY0s3bkb/B93BPP5ZAEhgBbRmAT3CCDqert8eCAqIpQ0RB2zpK8Ksxf+Pisl5oTzvPHtL4CVzzeHcw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=18.0"
       }
     },
     "node_modules/string_decoder": {
@@ -1493,6 +1454,38 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/strtok3": {
@@ -1568,9 +1561,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
-      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"
@@ -1607,9 +1600,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "0.7.4",
       "hasInstallScript": true,
       "dependencies": {
-        "@animalabs/agent-framework": "^0.7.2",
-        "@animalabs/chronicle": "^0.2.0",
+        "@animalabs/agent-framework": "^0.9.0",
+        "@animalabs/chronicle": "^0.3.0",
         "@animalabs/context-manager": "^0.6.3",
-        "@animalabs/membrane": "^0.5.77",
+        "@animalabs/membrane": "^0.5.78",
         "@opentui/core": "^0.1.82"
       },
       "devDependencies": {
@@ -94,14 +94,14 @@
       }
     },
     "node_modules/@animalabs/agent-framework": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/@animalabs/agent-framework/-/agent-framework-0.7.3.tgz",
-      "integrity": "sha512-lTNR3NwTMAYx4UL4paPYYq0G9VMnRZkU8P0EzYZIiqOiuwVENsl5mnkKxZII9LtY+l5tiUp33fv8oNi1cX1wMQ==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@animalabs/agent-framework/-/agent-framework-0.9.0.tgz",
+      "integrity": "sha512-JCHNbHEuY7tiAx/bPN+xtV8vTl2xi/an4toKc+1x5peaMur83jJLWOABzk+nNgmQk3nPKwwKSUYHRl/yiF5CCg==",
       "license": "MIT",
       "dependencies": {
-        "@animalabs/chronicle": "^0.2.2",
+        "@animalabs/chronicle": "^0.3.0",
         "@animalabs/context-manager": "^0.6.0",
-        "@animalabs/membrane": "^0.5.75",
+        "@animalabs/membrane": "^0.5.78",
         "chokidar": "^4.0.3",
         "discord.js": "^14.25.1",
         "ws": "^8.18.0"
@@ -115,17 +115,10 @@
       }
     },
     "node_modules/@animalabs/chronicle": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@animalabs/chronicle/-/chronicle-0.2.6.tgz",
-      "integrity": "sha512-+gbt2GR4SP8MnKxeqkJZf6oZn339fLiBtk6GHyBD/gHQ4e4eFqBpTaTd5eKycKBws0xWGcOqyiJFH4IdBkweUA==",
-      "license": "MIT",
-      "optionalDependencies": {
-        "@animalabs/chronicle-darwin-arm64": "0.2.6",
-        "@animalabs/chronicle-darwin-x64": "0.2.6",
-        "@animalabs/chronicle-linux-arm64-gnu": "0.2.6",
-        "@animalabs/chronicle-linux-x64-gnu": "0.2.6",
-        "@animalabs/chronicle-win32-x64-msvc": "0.2.6"
-      }
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@animalabs/chronicle/-/chronicle-0.3.0.tgz",
+      "integrity": "sha512-6BBJ9pWb8AnuHTNJTU07Y6Wut3IvdgWFxsy05IdlWcEnR5W23dlaBlaeJq7gDc7TwX05HfsDC+QZFEc69G+s4Q==",
+      "license": "MIT"
     },
     "node_modules/@animalabs/context-manager": {
       "version": "0.6.3",
@@ -140,16 +133,10 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@animalabs/context-manager/node_modules/@animalabs/chronicle": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@animalabs/chronicle/-/chronicle-0.3.0.tgz",
-      "integrity": "sha512-6BBJ9pWb8AnuHTNJTU07Y6Wut3IvdgWFxsy05IdlWcEnR5W23dlaBlaeJq7gDc7TwX05HfsDC+QZFEc69G+s4Q==",
-      "license": "MIT"
-    },
     "node_modules/@animalabs/membrane": {
-      "version": "0.5.77",
-      "resolved": "https://registry.npmjs.org/@animalabs/membrane/-/membrane-0.5.77.tgz",
-      "integrity": "sha512-1mVGEEjuWj7/CL9VsRTsyr5JhSCXCOJc392MRYXXr1f3MsCwt+54uw/+qo+VDeknihZ96dRVP8u/fvvMDeDiAw==",
+      "version": "0.5.79",
+      "resolved": "https://registry.npmjs.org/@animalabs/membrane/-/membrane-0.5.79.tgz",
+      "integrity": "sha512-wVto7V/WHqlG4P2FjyKv+WxqvhDi0NKb7iLlAdFTFnlCPfxrguDrUJoUx9MNCAjDSVjpwsb6c6rrokjnO0E+pw==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.52.0"
@@ -1497,17 +1484,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.12.2"
-      }
-    },
-    "node_modules/stage-js": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/stage-js/-/stage-js-1.0.1.tgz",
-      "integrity": "sha512-cz14aPp/wY0s3bkb/B93BPP5ZAEhgBbRmAT3CCDqert8eCAqIpQ0RB2zpK8Ksxf+Pisl5oTzvPHtL4CVzzeHcw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=18.0"
       }
     },
     "node_modules/string_decoder": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "postinstall": "test -d web && npm --prefix web install && npm --prefix web run build || true"
   },
   "dependencies": {
-    "@animalabs/agent-framework": "^0.9.0",
+    "@animalabs/agent-framework": "^0.10.0",
     "@animalabs/chronicle": "^0.3.0",
     "@animalabs/context-manager": "^0.6.3",
     "@animalabs/membrane": "^0.5.78",

--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
     "postinstall": "test -d web && npm --prefix web install && npm --prefix web run build || true"
   },
   "dependencies": {
-    "@animalabs/agent-framework": "^0.7.2",
-    "@animalabs/chronicle": "^0.2.0",
+    "@animalabs/agent-framework": "^0.9.0",
+    "@animalabs/chronicle": "^0.3.0",
     "@animalabs/context-manager": "^0.6.3",
-    "@animalabs/membrane": "^0.5.77",
+    "@animalabs/membrane": "^0.5.78",
     "@opentui/core": "^0.1.82"
   },
   "devDependencies": {

--- a/src/framework-strategy.ts
+++ b/src/framework-strategy.ts
@@ -2,6 +2,7 @@ import {
   AutobiographicalStrategy,
   PassthroughStrategy,
   type ContextStrategy,
+  type ConversationRouterConfig,
 } from '@animalabs/agent-framework';
 import type { Recipe, RecipeStrategy } from './recipe.js';
 import { FrontdeskStrategy } from './strategies/frontdesk-strategy.js';
@@ -124,4 +125,33 @@ export function buildFrameworkStrategy(
     : strategyType === 'frontdesk'
       ? new FrontdeskStrategy(autobiographicalOpts)
       : new AutobiographicalStrategy(autobiographicalOpts);
+}
+
+/**
+ * Map a recipe's `conversations` block to the framework's
+ * ConversationRouterConfig. The host supplies the two fields a recipe
+ * cannot: `templateAgent` is the recipe's own (sole) agent, and
+ * `strategyFactory` builds a FRESH instance of the recipe's configured
+ * strategy per fork — strategy instances are stateful and must never be
+ * shared between ContextManagers (without a factory the framework would
+ * silently give forks passthrough, i.e. no compression).
+ */
+export function buildConversationsConfig(
+  recipe: Recipe,
+  agentName: string,
+  model: string,
+  timeZone: string,
+  extensions?: ExtensionRegistry,
+): ConversationRouterConfig | undefined {
+  const conv = recipe.conversations;
+  if (!conv) return undefined;
+  return {
+    templateAgent: agentName,
+    ...(conv.bind !== undefined ? { bind: conv.bind } : {}),
+    ...(conv.trigger !== undefined ? { trigger: conv.trigger } : {}),
+    ...(conv.idleTtlMs !== undefined ? { idleTtlMs: conv.idleTtlMs } : {}),
+    ...(conv.closurePrompt !== undefined ? { closurePrompt: conv.closurePrompt } : {}),
+    ...(conv.agentPrefix !== undefined ? { agentPrefix: conv.agentPrefix } : {}),
+    strategyFactory: () => buildFrameworkStrategy(recipe, model, timeZone, extensions),
+  };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,7 @@ import {
 } from './recipe.js';
 import { createBranchState, resetBranchState, handleExport, type BranchState } from './commands.js';
 import { buildFrameworkAgentConfig, membraneCachingOverride } from './framework-agent-config.js';
-import { buildFrameworkStrategy } from './framework-strategy.js';
+import { buildFrameworkStrategy, buildConversationsConfig } from './framework-strategy.js';
 import { loadExtensions } from './extensions.js';
 
 export type { AppContext };
@@ -491,6 +491,10 @@ async function createFramework(
   const strategy = buildFrameworkStrategy(recipe, model, timeZone, extensionRegistry);
   const agentConfig = buildFrameworkAgentConfig(recipe, agentName, model, strategy);
 
+  // Per-channel conversation routing: the recipe agent becomes the trunk
+  // template; forks get a fresh instance of the same recipe strategy.
+  const conversations = buildConversationsConfig(recipe, agentName, model, timeZone, extensionRegistry);
+
   // -- Create framework --
   const framework = await AgentFramework.create({
     storePath,
@@ -502,6 +506,7 @@ agents: [agentConfig],
     timeZone,
     // Client-side programmatic tool calling (code_execution) — recipe opt-in.
     ...(recipe.codeExecution ? { codeExecution: recipe.codeExecution } : {}),
+    ...(conversations ? { conversations } : {}),
   });
 
   // Wire post-creation hooks

--- a/src/recipe.ts
+++ b/src/recipe.ts
@@ -728,6 +728,41 @@ export interface RecipeCodeExecution {
   idleReclaimMs?: number;
 }
 
+/**
+ * Per-channel conversation routing (agent-framework ConversationRouter):
+ * the recipe's agent becomes a dormant "trunk" template, and qualifying
+ * incoming channel messages spawn per-channel fork agents seeded from the
+ * trunk's current context. The host fills in what the framework needs but a
+ * recipe can't say: `templateAgent` is always the recipe's own agent, and
+ * `strategyFactory` builds a fresh instance of the recipe's `agent.strategy`
+ * per fork (strategy instances are stateful and must never be shared).
+ */
+export interface RecipeConversations {
+  /** When an unbound channel acquires a fork.
+   * Defaults: dm 'always', groupDm 'always', channel 'mention'. */
+  bind?: {
+    dm?: 'always' | 'mention' | 'never';
+    groupDm?: 'always' | 'mention' | 'never';
+    channel?: 'always' | 'mention' | 'never';
+  };
+  /** When a message on a bound channel triggers inference (it always lands
+   * in the fork's context regardless).
+   * Defaults: dm 'always', groupDm 'mention', channel 'mention'. */
+  trigger?: {
+    dm?: 'always' | 'mention';
+    groupDm?: 'always' | 'mention';
+    channel?: 'always' | 'mention';
+  };
+  /** Idle time before a binding expires and the fork runs its closure turn.
+   * Default 12h. */
+  idleTtlMs?: number;
+  /** Final system-initiated user message sent to a fork on expiry. */
+  closurePrompt?: string;
+  /** Prefix for generated fork agent names (default 'conversation'). Also
+   * the Chronicle namespace segment, so it is restricted to [A-Za-z0-9_-]. */
+  agentPrefix?: string;
+}
+
 export interface Recipe {
   name: string;
   description?: string;
@@ -740,6 +775,8 @@ export interface Recipe {
   sessionNaming?: { examples?: string[] };
   /** Client-side programmatic tool calling (code_execution tool). */
   codeExecution?: RecipeCodeExecution;
+  /** Per-channel conversation routing — fork-per-channel from this agent. */
+  conversations?: RecipeConversations;
 }
 
 // ---------------------------------------------------------------------------
@@ -1463,6 +1500,51 @@ export function validateRecipe(raw: unknown): Recipe {
       if (ce[k] !== undefined && (typeof ce[k] !== 'number' || (ce[k] as number) < 0)) {
         throw new Error(`Recipe codeExecution.${k} must be a non-negative number.`);
       }
+    }
+  }
+
+  if (obj.conversations !== undefined) {
+    if (!obj.conversations || typeof obj.conversations !== 'object' || Array.isArray(obj.conversations)) {
+      throw new Error('Recipe conversations must be an object.');
+    }
+    const conv = obj.conversations as Record<string, unknown>;
+    const kinds = ['dm', 'groupDm', 'channel'] as const;
+    for (const [field, allowed] of [
+      ['bind', ['always', 'mention', 'never']],
+      ['trigger', ['always', 'mention']],
+    ] as Array<[string, string[]]>) {
+      const rules = conv[field];
+      if (rules === undefined) continue;
+      if (!rules || typeof rules !== 'object' || Array.isArray(rules)) {
+        throw new Error(`Recipe conversations.${field} must be an object.`);
+      }
+      for (const [kind, rule] of Object.entries(rules as Record<string, unknown>)) {
+        if (!(kinds as readonly string[]).includes(kind)) {
+          throw new Error(
+            `Recipe conversations.${field} has unknown channel kind ${JSON.stringify(kind)} ` +
+            `(expected one of: ${kinds.join(', ')}).`,
+          );
+        }
+        if (typeof rule !== 'string' || !allowed.includes(rule)) {
+          throw new Error(
+            `Recipe conversations.${field}.${kind} must be one of ${allowed.map(r => `'${r}'`).join(', ')}, ` +
+            `got ${JSON.stringify(rule)}.`,
+          );
+        }
+      }
+    }
+    if (conv.idleTtlMs !== undefined && (typeof conv.idleTtlMs !== 'number' || conv.idleTtlMs <= 0)) {
+      throw new Error('Recipe conversations.idleTtlMs must be a positive number.');
+    }
+    if (conv.closurePrompt !== undefined && (typeof conv.closurePrompt !== 'string' || !conv.closurePrompt.trim())) {
+      throw new Error('Recipe conversations.closurePrompt must be a non-empty string.');
+    }
+    if (conv.agentPrefix !== undefined &&
+        (typeof conv.agentPrefix !== 'string' || !/^[A-Za-z0-9_-]+$/.test(conv.agentPrefix))) {
+      throw new Error(
+        'Recipe conversations.agentPrefix must be a non-empty string of [A-Za-z0-9_-] ' +
+        '(it names fork agents and their Chronicle namespaces).',
+      );
     }
   }
 

--- a/src/recipe.ts
+++ b/src/recipe.ts
@@ -1508,6 +1508,15 @@ export function validateRecipe(raw: unknown): Recipe {
       throw new Error('Recipe conversations must be an object.');
     }
     const conv = obj.conversations as Record<string, unknown>;
+    const allowedConversationKeys = new Set(['bind', 'trigger', 'idleTtlMs', 'closurePrompt', 'agentPrefix']);
+    for (const key of Object.keys(conv)) {
+      if (!allowedConversationKeys.has(key)) {
+        throw new Error(
+          `Recipe conversations has unknown field ${JSON.stringify(key)} ` +
+          `(expected one of: ${[...allowedConversationKeys].join(', ')}).`,
+        );
+      }
+    }
     const kinds = ['dm', 'groupDm', 'channel'] as const;
     for (const [field, allowed] of [
       ['bind', ['always', 'mention', 'never']],
@@ -1533,8 +1542,10 @@ export function validateRecipe(raw: unknown): Recipe {
         }
       }
     }
-    if (conv.idleTtlMs !== undefined && (typeof conv.idleTtlMs !== 'number' || conv.idleTtlMs <= 0)) {
-      throw new Error('Recipe conversations.idleTtlMs must be a positive number.');
+    if (conv.idleTtlMs !== undefined &&
+        (typeof conv.idleTtlMs !== 'number' || !Number.isFinite(conv.idleTtlMs) ||
+         !Number.isInteger(conv.idleTtlMs) || conv.idleTtlMs <= 0)) {
+      throw new Error('Recipe conversations.idleTtlMs must be a positive finite integer.');
     }
     if (conv.closurePrompt !== undefined && (typeof conv.closurePrompt !== 'string' || !conv.closurePrompt.trim())) {
       throw new Error('Recipe conversations.closurePrompt must be a non-empty string.');

--- a/test/conversations-recipe.test.ts
+++ b/test/conversations-recipe.test.ts
@@ -43,6 +43,12 @@ describe('validateRecipe — conversations schema', () => {
     expect(() => validateRecipe(baseRecipe({ conversations: [] }))).toThrow(/must be an object/);
   });
 
+  test('unknown top-level conversation field is rejected rather than silently ignored', () => {
+    expect(() => validateRecipe(baseRecipe({
+      conversations: { idleTTLms: 1000 },
+    }))).toThrow(/unknown field \"idleTTLms\"/);
+  });
+
   test('unknown channel kind is rejected', () => {
     expect(() => validateRecipe(baseRecipe({
       conversations: { bind: { thread: 'always' } },
@@ -66,6 +72,10 @@ describe('validateRecipe — conversations schema', () => {
       .toThrow(/idleTtlMs/);
     expect(() => validateRecipe(baseRecipe({ conversations: { idleTtlMs: -5 } })))
       .toThrow(/idleTtlMs/);
+    for (const bad of [Number.NaN, Number.POSITIVE_INFINITY, 1.5]) {
+      expect(() => validateRecipe(baseRecipe({ conversations: { idleTtlMs: bad } })))
+        .toThrow(/idleTtlMs/);
+    }
   });
 
   test('blank closurePrompt is rejected', () => {

--- a/test/conversations-recipe.test.ts
+++ b/test/conversations-recipe.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Recipe surface for per-channel conversation routing:
+ * schema validation of the `conversations` block, and the host-side mapping
+ * to the framework's ConversationRouterConfig (templateAgent auto-filled
+ * from the recipe agent, strategyFactory building fresh per-fork strategy
+ * instances from the recipe's own strategy config).
+ */
+import { describe, test, expect } from 'bun:test';
+import { validateRecipe, type Recipe } from '../src/recipe.js';
+import { buildConversationsConfig } from '../src/framework-strategy.js';
+
+function baseRecipe(extra: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    name: 'Test',
+    agent: { name: 'sherlock', systemPrompt: 'test' },
+    ...extra,
+  };
+}
+
+describe('validateRecipe — conversations schema', () => {
+  test('absent block is accepted', () => {
+    expect(() => validateRecipe(baseRecipe())).not.toThrow();
+  });
+
+  test('full valid block is accepted', () => {
+    expect(() => validateRecipe(baseRecipe({
+      conversations: {
+        bind: { dm: 'always', groupDm: 'always', channel: 'mention' },
+        trigger: { dm: 'always', groupDm: 'mention', channel: 'mention' },
+        idleTtlMs: 12 * 60 * 60 * 1000,
+        closurePrompt: 'Finalize the case report and post the answer.',
+        agentPrefix: 'case',
+      },
+    }))).not.toThrow();
+  });
+
+  test('empty object is accepted (all defaults come from the framework)', () => {
+    expect(() => validateRecipe(baseRecipe({ conversations: {} }))).not.toThrow();
+  });
+
+  test('non-object block is rejected', () => {
+    expect(() => validateRecipe(baseRecipe({ conversations: true }))).toThrow(/must be an object/);
+    expect(() => validateRecipe(baseRecipe({ conversations: [] }))).toThrow(/must be an object/);
+  });
+
+  test('unknown channel kind is rejected', () => {
+    expect(() => validateRecipe(baseRecipe({
+      conversations: { bind: { thread: 'always' } },
+    }))).toThrow(/unknown channel kind "thread"/);
+  });
+
+  test('invalid bind rule is rejected', () => {
+    expect(() => validateRecipe(baseRecipe({
+      conversations: { bind: { channel: 'sometimes' } },
+    }))).toThrow(/conversations\.bind\.channel/);
+  });
+
+  test("trigger rule 'never' is rejected (bind-only rule)", () => {
+    expect(() => validateRecipe(baseRecipe({
+      conversations: { trigger: { channel: 'never' } },
+    }))).toThrow(/conversations\.trigger\.channel/);
+  });
+
+  test('non-positive idleTtlMs is rejected', () => {
+    expect(() => validateRecipe(baseRecipe({ conversations: { idleTtlMs: 0 } })))
+      .toThrow(/idleTtlMs/);
+    expect(() => validateRecipe(baseRecipe({ conversations: { idleTtlMs: -5 } })))
+      .toThrow(/idleTtlMs/);
+  });
+
+  test('blank closurePrompt is rejected', () => {
+    expect(() => validateRecipe(baseRecipe({ conversations: { closurePrompt: '  ' } })))
+      .toThrow(/closurePrompt/);
+  });
+
+  test('agentPrefix with unsafe characters is rejected', () => {
+    for (const bad of ['with space', 'slash/py', 'dot.seg', '']) {
+      expect(() => validateRecipe(baseRecipe({ conversations: { agentPrefix: bad } })))
+        .toThrow(/agentPrefix/);
+    }
+    expect(() => validateRecipe(baseRecipe({ conversations: { agentPrefix: 'case-fork_2' } })))
+      .not.toThrow();
+  });
+});
+
+describe('buildConversationsConfig — recipe → FrameworkConfig mapping', () => {
+  const recipe = validateRecipe(baseRecipe({
+    conversations: {
+      bind: { channel: 'mention' },
+      idleTtlMs: 3600_000,
+      agentPrefix: 'case',
+    },
+  })) as Recipe;
+
+  test('returns undefined when the recipe has no conversations block', () => {
+    const bare = validateRecipe(baseRecipe()) as Recipe;
+    expect(buildConversationsConfig(bare, 'sherlock', 'model-x', 'UTC')).toBeUndefined();
+  });
+
+  test('templateAgent is auto-filled with the host agent name', () => {
+    const cfg = buildConversationsConfig(recipe, 'sherlock', 'model-x', 'UTC');
+    expect(cfg?.templateAgent).toBe('sherlock');
+  });
+
+  test('recipe fields pass through; omitted fields stay absent for framework defaults', () => {
+    const cfg = buildConversationsConfig(recipe, 'sherlock', 'model-x', 'UTC')!;
+    expect(cfg.bind).toEqual({ channel: 'mention' });
+    expect(cfg.idleTtlMs).toBe(3600_000);
+    expect(cfg.agentPrefix).toBe('case');
+    expect('trigger' in cfg).toBe(false);
+    expect('closurePrompt' in cfg).toBe(false);
+  });
+
+  test('strategyFactory builds a FRESH strategy instance per call', () => {
+    const cfg = buildConversationsConfig(recipe, 'sherlock', 'model-x', 'UTC')!;
+    expect(cfg.strategyFactory).toBeDefined();
+    const a = cfg.strategyFactory!();
+    const b = cfg.strategyFactory!();
+    expect(a).toBeDefined();
+    expect(b).toBeDefined();
+    expect(a).not.toBe(b);
+  });
+
+  test('strategyFactory honors the recipe strategy type', () => {
+    const passthrough = validateRecipe(baseRecipe({
+      agent: { name: 'p', systemPrompt: 't', strategy: { type: 'passthrough' } },
+      conversations: {},
+    })) as Recipe;
+    const cfg = buildConversationsConfig(passthrough, 'p', 'model-x', 'UTC')!;
+    expect(cfg.strategyFactory!().constructor.name).toBe('PassthroughStrategy');
+  });
+});


### PR DESCRIPTION
Raises the dependency floor to the current published line (branch name says af-0.8 — it predates af 0.9.0's release; rebased onto main and retargeted to 0.9.0):

- **af `^0.9.0`** ships `ConversationRouter` (prerequisite for the `conversations` recipe surface in #86) and exports `nudgeAgent` — which `src/commands.ts` has called since `/nudge` landed, a guaranteed runtime TypeError on every previously published af. The floor makes `/nudge` real; no code change needed anymore (the interim duck-typing this PR originally carried is dropped).
- **chronicle `^0.3.0`** aligns the whole tree on a single chronicle copy — context-manager 0.6.3 already required `^0.3.0` and nested its own next to the host's 0.2.x.
- **membrane `^0.5.78`** is af 0.9.0's own floor (resolves 0.5.79).

Changelog entry included per CONTRIBUTING (`Unreleased > Changed`), with the operator note: run a clean `npm ci` — a stale `node_modules` predating the lock is the known failure mode here (observed in the wild: installed af 0.6.8 vs lock 0.7.3).

Verified: clean install, 613/613 `bun test` on this branch (one fleet-panel timing test is flaky-by-6ms and passes in isolation), `tsc --noEmit` clean.

Stacked under: #86.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F8H4MXoSY8yHxpApLKjxaU