### PR TITLE
feat(recipe): cacheKeepalive — hold an idle agent's 1h prompt cache warm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@
 
 ### Added
 
+- **`agent.cacheKeepalive` — hold an idle agent's 1h prompt cache warm.** With
+  `cacheTtl: "1h"`, an idle agent's cached prefix expires after an hour and its
+  next wake pays a **2x cache write** over the entire context. Reading an entry
+  restarts its clock, so membrane now replays the last request with
+  `max_tokens: 0` (prefill only) to refresh it at cache-**read** price (0.1x).
+  On by default for the anthropic provider; `{ "enabled": false }` opts out.
+  - **Cost is proportional to actual idleness, not to `maxIdleHours`.** A poke
+    fires only when the entry is genuinely near expiry, so a busy agent never
+    fires one — its own traffic already refreshed the TTL. Measured on mythos
+    llm-calls over 36h: 563 of 637 gaps were under 5 minutes, only 5 exceeded
+    1h.
+  - Knobs: `maxIdleHours` (default 24, measured from the last **real** request
+    so pokes cannot extend their own mandate) and `refreshAfterMinutes`
+    (default 45). Recipe validation **rejects `refreshAfterMinutes >= the cache
+    TTL`** — such a keepalive always fires after the entry has already expired,
+    paying a full cache write on every poke while still looking like a healthy
+    successful call.
+  - Events land in `service-stderr.log`, warn-level for `ineffective` and
+    `disabled`, so a background spender is legible without opening a billing
+    dashboard.
+  - Sizing, from fable-cm's 11-day log (~500k-token prefix): 49.7M tokens of
+    `cache_creation` landed on turns following a >1h idle gap — ~$944 of write
+    premium at fable-5 rates that this converts to ~$308 of reads.
+
 - **`provider: "mock"` — run the whole host with zero provider spend and no
   credentials.** Wires membrane's existing `MockAdapter` (previously
   unreachable from any recipe) as a first-class provider: echoes the last

--- a/src/index.ts
+++ b/src/index.ts
@@ -962,6 +962,30 @@ async function main() {
                   : {}),
               }),
           baseURL: process.env.ANTHROPIC_BASE_URL || undefined,
+          // Hold this agent's cached prefix warm across idle gaps. Only fires
+          // when the entry is actually near expiry, so a busy agent costs
+          // nothing; only the 1h-TTL primary lane is eligible (the module
+          // skips anything else). Off with cacheKeepalive.enabled: false.
+          cacheKeepalive: {
+            enabled: recipe.agent.cacheKeepalive?.enabled !== false,
+            ...(recipe.agent.cacheKeepalive?.maxIdleHours !== undefined
+              ? { maxIdleMs: recipe.agent.cacheKeepalive.maxIdleHours * 60 * 60_000 }
+              : {}),
+            ...(recipe.agent.cacheKeepalive?.refreshAfterMinutes !== undefined
+              ? { refreshAfterMs: recipe.agent.cacheKeepalive.refreshAfterMinutes * 60_000 }
+              : {}),
+            onEvent: (event: import('@animalabs/membrane').KeepaliveEvent) => {
+              // Surfaced in service-stderr.log. A background spender must be
+              // legible without reading the billing dashboard — and the
+              // 'ineffective'/'disabled' lines are the ones that matter.
+              const detail = JSON.stringify(event);
+              if (event.type === 'refreshed' || event.type === 'expired') {
+                console.log(`[cache-keepalive] ${detail}`);
+              } else {
+                console.warn(`[cache-keepalive] ${detail}`);
+              }
+            },
+          },
         },
         llmLogPath,
         () => settingsModule.getReasoning(),

