### PR TITLE
test: make recipe path-resolution tests platform-portable

### DIFF
--- a/test/audit-module-optins.test.ts
+++ b/test/audit-module-optins.test.ts
@@ -8,7 +8,7 @@
 
 import { describe, test, expect } from 'bun:test';
 import { mkdtempSync, writeFileSync, mkdirSync, readFileSync, statSync } from 'node:fs';
-import { join } from 'node:path';
+import { basename, dirname, isAbsolute, join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
   classifyModule,
@@ -74,15 +74,22 @@ describe('auditRecipe', () => {
   });
 
   test('collects local fleet children, resolves relative paths, skips URLs', () => {
+    const parentPath = resolve('/deploy/recipes/parent.json');
     const a = auditRecipe(
       {
         name: 'parent',
         agent: AGENT,
         modules: { fleet: { children: [{ recipe: 'child.json' }, { recipe: 'https://x.example/c.json' }] } },
       },
-      '/deploy/recipes/parent.json',
+      parentPath,
     );
-    expect(a.childRecipePaths).toEqual(['/deploy/recipes/child.json']);
+
+    // The https child is skipped; the relative one resolves beside the parent.
+    expect(a.childRecipePaths).toHaveLength(1);
+    const [childPath] = a.childRecipePaths;
+    expect(isAbsolute(childPath)).toBe(true);
+    expect(dirname(childPath)).toBe(dirname(parentPath));
+    expect(basename(childPath)).toBe('child.json');
   });
 });
 

--- a/test/recipe-path-resolution.test.ts
+++ b/test/recipe-path-resolution.test.ts
@@ -8,7 +8,7 @@
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
 import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join, resolve } from 'node:path';
+import { basename, dirname, isAbsolute, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { loadRecipe, resolveRecipeRelative, type Recipe } from '../src/recipe.js';
 
@@ -48,15 +48,26 @@ describe('resolveRecipeRelative', () => {
   });
 
   test('bare filename resolves against parent dir', () => {
-    expect(resolveRecipeRelative('child.json', { kind: 'file', dir: '/opt/recipes' }))
-      .toBe('/opt/recipes/child.json');
+    const dir = resolve('/opt/recipes');
+    const out = resolveRecipeRelative('child.json', { kind: 'file', dir });
+
+    expect(isAbsolute(out)).toBe(true);
+    expect(dirname(out)).toBe(dir);
+    expect(basename(out)).toBe('child.json');
   });
 
   test('dotted prefix resolves against parent dir', () => {
-    expect(resolveRecipeRelative('./child.json', { kind: 'file', dir: '/opt/recipes' }))
-      .toBe('/opt/recipes/child.json');
-    expect(resolveRecipeRelative('../other/child.json', { kind: 'file', dir: '/opt/recipes' }))
-      .toBe('/opt/other/child.json');
+    const dir = resolve('/opt/recipes');
+
+    const here = resolveRecipeRelative('./child.json', { kind: 'file', dir });
+    expect(dirname(here)).toBe(dir);
+    expect(basename(here)).toBe('child.json');
+
+    // `..` must climb out of `dir` and land in a sibling directory.
+    const up = resolveRecipeRelative('../other/child.json', { kind: 'file', dir });
+    expect(basename(up)).toBe('child.json');
+    expect(basename(dirname(up))).toBe('other');
+    expect(dirname(dirname(up))).toBe(dirname(dir));
   });
 
   test('URL base resolves relative child to sibling URL', () => {
@@ -97,7 +108,7 @@ describe('loadRecipe — children[].recipe resolution', () => {
 
     const originalCwd = process.cwd();
     try {
-      process.chdir('/tmp');
+      process.chdir(tmpdir());
       const a = await loadRecipe(parentPath);
       process.chdir(tmpDir);
       const b = await loadRecipe(parentPath);


### PR DESCRIPTION

## Problem

Four path-resolution tests fail on native Windows. The failures are in the assertions, not in `src/` — `resolveRecipeRelative` behaves correctly on Windows.

Three compare against hardcoded POSIX literals:

```ts
expect(resolveRecipeRelative('child.json', { kind: 'file', dir: '/opt/recipes' }))
  .toBe('/opt/recipes/child.json');
```

On Windows, `resolve('/opt/recipes', 'child.json')` correctly returns `C:\opt\recipes\child.json` — the right answer, but an unmatchable string.

A fourth calls `process.chdir('/tmp')`, which resolves to `C:\tmp` on Windows and doesn't exist (`ENOENT`).

`ci.yml` runs `[ubuntu-latest, macos-latest]` with the test step gated to `ubuntu-latest`, so these assertions have only ever been evaluated on Linux. No issue filed.

Affected:

- `resolveRecipeRelative > bare filename resolves against parent dir`
- `resolveRecipeRelative > dotted prefix resolves against parent dir`
- `loadRecipe — children[].recipe resolution > CWD-independence`
- `auditRecipe > collects local fleet children, resolves relative paths, skips URLs`

## Changes

- Base directories built with `resolve()` rather than written as POSIX literals
- Exact-string comparisons replaced with property assertions (`isAbsolute` / `dirname` / `basename`) — the convention the *passing* tests in these same two files already use
- `process.chdir('/tmp')` → `process.chdir(tmpdir())`

Test-only; nothing under `src/` is touched. No companion PRs, nothing stacked on this.

The replacements are stricter than what they replace: the `../other/child.json` case now checks that `..` genuinely climbs a level and lands in a sibling directory, which a single string comparison couldn't distinguish from a coincidence.

## Tests

Windows 11, bun 1.3.12, node 22.15.0, at `fccc9fb`.

Full suite:

```
before: 566 pass / 27 fail / 3 errors  (593 tests, 69 files)
after:  the four above pass; no new failures in the touched files
```

Targeted:

```
bun test test/recipe-path-resolution.test.ts test/audit-module-optins.test.ts
→ 24 pass / 0 fail / 60 expect() calls
```

**Mutation check** — confirming the new assertions fail on unfixed code. Patching `resolveRecipeRelative` to ignore its base directory (`return resolve(child)`) turns them red:

```
(fail) resolveRecipeRelative > bare filename resolves against parent dir
(fail) resolveRecipeRelative > dotted prefix resolves against parent dir
(fail) loadRecipe — children[].recipe resolution > CWD-independence
```

plus three pre-existing tests in the same file. Mutation reverted; `src/` is untouched in this branch.

## Not verified

- **Linux and macOS were not run here.** The changes should be no-ops on POSIX — `resolve('/opt/recipes')` *is* `/opt/recipes` and `tmpdir()` *is* `/tmp` — but I have not executed the suite on either platform and am relying on CI for that.
- **`auditRecipe`'s own path handling** is a separate code path from `resolveRecipeRelative`; the mutation check above does not cover it. Its rewrite is verified only by passing on Windows and being POSIX-identical.
- **The remaining Windows failures are untouched by this PR.** They are a single unrelated cluster: the headless/fleet IPC layer creates unix domain sockets at filesystem paths (`{dataDir}/ipc.sock`), which don't exist on Windows, so children never connect and the tests fail by timeout. Their exact count varies between runs for that reason. Happy to open a separate issue with the diagnosis if that would be useful.
- **npm was not exercised** — bun only.

---

- [x] `CHANGELOG.md` updated under `## Unreleased` — or this change is
      internal-only / test-only / docs-only (apply the `no-changelog` label).

🤖 Generated with [Claude Code](https://claude.com/claude-code)