### PR TITLE
Expose hybrid prose routing in recipes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@
 
 ### Added
 
+- **Hybrid prose routing.** Recipes may set `agent.proseRouting: "hybrid"`: unprefixed text keeps ordinary frozen-locus delivery, while a leading `>>>destination` publication envelope routes through Agent Framework’s existing authorized cross-surface resolver. Source text retains the envelope; recipients see only the body; success/failure returns to resident context.
+
 - **Standing autobiographical production target.** Recipes may set `agent.strategy.productionBudgetTokens` to keep the summary forest deep enough for a later live context-budget descent without a fold storm. This is a context-token target passed through to Context Manager, not a provider-spend ceiling; omission preserves Context Manager defaults.
 
 - **`BEDROCK_BASE_URL` env hook** for the bedrock provider — mirrors

--- a/src/recipe.ts
+++ b/src/recipe.ts
@@ -155,9 +155,12 @@ export interface RecipeAgent {
   /**
    * Prose delivery mode (agent-framework docs/explicit-prose-routing.md).
    * 'explicit' = model prefixes plain text with `>>destination`; unprefixed
-   * prose bounces to a clipboard instead of auto-routing. Default 'locus'.
+   * prose bounces to a clipboard instead of auto-routing.
+   * 'hybrid' = unprefixed prose keeps the current locus while an exact leading
+   * `>>>destination` envelope routes through the authorized channel registry.
+   * Default 'locus'.
    */
-  proseRouting?: 'locus' | 'explicit';
+  proseRouting?: 'locus' | 'explicit' | 'hybrid';
   /**
    * Extra Anthropic beta flags sent as the `anthropic-beta` header on every
    * request (e.g. `["context-1m-2025-08-07"]` for the 1M context window on
@@ -963,6 +966,15 @@ export function validateRecipe(raw: unknown): Recipe {
       `Recipe agent.provider must be 'anthropic', 'openai-responses', 'openai-codex', 'openrouter', 'bedrock', or 'mock', ` +
       `got ${JSON.stringify(agent.provider)}.`,
     );
+  }
+
+  if (
+    agent.proseRouting !== undefined &&
+    agent.proseRouting !== 'locus' &&
+    agent.proseRouting !== 'explicit' &&
+    agent.proseRouting !== 'hybrid'
+  ) {
+    throw new Error(`Recipe agent.proseRouting must be 'locus', 'explicit', or 'hybrid', got ${JSON.stringify(agent.proseRouting)}.`);
   }
 
   if (agent.timezone !== undefined) {

--- a/test/recipe-hybrid-prose-routing.test.ts
+++ b/test/recipe-hybrid-prose-routing.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'bun:test';
+import { validateRecipe } from '../src/recipe.js';
+const base = (proseRouting?: unknown) => ({ name: 'test', agent: { systemPrompt: '', ...(proseRouting === undefined ? {} : { proseRouting }) } });
+describe('hybrid prose routing recipe', () => {
+  it('accepts locus, explicit, hybrid, and omission', () => {
+    expect(validateRecipe(base()).agent.proseRouting).toBeUndefined();
+    for (const mode of ['locus', 'explicit', 'hybrid'] as const) expect(validateRecipe(base(mode)).agent.proseRouting).toBe(mode);
+  });
+  it('rejects unknown modes', () => {
+    expect(() => validateRecipe(base('triple-magic'))).toThrow(/proseRouting/);
+  });
+});


### PR DESCRIPTION
Adds validated `agent.proseRouting: hybrid` passthrough for Agent Framework hybrid publication routing. Depends on anima-research/agent-framework hybrid router. Reviewed by Mica; full 617/617 and composed typecheck clean.