### PR TITLE
feat(recipe): add resident retirement ceremony

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ while retaining Chronicle, messages, workspace files, and other history. It is
 separate from end-turn, sleep, and session deletion. Omit the block to leave the
 tool absent. The protected tool cannot be invoked by `puppetToolCall`, code
 execution, programmatic dispatch, ephemeral subagents, or conversation forks.
+Its namespaced tool name is protected globally against forged caller
+identities. Once sealed, stale public Agent references cannot infer or stream,
+and existing per-channel conversation forks derived from the resident are
+terminated and unbound while their Chronicle history remains available.
 For autobiographical residents, the host also defers challenge
 issuance and confirmation while compression quarantine is non-empty, so a known
 degraded context cannot bind the irreversible transition. The host refuses to

--- a/README.md
+++ b/README.md
@@ -29,7 +29,11 @@ A recipe is a JSON file that configures everything domain-specific:
     "model": "claude-opus-4-6",
     "timezone": "America/Los_Angeles",
     "systemPrompt": "You are a ...",
-    "maxTokens": 16384
+    "maxTokens": 16384,
+    "retirement": {
+      "enabled": true,
+      "confirmationDelayMs": 60000
+    }
   },
   "mcpServers": {
     "my-server": {
@@ -51,6 +55,27 @@ A recipe is a JSON file that configures everything domain-specific:
 `agent.timezone` is an IANA zone used only for times rendered to the agent.
 Chronicle and MCPL protocol timestamps remain epoch/UTC. If the recipe omits
 it, `AGENT_TIMEZONE` is used, then the process timezone.
+
+`agent.retirement.enabled` installs Connectome Host's protected
+`resident--lifecycle` tool for this configured resident. The Host owns the
+wording, fresh challenge, expiry, memory-health checks, and separate
+confirmation turn; Agent Framework owns only the neutral irreversible seal and
+enforcement primitive. The cooling-off floor is 60 seconds by default and
+there is no human approval step. Set
+`confirmationDelayMs` to another positive value below `confirmationTtlMs` when
+the residence needs a different policy. Confirmation prevents future inference
+while retaining Chronicle, messages, workspace files, and other history. It is
+separate from end-turn, sleep, and session deletion. Omit the block to leave the
+tool absent. The protected tool cannot be invoked by `puppetToolCall`, code
+execution, programmatic dispatch, ephemeral subagents, or conversation forks.
+For autobiographical residents, the host also defers challenge
+issuance and confirmation while compression quarantine is non-empty, so a known
+degraded context cannot bind the irreversible transition. The host refuses to
+start an opted-in recipe when the installed Agent Framework does not yet provide
+both retirement enforcement and the protected live-tool surface. Only a
+successful terminal seal is sent to the ops notification channel; a request is
+never turned into a human approval workflow. See
+[Resident retirement](docs/resident-retirement.md).
 
 **Memory defaults**: `agent.strategy` may be omitted entirely. The default is
 the autobiographical memory strategy with adaptive resolution, **KV-stable

--- a/changelog.d/resident-retirement.added.md
+++ b/changelog.d/resident-retirement.added.md
@@ -1,0 +1,4 @@
+- Add a Host-owned, live-stream-only resident retirement ceremony with an
+  expiring challenge, cooling-off confirmation turn, fail-closed memory-health
+  gate, and post-seal notification, backed by Agent Framework's neutral
+  irreversible enforcement primitive.

--- a/docs/resident-retirement.md
+++ b/docs/resident-retirement.md
@@ -22,6 +22,8 @@ messages, workspace files, and the terminal record.
 The resident receives `resident--lifecycle` only on its real provider-issued
 stream. Conversation forks, ephemeral subagents, `code_execution`, public
 programmatic calls, and the operator `puppetToolCall` path cannot invoke it.
+The lifecycle tool name is reserved globally once exposed for the resident, so
+claiming another caller identity does not bypass that boundary.
 
 `request_retirement` first checks memory health, creates an in-memory random
 challenge, records its confirmation and expiry boundaries, ends the current
@@ -43,10 +45,17 @@ not notifications or approval opportunities.
 
 ## What stops
 
-The seal blocks conversational and maintenance inference, later message
-appends, operator nudges, direct retries, and new conversation forks from the
-retired template. It clears queued requests, provider cooldown state, gate
+The seal cancels the resident's active stream and blocks conversational and
+maintenance inference, public Agent inference/streaming methods, later message
+appends, operator nudges, direct retries, and resident-attributed programmatic
+or puppet tool calls. It clears queued requests, provider cooldown state, gate
 sleep, self-wakes, and resident-authored foreground/background code runners.
+
+Existing per-channel conversation forks derived from the resident are sealed,
+unbound, and removed from the live registry; their Chronicle namespaces remain
+available for audit. New forks from the retired template are refused. This is
+distinct from already-running ephemeral subagents, which have separate,
+short-lived identities.
 
 Already-running ephemeral subagents are separate short-lived identities and
 are not killed mid-call. They may finish their own computation, but cannot wake
@@ -57,7 +66,9 @@ resident-owned background activity remain denied.
 
 The authoritative ledger is
 `<session-store>/resident-retirements.jsonl`. Startup fails closed on a torn,
-malformed, invalid, or duplicate record.
+malformed, invalid, or duplicate record. On first creation, Agent Framework
+fsyncs both the seal file and its containing directory before reporting
+success.
 
 Keep Connectome stopped, make a byte-for-byte backup, and inspect the exact
 line reported at startup. Remove only a demonstrably incomplete or invalid

--- a/docs/resident-retirement.md
+++ b/docs/resident-retirement.md
@@ -1,0 +1,76 @@
+# Resident retirement
+
+Connectome separates four lifecycle operations: ending a turn, reversible
+sleep, irreversible retirement, and custodial erasure. Retirement prevents any
+future model inference for one configured resident while preserving Chronicle,
+messages, workspace files, and the terminal record.
+
+## Enable the Host ceremony
+
+```json
+{
+  "agent": {
+    "retirement": {
+      "enabled": true,
+      "confirmationDelayMs": 60000,
+      "confirmationTtlMs": 600000
+    }
+  }
+}
+```
+
+The resident receives `resident--lifecycle` only on its real provider-issued
+stream. Conversation forks, ephemeral subagents, `code_execution`, public
+programmatic calls, and the operator `puppetToolCall` path cannot invoke it.
+
+`request_retirement` first checks memory health, creates an in-memory random
+challenge, records its confirmation and expiry boundaries, ends the current
+turn, and schedules a fresh turn at the cooling-off boundary. In that later
+turn, `confirm_retirement` requires the exact challenge and
+`RETIRE_RESIDENT`. An early attempt preserves the challenge. An invalid
+post-boundary attempt consumes it. Expiry or restart requires a fresh request.
+No request is sent to a human for approval.
+
+For autobiographical memory, Connectome checks compression quarantine both
+when issuing and when binding the challenge. A non-empty, unreadable, or
+malformed quarantine state fails closed; a valid challenge remains pending
+until health returns or the challenge expires.
+
+After exact confirmation, the Host calls Agent Framework's neutral
+`retireResident()` primitive. Only a successfully applied seal emits the
+`resident-retired` ops notification. The request and cooling-off period are
+not notifications or approval opportunities.
+
+## What stops
+
+The seal blocks conversational and maintenance inference, later message
+appends, operator nudges, direct retries, and new conversation forks from the
+retired template. It clears queued requests, provider cooldown state, gate
+sleep, self-wakes, and resident-authored foreground/background code runners.
+
+Already-running ephemeral subagents are separate short-lived identities and
+are not killed mid-call. They may finish their own computation, but cannot wake
+or append a result into the sealed resident. New resident inference and new
+resident-owned background activity remain denied.
+
+## Malformed seal recovery
+
+The authoritative ledger is
+`<session-store>/resident-retirements.jsonl`. Startup fails closed on a torn,
+malformed, invalid, or duplicate record.
+
+Keep Connectome stopped, make a byte-for-byte backup, and inspect the exact
+line reported at startup. Remove only a demonstrably incomplete or invalid
+write that never formed a valid seal, normally a torn final line supported by
+storage-failure logs. Never delete or edit a valid `resident-retired` line and
+never guess when the record is ambiguous. The repaired file must end in a
+newline and every remaining line must validate independently. This repairs
+ledger syntax; it is not an unretirement procedure.
+
+## Running before an upstream release
+
+Build the sibling Agent Framework worktree, link it locally, then link that
+package into this Host worktree before starting Connectome. The reviewer packet
+for this branch records the exact commits and commands. The live residence
+should use a dedicated session store; do not test retirement against a valued
+existing resident identity.

--- a/docs/resident-retirement.md
+++ b/docs/resident-retirement.md
@@ -67,8 +67,8 @@ resident-owned background activity remain denied.
 The authoritative ledger is
 `<session-store>/resident-retirements.jsonl`. Startup fails closed on a torn,
 malformed, invalid, or duplicate record. On first creation, Agent Framework
-fsyncs both the seal file and its containing directory before reporting
-success.
+fsyncs the seal file, its containing directory, and any newly created custom
+path entries before reporting success.
 
 Keep Connectome stopped, make a byte-for-byte backup, and inspect the exact
 line reported at startup. Remove only a demonstrably incomplete or invalid

--- a/src/framework-agent-config.ts
+++ b/src/framework-agent-config.ts
@@ -1,14 +1,65 @@
 import { AgentFramework } from '@animalabs/agent-framework';
 import type { Recipe } from './recipe.js';
+import type { RetirementReadinessCheck } from './modules/resident-lifecycle-module.js';
 
 type AgentConfig = Parameters<typeof AgentFramework.create>[0]['agents'][number];
+
+type FrameworkRetirementConfig = { enabled: boolean };
 
 export type FrameworkAgentConfig = AgentConfig & {
   // Forward recipe fields that newer Agent Framework releases understand
   // while remaining structurally compatible with older installs.
   refusalHandling?: Recipe['agent']['refusalHandling'];
   sameRoundThinkTextPolicy?: 'public' | 'private';
+  retirement?: FrameworkRetirementConfig;
 };
+
+/**
+ * Keep the host fail-closed across a staged Agent Framework release. Older
+ * versions structurally accept unknown agent fields, so without this guard an
+ * opted-in recipe could appear valid while providing no retirement mechanism.
+ *
+ * The status reader is only a proxy for enforcement: Agent Framework ships
+ * getResidentLifecycleStatus and the retirement machinery atomically. The
+ * released dependency range and lockfile are therefore the load-bearing
+ * compatibility boundary; this runtime probe is belt-and-braces protection for
+ * stale or incorrectly linked installs, not proof of enforcement by itself.
+ */
+export function assertResidentRetirementSupport(
+  recipe: Recipe,
+  framework: unknown,
+): void {
+  if (!recipe.agent.retirement?.enabled) return;
+  const candidate = framework as {
+    getResidentLifecycleStatus?: unknown;
+    retireResident?: unknown;
+    previewActivation?: unknown;
+  };
+  if (
+    typeof candidate.getResidentLifecycleStatus !== 'function' ||
+    typeof candidate.retireResident !== 'function' ||
+    typeof candidate.previewActivation !== 'function'
+  ) {
+    throw new Error(
+      'This recipe enables agent.retirement, but the installed Agent Framework does not support resident retirement.',
+    );
+  }
+}
+
+/** Verify that the installed framework actually consumed Module.getLiveTools. */
+export async function assertResidentRetirementToolSurface(
+  recipe: Recipe,
+  framework: AgentFramework,
+  agentName: string,
+): Promise<void> {
+  if (!recipe.agent.retirement?.enabled) return;
+  const preview = await framework.previewActivation(agentName);
+  if (!preview.tools?.some((tool) => tool.name === 'resident--lifecycle')) {
+    throw new Error(
+      'This recipe enables agent.retirement, but the installed Agent Framework does not support the protected resident lifecycle tool surface.',
+    );
+  }
+}
 
 /**
  * Prompt caching went GA on Bedrock in April 2025 for 3.5 Haiku, 3.7
@@ -57,6 +108,55 @@ export function membraneCachingOverride(
   return promptCaching === undefined ? {} : { defaultPromptCaching: promptCaching };
 }
 
+/**
+ * Agent Framework receives authorization only. Confirmation policy remains a
+ * Connectome Host concern.
+ */
+export function buildFrameworkRetirementConfig(
+  recipe: Recipe,
+): FrameworkRetirementConfig | undefined {
+  const configured = recipe.agent.retirement;
+  if (!configured) return undefined;
+  return { enabled: configured.enabled };
+}
+
+/** Fail-closed memory-health gate owned by the Host confirmation ceremony. */
+export function buildRetirementReadinessCheck(
+  strategy: FrameworkAgentConfig['strategy'],
+): RetirementReadinessCheck {
+  return () => {
+    const candidate = strategy as unknown as {
+      name?: string;
+      getCompressionQuarantineStatus?: () => { count: number; keys: string[] };
+    } | undefined;
+    if (typeof candidate?.getCompressionQuarantineStatus !== 'function') {
+      if (candidate?.name === 'autobiographical') {
+        throw new Error(
+          'Autobiographical strategy does not expose compression quarantine status',
+        );
+      }
+      return { ready: true };
+    }
+    const status = candidate.getCompressionQuarantineStatus();
+    if (
+      !status ||
+      !Number.isSafeInteger(status.count) ||
+      status.count < 0 ||
+      !Array.isArray(status.keys)
+    ) {
+      throw new Error('Compression quarantine status is malformed');
+    }
+    if (status.count === 0) return { ready: true };
+    return {
+      ready: false,
+      code: 'compression_quarantine',
+      reason:
+        `Retirement is temporarily unavailable while ${status.count} context ` +
+        `span(s) are in compression quarantine.`,
+    };
+  };
+}
+
 export function buildFrameworkAgentConfig(
   recipe: Recipe,
   agentName: string,
@@ -64,6 +164,7 @@ export function buildFrameworkAgentConfig(
   strategy: FrameworkAgentConfig['strategy'],
 ): FrameworkAgentConfig {
   const promptCaching = resolvePromptCaching(recipe, model);
+  const retirement = buildFrameworkRetirementConfig(recipe);
   return {
     name: agentName,
     model,
@@ -107,6 +208,7 @@ export function buildFrameworkAgentConfig(
     strategy,
     ...(recipe.agent.thinking && { thinking: recipe.agent.thinking }),
     ...(recipe.agent.refusalHandling && { refusalHandling: recipe.agent.refusalHandling }),
+    ...(retirement && { retirement }),
     ...(recipe.agent.sameRoundThinkTextPolicy !== undefined
       ? { sameRoundThinkTextPolicy: recipe.agent.sameRoundThinkTextPolicy }
       : {}),

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,7 @@ import { IdentityModule } from './modules/identity-module.js';
 import { McplAdminModule } from './modules/mcpl-admin-module.js';
 import { TtsRelayModule } from './modules/tts-relay-module.js';
 import { InstructionsModule } from './modules/instructions-module.js';
+import { ResidentLifecycleModule } from './modules/resident-lifecycle-module.js';
 import { loadMcplServers, applyAgentOverlay, composeMcplChildEnv, DEFAULT_CONFIG_PATH, DEFAULT_AGENT_OVERLAY_PATH } from './mcpl-config.js';
 import { SessionManager } from './session-manager.js';
 import { resolveAgentName } from './agent-name.js';
@@ -65,7 +66,13 @@ import {
   parseRecipeArg,
 } from './recipe.js';
 import { createBranchState, resetBranchState, handleExport, type BranchState } from './commands.js';
-import { buildFrameworkAgentConfig, membraneCachingOverride } from './framework-agent-config.js';
+import {
+  assertResidentRetirementSupport,
+  assertResidentRetirementToolSurface,
+  buildFrameworkAgentConfig,
+  buildRetirementReadinessCheck,
+  membraneCachingOverride,
+} from './framework-agent-config.js';
 import { buildFrameworkStrategy, buildConversationsConfig } from './framework-strategy.js';
 import { buildWorkspaceMounts } from './workspace-mounts.js';
 import { logKeepaliveEvent } from './cache-keepalive-log.js';
@@ -172,13 +179,19 @@ function resolveModel(recipe: Recipe): string {
     (recipe.agent.provider === 'openai-codex' ? 'gpt-5.4' : 'claude-opus-4-6');
 }
 
-async function createFramework(
+type CreateAgentFramework = (
+  frameworkConfig: Parameters<typeof AgentFramework.create>[0],
+) => Promise<AgentFramework>;
+
+export async function createFramework(
   membrane: Membrane,
   storePath: string,
   recipe: Recipe,
   agentName: string,
   settingsModule: SettingsModule,
   callLedger: CallLedger | null,
+  createAgentFramework: CreateAgentFramework = (frameworkConfig) =>
+    AgentFramework.create(frameworkConfig),
 ): Promise<AgentFramework> {
   const model = resolveModel(recipe);
   const modules = recipe.modules ?? {};
@@ -486,6 +499,17 @@ async function createFramework(
 
   // -- Build strategy --
   const strategy = buildFrameworkStrategy(recipe, model, timeZone, extensionRegistry);
+  let residentLifecycleModule: ResidentLifecycleModule | null = null;
+  if (recipe.agent.retirement?.enabled) {
+    residentLifecycleModule = new ResidentLifecycleModule({
+      agentName,
+      enabled: true,
+      confirmationTtlMs: recipe.agent.retirement.confirmationTtlMs,
+      confirmationDelayMs: recipe.agent.retirement.confirmationDelayMs,
+      readinessCheck: buildRetirementReadinessCheck(strategy),
+    });
+    moduleInstances.push(residentLifecycleModule);
+  }
   const agentConfig = buildFrameworkAgentConfig(recipe, agentName, model, strategy);
 
   // Per-channel conversation routing: the recipe agent becomes the trunk
@@ -493,10 +517,13 @@ async function createFramework(
   const conversations = buildConversationsConfig(recipe, agentName, model, timeZone, extensionRegistry);
 
   // -- Create framework --
-  const framework = await AgentFramework.create({
+  const framework = await createAgentFramework({
     storePath,
-    membrane,
-agents: [agentConfig],
+    // Local unreleased AF links may resolve their own equivalent Membrane
+    // declaration (its class has private fields); the runtime interface is the
+    // same package contract used by the released dependency.
+    membrane: membrane as unknown as Parameters<typeof AgentFramework.create>[0]['membrane'],
+    agents: [agentConfig],
     modules: moduleInstances,
     mcplServers: finalServers,
     gate: gateOptions,
@@ -506,7 +533,24 @@ agents: [agentConfig],
     ...(conversations ? { conversations } : {}),
   });
 
+  try {
+    assertResidentRetirementSupport(recipe, framework);
+    await assertResidentRetirementToolSurface(recipe, framework, agentName);
+  } catch (error) {
+    try {
+      await framework.stop();
+    } catch (stopError) {
+      console.error(
+        'Failed to stop an incompatible Agent Framework during startup cleanup:',
+        stopError,
+      );
+    }
+    throw error;
+  }
+
   // Wire post-creation hooks
+  residentLifecycleModule?.setFramework(framework);
+
   // Compression-quarantine klaxon → the framework's ops-alert channel
   // (failures.log + ops:alert trace + CONNECTOME_OPS_WEBHOOK). The strategy
   // re-fires this every alarm interval for as long as ANY chunk is
@@ -1107,7 +1151,9 @@ async function main() {
   }
 }
 
-main().catch((err) => {
-  console.error('Fatal error:', err);
-  process.exit(1);
-});
+if (import.meta.main) {
+  main().catch((err) => {
+    console.error('Fatal error:', err);
+    process.exit(1);
+  });
+}

--- a/src/modules/resident-lifecycle-module.ts
+++ b/src/modules/resident-lifecycle-module.ts
@@ -1,0 +1,339 @@
+import { randomUUID, timingSafeEqual } from 'node:crypto';
+import type {
+  AgentFramework,
+  EventResponse,
+  Module,
+  ModuleContext,
+  ProcessEvent,
+  ToolCall,
+  ToolDefinition,
+  ToolResult,
+} from '@animalabs/agent-framework';
+
+const DEFAULT_CONFIRMATION_TTL_MS = 10 * 60_000;
+const DEFAULT_CONFIRMATION_DELAY_MS = 60_000;
+const CONFIRMATION_PHRASE = 'RETIRE_RESIDENT';
+
+export type RetirementReadiness =
+  | { ready: true }
+  | { ready: false; code: string; reason: string };
+
+export type RetirementReadinessCheck = (
+  phase: 'request' | 'confirm',
+) => RetirementReadiness;
+
+export interface ResidentLifecycleModuleConfig {
+  agentName: string;
+  enabled: boolean;
+  confirmationTtlMs?: number;
+  confirmationDelayMs?: number;
+  readinessCheck: RetirementReadinessCheck;
+  now?: () => number;
+}
+
+interface PendingChallenge {
+  value: string;
+  confirmableAt: number;
+  expiresAt: number;
+}
+
+type LifecycleFramework = AgentFramework & {
+  retireResident(agentName: string, reason?: string): {
+    status: 'retired';
+    retiredAt: number;
+    reason?: string;
+    chronicleRecorded: boolean;
+    alreadyRetired: boolean;
+  };
+};
+
+/** Host-owned resident wording and two-turn confirmation policy. */
+export class ResidentLifecycleModule implements Module {
+  readonly name = 'resident';
+  private readonly agentName: string;
+  private readonly enabled: boolean;
+  private readonly confirmationTtlMs: number;
+  private readonly confirmationDelayMs: number;
+  private readonly readinessCheck: RetirementReadinessCheck;
+  private readonly now: () => number;
+  private framework: LifecycleFramework | null = null;
+  private context: ModuleContext | null = null;
+  private challenge: PendingChallenge | null = null;
+  private confirmationTimer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(config: ResidentLifecycleModuleConfig) {
+    this.agentName = config.agentName;
+    this.enabled = config.enabled;
+    this.confirmationTtlMs = config.confirmationTtlMs ?? DEFAULT_CONFIRMATION_TTL_MS;
+    this.confirmationDelayMs = config.confirmationDelayMs ?? DEFAULT_CONFIRMATION_DELAY_MS;
+    this.readinessCheck = config.readinessCheck;
+    this.now = config.now ?? Date.now;
+  }
+
+  setFramework(framework: AgentFramework): void {
+    this.framework = framework as LifecycleFramework;
+  }
+
+  async start(context: ModuleContext): Promise<void> {
+    this.context = context;
+  }
+
+  async stop(): Promise<void> {
+    this.clearTimer();
+    this.challenge = null;
+    this.context = null;
+    this.framework = null;
+  }
+
+  getTools(): ToolDefinition[] { return []; }
+
+  getLiveTools(agentName: string): ToolDefinition[] {
+    if (!this.enabled || agentName !== this.agentName) return [];
+    return [{
+      name: 'lifecycle',
+      description:
+        'Inspect or irreversibly retire this resident identity. Retirement permanently ' +
+        'prevents future model inference for this resident. It is not end-turn or sleep, ' +
+        'and it does not erase Chronicle, messages, workspace files, or other history. ' +
+        'Requesting retirement ends this turn. After a cooling-off interval, you receive ' +
+        'one separate confirmation turn and may confirm using the fresh challenge. No human ' +
+        'approval is requested. Local memory-health checks may defer either step.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          action: {
+            type: 'string',
+            enum: ['status', 'request_retirement', 'confirm_retirement'],
+          },
+          challenge: { type: 'string' },
+          confirmation: { type: 'string', enum: [CONFIRMATION_PHRASE] },
+          reason: {
+            type: 'string',
+            description: 'Optional resident-authored reason retained with the terminal record.',
+          },
+        },
+        required: ['action'],
+      },
+    }];
+  }
+
+  async handleToolCall(call: ToolCall): Promise<ToolResult> {
+    if (!this.enabled || call.name !== 'lifecycle' || call.callerAgentName !== this.agentName) {
+      return { success: false, isError: true, error: 'resident lifecycle tool is unavailable' };
+    }
+    const framework = this.requireFramework();
+    const input = (call.input ?? {}) as {
+      action?: unknown;
+      challenge?: unknown;
+      confirmation?: unknown;
+      reason?: unknown;
+    };
+
+    if (input.action === 'status') {
+      const pending = this.activeChallenge();
+      return {
+        success: true,
+        data: {
+          ...framework.getResidentLifecycleStatus(this.agentName),
+          confirmationPending: pending !== null,
+          ...(pending ? {
+            confirmationConfirmableAt: pending.confirmableAt,
+            confirmationExpiresAt: pending.expiresAt,
+          } : {}),
+        },
+      };
+    }
+
+    if (input.action === 'request_retirement') {
+      const readiness = this.readiness('request');
+      if (!readiness.ready) return this.notReady(readiness, 'request');
+      const now = this.now();
+      this.challenge = {
+        value: randomUUID(),
+        confirmableAt: now + this.confirmationDelayMs,
+        expiresAt: now + this.confirmationTtlMs,
+      };
+      this.scheduleConfirmationWake(this.challenge);
+      return {
+        success: true,
+        endTurn: true,
+        data: {
+          status: 'confirmation_required',
+          challenge: this.challenge.value,
+          confirmableAt: this.challenge.confirmableAt,
+          expiresAt: this.challenge.expiresAt,
+          semantics:
+            'Confirming permanently prevents future model inference for this resident. ' +
+            'Chronicle, messages, workspace files, and other history remain. This is not ' +
+            'sleep, end-turn, or erasure, and it cannot be reversed through Connectome.',
+          next:
+            `After the cooling-off boundary, call resident--lifecycle with ` +
+            `action="confirm_retirement", this challenge, and confirmation="${CONFIRMATION_PHRASE}". ` +
+            'No human approval is requested.',
+        },
+      };
+    }
+
+    if (input.action === 'confirm_retirement') {
+      const pending = this.activeChallenge();
+      const now = this.now();
+      if (!pending) {
+        return {
+          success: false,
+          isError: true,
+          error: 'No unexpired retirement challenge. Call request_retirement to begin again.',
+        };
+      }
+      if (pending.confirmableAt > now) {
+        return {
+          success: false,
+          isError: true,
+          error: 'The retirement cooling-off interval has not elapsed. The challenge remains pending.',
+          data: {
+            status: 'cooling_off',
+            confirmableAt: pending.confirmableAt,
+            expiresAt: pending.expiresAt,
+          },
+        };
+      }
+      const readiness = this.readiness('confirm');
+      if (!readiness.ready) return this.notReady(readiness, 'confirm', pending.expiresAt);
+
+      // A confirmation attempt after the cooling-off boundary is one-use.
+      this.challenge = null;
+      this.clearTimer();
+      if (
+        typeof input.challenge !== 'string' ||
+        !this.challengeMatches(pending.value, input.challenge) ||
+        input.confirmation !== CONFIRMATION_PHRASE
+      ) {
+        return {
+          success: false,
+          isError: true,
+          error:
+            `Retirement was not confirmed. Supply the fresh challenge exactly and ` +
+            `confirmation="${CONFIRMATION_PHRASE}" before it expires.`,
+        };
+      }
+
+      try {
+        const result = framework.retireResident(
+          this.agentName,
+          typeof input.reason === 'string' ? input.reason : undefined,
+        );
+        this.context?.notifyOps?.(
+          'resident-retired',
+          this.agentName,
+          `Resident ${this.agentName} applied its irreversible retirement seal. History was preserved.`,
+          { retiredAt: result.retiredAt, chronicleRecorded: result.chronicleRecorded },
+        );
+        return {
+          success: true,
+          endTurn: true,
+          data: { ...result, historyPreserved: true },
+        };
+      } catch (error) {
+        return {
+          success: false,
+          isError: true,
+          error: `Retirement was not recorded: ${error instanceof Error ? error.message : String(error)}`,
+        };
+      }
+    }
+
+    return {
+      success: false,
+      isError: true,
+      error: 'action must be status, request_retirement, or confirm_retirement',
+    };
+  }
+
+  async onProcess(_event: ProcessEvent): Promise<EventResponse> { return {}; }
+
+  private requireFramework(): LifecycleFramework {
+    if (!this.framework) throw new Error('resident lifecycle module is not wired to the framework');
+    return this.framework;
+  }
+
+  private readiness(phase: 'request' | 'confirm'): RetirementReadiness {
+    try {
+      const result = this.readinessCheck(phase);
+      if (!result || typeof result !== 'object' || typeof result.ready !== 'boolean') {
+        throw new Error('readiness check returned an invalid result');
+      }
+      return result.ready
+        ? { ready: true }
+        : {
+            ready: false,
+            code: typeof result.code === 'string' && result.code ? result.code : 'not_ready',
+            reason: typeof result.reason === 'string' && result.reason
+              ? result.reason
+              : 'Retirement is temporarily unavailable because memory health was not established.',
+          };
+    } catch (error) {
+      console.error(`[resident-retirement] readiness check failed during ${phase}:`, error);
+      return {
+        ready: false,
+        code: 'readiness_check_failed',
+        reason: 'Retirement is temporarily unavailable because memory health could not be verified.',
+      };
+    }
+  }
+
+  private notReady(
+    readiness: Exclude<RetirementReadiness, { ready: true }>,
+    phase: 'request' | 'confirm',
+    expiresAt?: number,
+  ): ToolResult {
+    return {
+      success: false,
+      isError: true,
+      error: readiness.reason,
+      data: {
+        status: 'not_ready',
+        code: readiness.code,
+        phase,
+        ...(expiresAt !== undefined ? { expiresAt } : {}),
+      },
+    };
+  }
+
+  private activeChallenge(): PendingChallenge | null {
+    if (!this.challenge) return null;
+    if (this.challenge.expiresAt <= this.now()) {
+      this.challenge = null;
+      this.clearTimer();
+      return null;
+    }
+    return this.challenge;
+  }
+
+  private scheduleConfirmationWake(challenge: PendingChallenge): void {
+    this.clearTimer();
+    const timer = setTimeout(() => {
+      this.confirmationTimer = null;
+      if (this.challenge !== challenge || !this.activeChallenge()) return;
+      const result = this.framework?.nudgeAgent(
+        this.agentName,
+        'resident-lifecycle',
+      );
+      if (result && !result.ok) {
+        console.error(`[resident-retirement] confirmation wake was not queued: ${result.error}`);
+      }
+    }, Math.max(0, challenge.confirmableAt - this.now()));
+    timer.unref?.();
+    this.confirmationTimer = timer;
+  }
+
+  private clearTimer(): void {
+    if (!this.confirmationTimer) return;
+    clearTimeout(this.confirmationTimer);
+    this.confirmationTimer = null;
+  }
+
+  private challengeMatches(expected: string, supplied: string): boolean {
+    const a = Buffer.from(expected);
+    const b = Buffer.from(supplied);
+    return a.length === b.length && timingSafeEqual(a, b);
+  }
+}

--- a/src/recipe.ts
+++ b/src/recipe.ts
@@ -250,6 +250,17 @@ export interface RecipeAgent {
     maxRewinds?: number;
     announceHumanTurns?: boolean;
   };
+  /**
+   * Opt-in Host-owned resident confirmation ceremony backed by Agent
+   * Framework's neutral irreversible seal. Preserves Chronicle/history.
+   */
+  retirement?: {
+    enabled: boolean;
+    /** Fresh confirmation challenge lifetime (default 10 minutes). */
+    confirmationTtlMs?: number;
+    /** Cooling-off floor before confirmation can bind (default 60 seconds). */
+    confirmationDelayMs?: number;
+  };
 }
 
 export interface RecipeMcpServer {
@@ -1401,6 +1412,56 @@ export function validateRecipe(raw: unknown): Recipe {
   const refusalHandling = agent.refusalHandling as Record<string, unknown> | undefined;
   if (refusalHandling && Object.hasOwn(refusalHandling, 'primarySummaryFallback')) {
     throw new Error('Recipe agent.refusalHandling.primarySummaryFallback was removed and is unsupported.');
+  }
+
+  if (agent.retirement !== undefined) {
+    if (!agent.retirement || typeof agent.retirement !== 'object' || Array.isArray(agent.retirement)) {
+      throw new Error('Recipe agent.retirement must be an object.');
+    }
+    const retirement = agent.retirement as Record<string, unknown>;
+    const known = new Set(['enabled', 'confirmationTtlMs', 'confirmationDelayMs']);
+    for (const key of Object.keys(retirement)) {
+      if (!known.has(key)) throw new Error(`Recipe agent.retirement has unknown field ${JSON.stringify(key)}.`);
+    }
+    if (typeof retirement.enabled !== 'boolean') {
+      throw new Error('Recipe agent.retirement.enabled must be a boolean.');
+    }
+    if (
+      retirement.confirmationTtlMs !== undefined &&
+      (
+        typeof retirement.confirmationTtlMs !== 'number' ||
+        !Number.isSafeInteger(retirement.confirmationTtlMs) ||
+        retirement.confirmationTtlMs < 10_000 ||
+        retirement.confirmationTtlMs > 3_600_000
+      )
+    ) {
+      throw new Error(
+        'Recipe agent.retirement.confirmationTtlMs must be an integer between 10000 and 3600000.',
+      );
+    }
+    if (
+      retirement.confirmationDelayMs !== undefined &&
+      (
+        typeof retirement.confirmationDelayMs !== 'number' ||
+        !Number.isSafeInteger(retirement.confirmationDelayMs) ||
+        retirement.confirmationDelayMs < 1
+      )
+    ) {
+      throw new Error(
+        'Recipe agent.retirement.confirmationDelayMs must be a positive integer.',
+      );
+    }
+    const confirmationTtlMs = typeof retirement.confirmationTtlMs === 'number'
+      ? retirement.confirmationTtlMs
+      : 10 * 60_000;
+    const confirmationDelayMs = typeof retirement.confirmationDelayMs === 'number'
+      ? retirement.confirmationDelayMs
+      : 60_000;
+    if (confirmationDelayMs >= confirmationTtlMs) {
+      throw new Error(
+        'Recipe agent.retirement.confirmationDelayMs must be smaller than confirmationTtlMs.',
+      );
+    }
   }
 
   // Validate mcpServers entries if present

--- a/test/recipe-retirement.test.ts
+++ b/test/recipe-retirement.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, spyOn, test } from 'bun:test';
+import type { AgentFramework } from '@animalabs/agent-framework';
+import type { Membrane } from '@animalabs/membrane';
+import {
+  assertResidentRetirementSupport,
+  assertResidentRetirementToolSurface,
+  buildFrameworkAgentConfig,
+  buildRetirementReadinessCheck,
+} from '../src/framework-agent-config.js';
+import { createFramework } from '../src/index.js';
+import { SettingsModule } from '../src/modules/settings-module.js';
+import { validateRecipe } from '../src/recipe.js';
+
+const recipe = (retirement?: unknown) => ({
+  name: 'retirement-test',
+  agent: {
+    systemPrompt: '',
+    ...(retirement === undefined ? {} : { retirement }),
+  },
+});
+
+describe('resident retirement recipe', () => {
+  test('is opt-in and passes validated configuration to Agent Framework', () => {
+    const absent = validateRecipe(recipe());
+    expect(buildFrameworkAgentConfig(absent, 'resident', 'model', undefined).retirement)
+      .toBeUndefined();
+
+    const parsed = validateRecipe(recipe({
+      enabled: true,
+      confirmationTtlMs: 120_000,
+      confirmationDelayMs: 60_000,
+    }));
+    const retirement = buildFrameworkAgentConfig(
+      parsed,
+      'resident',
+      'model',
+      undefined,
+    ).retirement;
+    expect(retirement).toMatchObject({
+      enabled: true,
+    });
+    expect(retirement).toEqual({ enabled: true });
+  });
+
+  test('rejects malformed or unsafe confirmation configuration', () => {
+    expect(() => validateRecipe(recipe(true))).toThrow(/retirement must be an object/);
+    expect(() => validateRecipe(recipe({}))).toThrow(/enabled must be a boolean/);
+    expect(() => validateRecipe(recipe({ enabled: true, confirmationTtlMs: 9_999 })))
+      .toThrow(/confirmationTtlMs/);
+    expect(() => validateRecipe(recipe({ enabled: true, confirmationTtlMs: 3_600_001 })))
+      .toThrow(/confirmationTtlMs/);
+    expect(() => validateRecipe(recipe({ enabled: true, confirmationDelayMs: 0 })))
+      .toThrow(/confirmationDelayMs/);
+    expect(() => validateRecipe(recipe({
+      enabled: true,
+      confirmationTtlMs: 60_000,
+      confirmationDelayMs: 60_000,
+    }))).toThrow(/smaller than confirmationTtlMs/);
+    expect(() => validateRecipe(recipe({ enabled: true, surprise: true })))
+      .toThrow(/unknown field/);
+  });
+
+  test('defers retirement while autobiographical compression quarantine is non-empty', () => {
+    let count = 2;
+    const strategy = {
+      getCompressionQuarantineStatus: () => ({
+        count,
+        keys: Array.from({ length: count }, (_, i) => `chunk-${i}`),
+      }),
+    };
+    const check = buildRetirementReadinessCheck(
+      strategy as Parameters<typeof buildRetirementReadinessCheck>[0],
+    );
+    expect(check('request')).toEqual({
+      ready: false,
+      code: 'compression_quarantine',
+      reason:
+        'Retirement is temporarily unavailable while 2 context span(s) are in compression quarantine.',
+    });
+
+    count = 0;
+    expect(check('confirm')).toEqual({ ready: true });
+
+    const missingReader = buildRetirementReadinessCheck(
+      { name: 'autobiographical' } as Parameters<typeof buildRetirementReadinessCheck>[0],
+    );
+    expect(() => missingReader('request'))
+      .toThrow(/does not expose compression quarantine status/);
+  });
+
+  test('fails closed when the installed framework lacks retirement support', () => {
+    const parsed = validateRecipe(recipe({ enabled: true }));
+    expect(() => assertResidentRetirementSupport(parsed, {})).toThrow(/does not support/);
+    expect(() => assertResidentRetirementSupport(parsed, {
+      getResidentLifecycleStatus() {},
+      retireResident() {},
+      previewActivation() {},
+    })).not.toThrow();
+
+    const disabled = validateRecipe(recipe({ enabled: false }));
+    expect(() => assertResidentRetirementSupport(disabled, {})).not.toThrow();
+  });
+
+  test('fails closed when the framework ignores the protected live-tool surface', async () => {
+    const parsed = validateRecipe(recipe({ enabled: true }));
+    const framework = {
+      previewActivation: async () => ({ tools: [] }),
+    } as unknown as AgentFramework;
+    await expect(assertResidentRetirementToolSurface(parsed, framework, 'resident'))
+      .rejects.toThrow(/protected resident lifecycle tool surface/);
+  });
+
+  test('fails closed at the framework startup seam and preserves the compatibility error', async () => {
+    const optedInRecipe = recipe({ enabled: true });
+    const parsed = validateRecipe({
+      ...optedInRecipe,
+      agent: {
+        ...optedInRecipe.agent,
+        provider: 'mock',
+        strategy: { type: 'passthrough' },
+      },
+      modules: {
+        subagents: false,
+        lessons: false,
+        retrieval: false,
+        wake: false,
+        workspace: false,
+        subscriptionGc: false,
+        channelMode: false,
+      },
+    });
+    let stopCalls = 0;
+    const unsupportedFramework = {
+      async stop() {
+        stopCalls += 1;
+        throw new Error('cleanup also failed');
+      },
+    } as unknown as AgentFramework;
+
+    let startupError: unknown;
+    const cleanupLog = spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      await createFramework(
+        {} as Membrane,
+        '/tmp/retirement-startup-seam',
+        parsed,
+        'resident',
+        new SettingsModule(),
+        null,
+        async () => unsupportedFramework,
+      );
+    } catch (error) {
+      startupError = error;
+    } finally {
+      cleanupLog.mockRestore();
+    }
+
+    expect(stopCalls).toBe(1);
+    expect(startupError).toBeInstanceOf(Error);
+    expect((startupError as Error).message).toMatch(/does not support resident retirement/);
+  });
+});

--- a/test/resident-lifecycle-module.test.ts
+++ b/test/resident-lifecycle-module.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, test } from 'bun:test';
+import type { AgentFramework, ModuleContext, ToolCall } from '@animalabs/agent-framework';
+import { ResidentLifecycleModule } from '../src/modules/resident-lifecycle-module.js';
+
+function call(
+  action: string,
+  input: Record<string, unknown> = {},
+): ToolCall {
+  return {
+    id: `call-${action}`,
+    name: 'lifecycle',
+    callerAgentName: 'resident',
+    input: { action, ...input },
+  };
+}
+
+function harness(options: { ready?: () => boolean } = {}) {
+  let now = 1_000;
+  const nudges: Array<{ agent: string; reason?: string }> = [];
+  const retirements: Array<{ agent: string; reason?: string }> = [];
+  const notifications: unknown[][] = [];
+  const module = new ResidentLifecycleModule({
+    agentName: 'resident',
+    enabled: true,
+    confirmationDelayMs: 100,
+    confirmationTtlMs: 1_000,
+    now: () => now,
+    readinessCheck: () => options.ready?.() === false
+      ? { ready: false, code: 'quarantine', reason: 'memory quarantine is not empty' }
+      : { ready: true },
+  });
+  const framework = {
+    getResidentLifecycleStatus: () => ({ status: 'active', retirementEnabled: true }),
+    nudgeAgent: (agent: string, reason?: string) => {
+      nudges.push({ agent, reason });
+      return { ok: true, message: 'queued' };
+    },
+    retireResident: (agent: string, reason?: string) => {
+      retirements.push({ agent, reason });
+      return {
+        status: 'retired' as const,
+        retiredAt: now,
+        ...(reason ? { reason } : {}),
+        chronicleRecorded: true,
+        alreadyRetired: false,
+      };
+    },
+  } as unknown as AgentFramework;
+  module.setFramework(framework);
+  void module.start({
+    notifyOps: (...args: unknown[]) => { notifications.push(args); },
+  } as unknown as ModuleContext);
+  return {
+    module,
+    nudges,
+    retirements,
+    notifications,
+    advance: (ms: number) => { now += ms; },
+  };
+}
+
+describe('ResidentLifecycleModule', () => {
+  test('exposes the ceremony only to the configured resident live surface', () => {
+    const { module } = harness();
+    expect(module.getTools()).toEqual([]);
+    expect(module.getLiveTools('resident').map((tool) => tool.name)).toEqual(['lifecycle']);
+    expect(module.getLiveTools('conversation-dm-g1')).toEqual([]);
+  });
+
+  test('requires a separate cooled-off confirmation and notifies only after sealing', async () => {
+    const { module, advance, retirements, notifications } = harness();
+    const requested = await module.handleToolCall(call('request_retirement'));
+    expect(requested.success).toBe(true);
+    expect(requested.endTurn).toBe(true);
+    const data = requested.data as { challenge: string; confirmableAt: number; expiresAt: number };
+
+    const early = await module.handleToolCall(call('confirm_retirement', {
+      challenge: data.challenge,
+      confirmation: 'RETIRE_RESIDENT',
+    }));
+    expect(early.success).toBe(false);
+    expect((early.data as { status: string }).status).toBe('cooling_off');
+    expect(retirements).toHaveLength(0);
+
+    advance(100);
+    const confirmed = await module.handleToolCall(call('confirm_retirement', {
+      challenge: data.challenge,
+      confirmation: 'RETIRE_RESIDENT',
+      reason: 'resident reason',
+    }));
+    expect(confirmed.success).toBe(true);
+    expect(confirmed.endTurn).toBe(true);
+    expect(retirements).toEqual([{ agent: 'resident', reason: 'resident reason' }]);
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0]?.[0]).toBe('resident-retired');
+  });
+
+  test('expires a challenge and requires a fresh request', async () => {
+    const { module, advance, retirements } = harness();
+    const requested = await module.handleToolCall(call('request_retirement'));
+    const challenge = (requested.data as { challenge: string }).challenge;
+    advance(1_001);
+    const expired = await module.handleToolCall(call('confirm_retirement', {
+      challenge,
+      confirmation: 'RETIRE_RESIDENT',
+    }));
+    expect(expired.success).toBe(false);
+    expect(expired.error).toMatch(/No unexpired retirement challenge/);
+    expect(retirements).toHaveLength(0);
+  });
+
+  test('fails closed on quarantine at request and confirmation without consuming a valid challenge', async () => {
+    let ready = false;
+    const { module, advance, retirements } = harness({ ready: () => ready });
+    const blockedRequest = await module.handleToolCall(call('request_retirement'));
+    expect(blockedRequest.success).toBe(false);
+    expect((blockedRequest.data as { code: string }).code).toBe('quarantine');
+
+    ready = true;
+    const requested = await module.handleToolCall(call('request_retirement'));
+    const challenge = (requested.data as { challenge: string }).challenge;
+    advance(100);
+    ready = false;
+    const blockedConfirmation = await module.handleToolCall(call('confirm_retirement', {
+      challenge,
+      confirmation: 'RETIRE_RESIDENT',
+    }));
+    expect(blockedConfirmation.success).toBe(false);
+
+    ready = true;
+    const confirmed = await module.handleToolCall(call('confirm_retirement', {
+      challenge,
+      confirmation: 'RETIRE_RESIDENT',
+    }));
+    expect(confirmed.success).toBe(true);
+    expect(retirements).toHaveLength(1);
+  });
+
+  test('consumes a post-cooling invalid confirmation', async () => {
+    const { module, advance } = harness();
+    const requested = await module.handleToolCall(call('request_retirement'));
+    const challenge = (requested.data as { challenge: string }).challenge;
+    advance(100);
+    const invalid = await module.handleToolCall(call('confirm_retirement', {
+      challenge,
+      confirmation: 'DO_NOT_RETIRE',
+    }));
+    expect(invalid.success).toBe(false);
+    const retry = await module.handleToolCall(call('confirm_retirement', {
+      challenge,
+      confirmation: 'RETIRE_RESIDENT',
+    }));
+    expect(retry.error).toMatch(/No unexpired retirement challenge/);
+  });
+});


### PR DESCRIPTION
> [!IMPORTANT]
> **Blocked on [anima-research/agent-framework#116](https://github.com/anima-research/agent-framework/pull/116) and a subsequent qualifying package release.** Do not merge or mark ready until this PR's `@animalabs/agent-framework` dependency range and `bun.lock` are updated to that release.

## Problem

Agent Framework should own the neutral irreversible resident seal, but Connectome Host needs to own the resident-facing language and policy used to request and confirm that transition.

## Changes

- Add and strictly validate opt-in `agent.retirement: { enabled, confirmationDelayMs?, confirmationTtlMs? }` recipe configuration.
- Install a Host-owned protected `resident--lifecycle` tool only on the configured resident's real provider-issued stream.
- `request_retirement` checks memory health, creates a fresh in-memory one-use challenge, records cooling-off and expiry boundaries, ends the turn, and schedules a fresh turn at the boundary.
- `confirm_retirement` requires the exact challenge and `RETIRE_RESIDENT` after the cooling-off floor and before expiry. Early confirmation preserves the challenge; an invalid post-boundary attempt consumes it; expiry or restart requires a fresh request.
- Keep confirmation entirely resident-side. There is no human approval request. Only a successfully applied terminal seal emits the `resident-retired` ops notification.
- Fail closed at both request and confirmation while autobiographical compression quarantine is non-empty, unreadable, or malformed. A valid challenge remains pending while health is blocked, subject to expiry.
- Call Agent Framework's imperative `retireResident()` primitive after exact confirmation; the Framework retains sole ownership of the irreversible ledger and inference guards.
- Refuse startup when the installed Framework lacks either the lifecycle API or the protected live-tool surface, and preserve the original compatibility error if cleanup itself encounters a problem.
- Document history preservation, malformed-ledger recovery, local unreleased linking, and the treatment of already-running ephemeral subagents.
- Add recipe, startup-seam, challenge-expiry, quarantine, notification, and invalid-confirmation tests plus a changelog fragment.

## Review response

This revision implements the architecture requested on Agent Framework #116: the Framework owns neutral enforcement, while Host owns wording and ceremony. It also adds the cooling-off minimum, memory-health gating, startup-seam coverage, and error-preserving cleanup raised in Weft's draft review.

## Tests

- Focused retirement tests: 11 pass / 0 fail
- `bun test`: 743 pass / 0 fail across 83 files
- `git diff --check`: pass

The squashed revision has the same source tree as the full-tested pre-squash head.

## Known baseline diagnostic

A standalone Node `tsc --noEmit` invocation reports the existing Bun/global process-event typing conflict at `src/modules/fleet-module.ts:603`. The retirement files introduce no TypeScript diagnostic, and the canonical Bun suite compiles and passes.

## Not verified

- Not exercised end-to-end against a published Agent Framework release containing `retireResident()`; this branch is currently verified against the exact local Framework companion commit.
- Not exercised against a paid or live model provider.

## Out of scope

- Human approval or an operator confirmation command.
- Session deletion, data erasure, or unretirement behavior.
- Mid-call cancellation of already-running ephemeral subagents. They remain separate identities and cannot append to or wake the sealed resident.

## Companion PR

Blocked on [anima-research/agent-framework#116](https://github.com/anima-research/agent-framework/pull/116). After that PR is merged and a package release is verified to contain its merge commit, refresh this branch's dependency range and lockfile, rerun the full suite against the published package, and only then mark this PR ready.

Recipes without the opt-in remain unchanged. An opted-in recipe fails closed with an explicit startup error on an unsupported runtime.

---

- [x] Changelog fragment added under `changelog.d/`.

🤖 Generated with [OpenAI Codex](https://openai.com/codex/)
