### PR TITLE
feat(recipe): conversations block — per-channel fork routing surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,19 @@
 
 ### Added
 
+- **`conversations` recipe block — per-channel conversation forks.** Maps to
+  agent-framework's `ConversationRouter` (af ≥0.9.0): the recipe's agent
+  becomes a dormant trunk template, and qualifying incoming channel messages
+  spawn per-channel fork agents seeded from the trunk's current context.
+  Recipe surface: `bind` / `trigger` rules per channel kind
+  (`dm`/`groupDm`/`channel`), `idleTtlMs` (default 12h), `closurePrompt`,
+  `agentPrefix` (restricted to `[A-Za-z0-9_-]` — it names fork agents and
+  their Chronicle namespaces). The host fills what a recipe can't say:
+  `templateAgent` is always the recipe's own agent, and each fork gets a
+  **fresh** instance of the recipe's `agent.strategy` (strategy instances
+  are stateful; sharing one across ContextManagers corrupts compression).
+  Absent block = no routing, zero behavior change.
+
 - **Standing autobiographical production target.** Recipes may set `agent.strategy.productionBudgetTokens` to keep the summary forest deep enough for a later live context-budget descent without a fold storm. This is a context-token target passed through to Context Manager, not a provider-spend ceiling; omission preserves Context Manager defaults.
 
 - **`BEDROCK_BASE_URL` env hook** for the bedrock provider — mirrors

--- a/src/framework-strategy.ts
+++ b/src/framework-strategy.ts
@@ -2,6 +2,7 @@ import {
   AutobiographicalStrategy,
   PassthroughStrategy,
   type ContextStrategy,
+  type ConversationRouterConfig,
 } from '@animalabs/agent-framework';
 import type { Recipe, RecipeStrategy } from './recipe.js';
 import { FrontdeskStrategy } from './strategies/frontdesk-strategy.js';