--- a/src/recipe.ts
+++ b/src/recipe.ts
@@ -140,6 +140,28 @@ export interface RecipeAgent {
    *  cache and rejects the ttl field. */
   cacheTtl?: '5m' | '1h';
   /**
+   * Prompt-cache keepalive. With `cacheTtl: '1h'`, an idle agent's cached
+   * prefix expires after an hour and its next wake pays a 2x cache write over
+   * the whole context. Reading an entry refreshes its TTL at 0.1x, so a
+   * periodic `max_tokens: 0` replay holds it warm for pennies.
+   *
+   * On by default for the anthropic provider (ignored elsewhere — bedrock has
+   * no 1h cache). Measured on fable-cm 2026-08-11..22: 49.7M tokens of cache
+   * writes followed a >1h idle gap, ~$944 of write premium at fable-5 rates
+   * that this converts to ~$308 of reads.
+   *
+   * Cost is proportional to actual idleness, not to `maxIdleHours` — a busy
+   * agent never fires one, because its own traffic already refreshes the TTL.
+   */
+  cacheKeepalive?: {
+    /** Default true (anthropic provider only). */
+    enabled?: boolean;
+    /** Stop refreshing this long after the last REAL request. Default 24. */
+    maxIdleHours?: number;
+    /** Refresh once untouched this long. Must be < 60 with a 1h TTL. Default 45. */
+    refreshAfterMinutes?: number;
+  };
+  /**
    * Explicit prompt-caching override. Unset means provider-appropriate
    * default: on for everything except bedrock models that predate caching
    * support there (see bedrockModelSupportsPromptCaching). Set false if a
@@ -1084,6 +1106,37 @@ export function validateRecipe(raw: unknown): Recipe {
     throw new Error(`Recipe agent.cacheTtl must be '5m' or '1h', got ${JSON.stringify(agent.cacheTtl)}.`);
   }
   agent.cacheTtl ??= '1h';
+
+  // A keepalive that fires AFTER the entry has already expired is the worst of
+  // both worlds: it pays a full 2x cache write on every poke, forever, and
+  // reports success while doing it. Refuse the config rather than discover it
+  // in a bill. (The runtime also self-checks — see membrane cache-keepalive —
+  // but a typo'd recipe should never get that far.)
+  const keepalive = agent.cacheKeepalive;
+  if (keepalive !== undefined) {
+    if (typeof keepalive !== 'object' || keepalive === null) {
+      throw new Error(`Recipe agent.cacheKeepalive must be an object, got ${JSON.stringify(keepalive)}.`);
+    }
+    const { maxIdleHours, refreshAfterMinutes } = keepalive as {
+      maxIdleHours?: unknown;
+      refreshAfterMinutes?: unknown;
+    };
+    if (refreshAfterMinutes !== undefined) {
+      if (typeof refreshAfterMinutes !== 'number' || !(refreshAfterMinutes > 0)) {
+        throw new Error(`Recipe agent.cacheKeepalive.refreshAfterMinutes must be a positive number, got ${JSON.stringify(refreshAfterMinutes)}.`);
+      }
+      const ttlMinutes = agent.cacheTtl === '1h' ? 60 : 5;
+      if (refreshAfterMinutes >= ttlMinutes) {
+        throw new Error(
+          `Recipe agent.cacheKeepalive.refreshAfterMinutes (${refreshAfterMinutes}) must be less than the ${agent.cacheTtl} cache TTL (${ttlMinutes}m), ` +
+          'or every keepalive would land after the entry expired and pay a full cache write instead of a read.',
+        );
+      }
+    }
+    if (maxIdleHours !== undefined && (typeof maxIdleHours !== 'number' || !(maxIdleHours > 0))) {
+      throw new Error(`Recipe agent.cacheKeepalive.maxIdleHours must be a positive number, got ${JSON.stringify(maxIdleHours)}.`);
+    }
+  }
 
   if (agent.promptCaching !== undefined && typeof agent.promptCaching !== 'boolean') {
     throw new Error(

--- a/test/recipe-cache-keepalive.test.ts
+++ b/test/recipe-cache-keepalive.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Tests for recipe.agent.cacheKeepalive validation.
+ *
+ * The load-bearing case is `refreshAfterMinutes >= the cache TTL`: such a
+ * keepalive always fires AFTER the entry has expired, so every poke pays a full
+ * 2x cache write instead of a 0.1x read — while still looking like a healthy
+ * successful call. That must fail at recipe-load time, not on a bill.
+ */
+import { describe, test, expect } from 'bun:test';
+import { validateRecipe } from '../src/recipe.js';
+
+function recipeWith(cacheKeepalive?: unknown, cacheTtl?: unknown) {
+  return {
+    name: 'keepalive-test',
+    agent: {
+      systemPrompt: 'sys',
+      ...(cacheTtl !== undefined && { cacheTtl }),
+      ...(cacheKeepalive !== undefined && { cacheKeepalive }),
+    },
+  };
+}
+
+describe('recipe agent.cacheKeepalive validation', () => {
+  test('omitting it is valid — keepalive is on by default', () => {
+    expect(validateRecipe(recipeWith()).agent.cacheKeepalive).toBeUndefined();
+  });
+
+  test('accepts an explicit opt-out', () => {
+    const r = validateRecipe(recipeWith({ enabled: false }));
+    expect(r.agent.cacheKeepalive?.enabled).toBe(false);
+  });
+
+  test('accepts sane tuning', () => {
+    const r = validateRecipe(recipeWith({ maxIdleHours: 12, refreshAfterMinutes: 50 }));
+    expect(r.agent.cacheKeepalive?.maxIdleHours).toBe(12);
+    expect(r.agent.cacheKeepalive?.refreshAfterMinutes).toBe(50);
+  });
+
+  test('rejects a refresh interval at or past the 1h TTL (every poke would be a cache WRITE)', () => {
+    expect(() => validateRecipe(recipeWith({ refreshAfterMinutes: 60 }, '1h'))).toThrow(/less than the 1h cache TTL/);
+    expect(() => validateRecipe(recipeWith({ refreshAfterMinutes: 90 }, '1h'))).toThrow(/less than the 1h cache TTL/);
+  });
+
+  test('rejects a refresh interval at or past the 5m TTL', () => {
+    expect(() => validateRecipe(recipeWith({ refreshAfterMinutes: 45 }, '5m'))).toThrow(/less than the 5m cache TTL/);
+    expect(validateRecipe(recipeWith({ refreshAfterMinutes: 4 }, '5m')).agent.cacheKeepalive?.refreshAfterMinutes).toBe(4);
+  });
+
+  test('rejects non-positive and non-numeric values', () => {
+    expect(() => validateRecipe(recipeWith({ refreshAfterMinutes: 0 }))).toThrow(/positive number/);
+    expect(() => validateRecipe(recipeWith({ refreshAfterMinutes: '45' }))).toThrow(/positive number/);
+    expect(() => validateRecipe(recipeWith({ maxIdleHours: -1 }))).toThrow(/positive number/);
+    expect(() => validateRecipe(recipeWith({ maxIdleHours: 'lots' }))).toThrow(/positive number/);
+  });
+
+  test('rejects a non-object', () => {
+    expect(() => validateRecipe(recipeWith('yes'))).toThrow(/must be an object/);
+  });
+});


### PR DESCRIPTION
Surfaces membrane's prompt-cache keepalive (antra-tess/membrane#47) as `agent.cacheKeepalive`, **on by default** for the anthropic provider.

An idle agent's cached prefix expires on its TTL and the next wake pays a 2x cache write over the whole context; reading an entry restarts its clock, so a periodic `max_tokens: 0` replay holds it warm at 0.1x.

**Cost is proportional to actual idleness, not to `maxIdleHours`** — a busy agent never fires a keepalive, because its own traffic already refreshes the TTL. Measured on mythos: 563 of 637 gaps over 36h were under 5 minutes.

```jsonc
"agent": {
  "cacheTtl": "1h",
  "cacheKeepalive": { "enabled": true, "maxIdleHours": 24, "refreshAfterMinutes": 45 }
}
```

## Validation earns its keep

Load-time validation rejects `refreshAfterMinutes >= the cache TTL`. Such a keepalive always fires **after** the entry has expired, so every poke pays a full cache write instead of a read — while still looking like a healthy successful call. That belongs in a load-time error, not in a bill. (Membrane also self-checks the usage numbers on every poke; a typo'd recipe should never get that far.)

## Observability

Keepalive events go to `service-stderr.log`, warn-level for the ones that matter (`ineffective` / `disabled`). A background spender should be legible without reading the billing dashboard.

## Sizing

From fable-cm's 11-day log (~500k-token prefix): 49.7M tokens of `cache_creation` landed on turns following a >1h idle gap — ~$944 of write premium at fable-5 rates that this converts to ~$308 of reads.

## Tests

7 new tests on the validation boundary. Recipe suite: **77 pass / 0 fail**.

Typecheck adds **0** new errors vs. baseline. (`main` currently has one pre-existing `proseRouting: 'hybrid'` error against agent-framework — verified identical with and without this change.)

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KxYS1YL6FjQk6XhBeitAsQ