@@ -124,4 +125,33 @@ export function buildFrameworkStrategy(
     : strategyType === 'frontdesk'
       ? new FrontdeskStrategy(autobiographicalOpts)
       : new AutobiographicalStrategy(autobiographicalOpts);
+}
+
+/**
+ * Map a recipe's `conversations` block to the framework's
+ * ConversationRouterConfig. The host supplies the two fields a recipe
+ * cannot: `templateAgent` is the recipe's own (sole) agent, and
+ * `strategyFactory` builds a FRESH instance of the recipe's configured
+ * strategy per fork — strategy instances are stateful and must never be
+ * shared between ContextManagers (without a factory the framework would
+ * silently give forks passthrough, i.e. no compression).
+ */
+export function buildConversationsConfig(
+  recipe: Recipe,
+  agentName: string,
+  model: string,
+  timeZone: string,
+  extensions?: ExtensionRegistry,
+): ConversationRouterConfig | undefined {
+  const conv = recipe.conversations;
+  if (!conv) return undefined;
+  return {
+    templateAgent: agentName,
+    ...(conv.bind !== undefined ? { bind: conv.bind } : {}),
+    ...(conv.trigger !== undefined ? { trigger: conv.trigger } : {}),
+    ...(conv.idleTtlMs !== undefined ? { idleTtlMs: conv.idleTtlMs } : {}),
+    ...(conv.closurePrompt !== undefined ? { closurePrompt: conv.closurePrompt } : {}),
+    ...(conv.agentPrefix !== undefined ? { agentPrefix: conv.agentPrefix } : {}),
+    strategyFactory: () => buildFrameworkStrategy(recipe, model, timeZone, extensions),
+  };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,7 @@ import {
 } from './recipe.js';
 import { createBranchState, resetBranchState, handleExport, type BranchState } from './commands.js';
 import { buildFrameworkAgentConfig, membraneCachingOverride } from './framework-agent-config.js';
-import { buildFrameworkStrategy } from './framework-strategy.js';
+import { buildFrameworkStrategy, buildConversationsConfig } from './framework-strategy.js';
 import { loadExtensions } from './extensions.js';
 
 export type { AppContext };
@@ -490,6 +490,10 @@ async function createFramework(
   const strategy = buildFrameworkStrategy(recipe, model, timeZone, extensionRegistry);
   const agentConfig = buildFrameworkAgentConfig(recipe, agentName, model, strategy);
 
+  // Per-channel conversation routing: the recipe agent becomes the trunk
+  // template; forks get a fresh instance of the same recipe strategy.
+  const conversations = buildConversationsConfig(recipe, agentName, model, timeZone, extensionRegistry);
+
   // -- Create framework --
   const framework = await AgentFramework.create({
     storePath,
@@ -501,6 +505,7 @@ agents: [agentConfig],
     timeZone,
     // Client-side programmatic tool calling (code_execution) — recipe opt-in.
     ...(recipe.codeExecution ? { codeExecution: recipe.codeExecution } : {}),
+    ...(conversations ? { conversations } : {}),
   });
 
   // Wire post-creation hooks

--- a/src/recipe.ts
+++ b/src/recipe.ts
@@ -714,6 +714,41 @@ export interface RecipeCodeExecution {
   idleReclaimMs?: number;
 }
 
+/**
+ * Per-channel conversation routing (agent-framework ConversationRouter):
+ * the recipe's agent becomes a dormant "trunk" template, and qualifying
+ * incoming channel messages spawn per-channel fork agents seeded from the
+ * trunk's current context. The host fills in what the framework needs but a
+ * recipe can't say: `templateAgent` is always the recipe's own agent, and
+ * `strategyFactory` builds a fresh instance of the recipe's `agent.strategy`
+ * per fork (strategy instances are stateful and must never be shared).
+ */
+export interface RecipeConversations {
+  /** When an unbound channel acquires a fork.
+   * Defaults: dm 'always', groupDm 'always', channel 'mention'. */
+  bind?: {
+    dm?: 'always' | 'mention' | 'never';
+    groupDm?: 'always' | 'mention' | 'never';
+    channel?: 'always' | 'mention' | 'never';
+  };
+  /** When a message on a bound channel triggers inference (it always lands
+   * in the fork's context regardless).
+   * Defaults: dm 'always', groupDm 'mention', channel 'mention'. */
+  trigger?: {
+    dm?: 'always' | 'mention';
+    groupDm?: 'always' | 'mention';
+    channel?: 'always' | 'mention';
+  };
+  /** Idle time before a binding expires and the fork runs its closure turn.
+   * Default 12h. */
+  idleTtlMs?: number;
+  /** Final system-initiated user message sent to a fork on expiry. */
+  closurePrompt?: string;
+  /** Prefix for generated fork agent names (default 'conversation'). Also
+   * the Chronicle namespace segment, so it is restricted to [A-Za-z0-9_-]. */
+  agentPrefix?: string;
+}
+
 export interface Recipe {
   name: string;
   description?: string;
@@ -726,6 +761,8 @@ export interface Recipe {
   sessionNaming?: { examples?: string[] };
   /** Client-side programmatic tool calling (code_execution tool). */
   codeExecution?: RecipeCodeExecution;
+  /** Per-channel conversation routing — fork-per-channel from this agent. */
+  conversations?: RecipeConversations;
 }
 
 // ---------------------------------------------------------------------------
@@ -1425,6 +1462,51 @@ export function validateRecipe(raw: unknown): Recipe {
       if (ce[k] !== undefined && (typeof ce[k] !== 'number' || (ce[k] as number) < 0)) {
         throw new Error(`Recipe codeExecution.${k} must be a non-negative number.`);
       }
+    }
+  }
+
+  if (obj.conversations !== undefined) {
+    if (!obj.conversations || typeof obj.conversations !== 'object' || Array.isArray(obj.conversations)) {
+      throw new Error('Recipe conversations must be an object.');
+    }
+    const conv = obj.conversations as Record<string, unknown>;
+    const kinds = ['dm', 'groupDm', 'channel'] as const;
+    for (const [field, allowed] of [
+      ['bind', ['always', 'mention', 'never']],
+      ['trigger', ['always', 'mention']],
+    ] as Array<[string, string[]]>) {
+      const rules = conv[field];
+      if (rules === undefined) continue;
+      if (!rules || typeof rules !== 'object' || Array.isArray(rules)) {
+        throw new Error(`Recipe conversations.${field} must be an object.`);
+      }
+      for (const [kind, rule] of Object.entries(rules as Record<string, unknown>)) {
+        if (!(kinds as readonly string[]).includes(kind)) {
+          throw new Error(
+            `Recipe conversations.${field} has unknown channel kind ${JSON.stringify(kind)} ` +
+            `(expected one of: ${kinds.join(', ')}).`,
+          );
+        }
+        if (typeof rule !== 'string' || !allowed.includes(rule)) {
+          throw new Error(
+            `Recipe conversations.${field}.${kind} must be one of ${allowed.map(r => `'${r}'`).join(', ')}, ` +
+            `got ${JSON.stringify(rule)}.`,
+          );
+        }
+      }
+    }
+    if (conv.idleTtlMs !== undefined && (typeof conv.idleTtlMs !== 'number' || conv.idleTtlMs <= 0)) {
+      throw new Error('Recipe conversations.idleTtlMs must be a positive number.');
+    }
+    if (conv.closurePrompt !== undefined && (typeof conv.closurePrompt !== 'string' || !conv.closurePrompt.trim())) {
+      throw new Error('Recipe conversations.closurePrompt must be a non-empty string.');
+    }
+    if (conv.agentPrefix !== undefined &&
+        (typeof conv.agentPrefix !== 'string' || !/^[A-Za-z0-9_-]+$/.test(conv.agentPrefix))) {
+      throw new Error(
+        'Recipe conversations.agentPrefix must be a non-empty string of [A-Za-z0-9_-] ' +
+        '(it names fork agents and their Chronicle namespaces).',
+      );
     }
   }
 

--- a/test/conversations-recipe.test.ts
+++ b/test/conversations-recipe.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Recipe surface for per-channel conversation routing:
+ * schema validation of the `conversations` block, and the host-side mapping
+ * to the framework's ConversationRouterConfig (templateAgent auto-filled
+ * from the recipe agent, strategyFactory building fresh per-fork strategy
+ * instances from the recipe's own strategy config).
+ */
+import { describe, test, expect } from 'bun:test';
+import { validateRecipe, type Recipe } from '../src/recipe.js';
+import { buildConversationsConfig } from '../src/framework-strategy.js';
+
+function baseRecipe(extra: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    name: 'Test',
+    agent: { name: 'sherlock', systemPrompt: 'test' },
+    ...extra,
+  };
+}
+
+describe('validateRecipe — conversations schema', () => {
+  test('absent block is accepted', () => {
+    expect(() => validateRecipe(baseRecipe())).not.toThrow();
+  });
+
+  test('full valid block is accepted', () => {
+    expect(() => validateRecipe(baseRecipe({
+      conversations: {
+        bind: { dm: 'always', groupDm: 'always', channel: 'mention' },
+        trigger: { dm: 'always', groupDm: 'mention', channel: 'mention' },
+        idleTtlMs: 12 * 60 * 60 * 1000,
+        closurePrompt: 'Finalize the case report and post the answer.',
+        agentPrefix: 'case',
+      },
+    }))).not.toThrow();
+  });
+
+  test('empty object is accepted (all defaults come from the framework)', () => {
+    expect(() => validateRecipe(baseRecipe({ conversations: {} }))).not.toThrow();
+  });
+
+  test('non-object block is rejected', () => {
+    expect(() => validateRecipe(baseRecipe({ conversations: true }))).toThrow(/must be an object/);
+    expect(() => validateRecipe(baseRecipe({ conversations: [] }))).toThrow(/must be an object/);
+  });
+
+  test('unknown channel kind is rejected', () => {
+    expect(() => validateRecipe(baseRecipe({
+      conversations: { bind: { thread: 'always' } },
+    }))).toThrow(/unknown channel kind "thread"/);
+  });
+
+  test('invalid bind rule is rejected', () => {
+    expect(() => validateRecipe(baseRecipe({
+      conversations: { bind: { channel: 'sometimes' } },
+    }))).toThrow(/conversations\.bind\.channel/);
+  });
+
+  test("trigger rule 'never' is rejected (bind-only rule)", () => {
+    expect(() => validateRecipe(baseRecipe({
+      conversations: { trigger: { channel: 'never' } },
+    }))).toThrow(/conversations\.trigger\.channel/);
+  });
+
+  test('non-positive idleTtlMs is rejected', () => {
+    expect(() => validateRecipe(baseRecipe({ conversations: { idleTtlMs: 0 } })))
+      .toThrow(/idleTtlMs/);
+    expect(() => validateRecipe(baseRecipe({ conversations: { idleTtlMs: -5 } })))
+      .toThrow(/idleTtlMs/);
+  });
+
+  test('blank closurePrompt is rejected', () => {
+    expect(() => validateRecipe(baseRecipe({ conversations: { closurePrompt: '  ' } })))
+      .toThrow(/closurePrompt/);
+  });
+
+  test('agentPrefix with unsafe characters is rejected', () => {
+    for (const bad of ['with space', 'slash/py', 'dot.seg', '']) {
+      expect(() => validateRecipe(baseRecipe({ conversations: { agentPrefix: bad } })))
+        .toThrow(/agentPrefix/);
+    }
+    expect(() => validateRecipe(baseRecipe({ conversations: { agentPrefix: 'case-fork_2' } })))
+      .not.toThrow();
+  });
+});
+
+describe('buildConversationsConfig — recipe → FrameworkConfig mapping', () => {
+  const recipe = validateRecipe(baseRecipe({
+    conversations: {
+      bind: { channel: 'mention' },
+      idleTtlMs: 3600_000,
+      agentPrefix: 'case',
+    },
+  })) as Recipe;
+
+  test('returns undefined when the recipe has no conversations block', () => {
+    const bare = validateRecipe(baseRecipe()) as Recipe;
+    expect(buildConversationsConfig(bare, 'sherlock', 'model-x', 'UTC')).toBeUndefined();
+  });
+
+  test('templateAgent is auto-filled with the host agent name', () => {
+    const cfg = buildConversationsConfig(recipe, 'sherlock', 'model-x', 'UTC');
+    expect(cfg?.templateAgent).toBe('sherlock');
+  });
+
+  test('recipe fields pass through; omitted fields stay absent for framework defaults', () => {
+    const cfg = buildConversationsConfig(recipe, 'sherlock', 'model-x', 'UTC')!;
+    expect(cfg.bind).toEqual({ channel: 'mention' });
+    expect(cfg.idleTtlMs).toBe(3600_000);
+    expect(cfg.agentPrefix).toBe('case');
+    expect('trigger' in cfg).toBe(false);
+    expect('closurePrompt' in cfg).toBe(false);
+  });
+
+  test('strategyFactory builds a FRESH strategy instance per call', () => {
+    const cfg = buildConversationsConfig(recipe, 'sherlock', 'model-x', 'UTC')!;
+    expect(cfg.strategyFactory).toBeDefined();
+    const a = cfg.strategyFactory!();
+    const b = cfg.strategyFactory!();
+    expect(a).toBeDefined();
+    expect(b).toBeDefined();
+    expect(a).not.toBe(b);
+  });
+
+  test('strategyFactory honors the recipe strategy type', () => {
+    const passthrough = validateRecipe(baseRecipe({
+      agent: { name: 'p', systemPrompt: 't', strategy: { type: 'passthrough' } },
+      conversations: {},
+    })) as Recipe;
+    const cfg = buildConversationsConfig(passthrough, 'p', 'model-x', 'UTC')!;
+    expect(cfg.strategyFactory!().constructor.name).toBe('PassthroughStrategy');
+  });
+});


### PR DESCRIPTION
Recipe surface for af 0.8.0's `ConversationRouter` (per-channel conversation forks — the "Sherlock combine" trunk/fork pattern). Adds a top-level `Recipe.conversations` block mapped to `FrameworkConfig.conversations`:

- `templateAgent` is host-filled with the recipe's own agent name (a recipe has exactly one agent, so it's not part of the surface).
- `strategyFactory` builds a **fresh** instance of the recipe's `agent.strategy` per fork via the existing `buildFrameworkStrategy` path — strategy instances are stateful and must never be shared; without a factory, forks silently fall back to passthrough (no compression).
- `bind` / `trigger` rules per channel kind, `idleTtlMs`, `closurePrompt`, `agentPrefix` pass through. `agentPrefix` is restricted to `[A-Za-z0-9_-]` since it names fork agents and their Chronicle namespaces.
- Validated in `validateRecipe` (rule enums per kind, positive TTL, non-empty closure prompt) — unlike the wake-config passthrough, typos don't reach the framework.

Example:

```json
"conversations": {
  "bind":    { "dm": "always", "channel": "mention" },
  "trigger": { "dm": "always", "channel": "mention" },
  "idleTtlMs": 43200000,
  "closurePrompt": "Finalize the case report and post the answer.",
  "agentPrefix": "case"
}
```

15 new tests (`test/conversations-recipe.test.ts`): schema validation cases plus the recipe→FrameworkConfig mapping (templateAgent auto-fill, per-call fresh strategy instances, strategy-type honoring). Suite 620/620, tsc clean.

**Stacked on #85** (needs af ^0.8.0 for the `ConversationRouterConfig` type); base is set to `chore/af-0.8-deps` — retarget to `main` after #85 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F8H4MXoSY8yHxpApLKjxaU