### PR TITLE
feat(commands): /puppet — admin-execute a tool AS the agent; await asyncWork over IPC

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -36,6 +36,10 @@ import { type FleetModule, formatChildRow } from './modules/fleet-module.js';
 /** Imported lazily to avoid circular deps — index.ts re-exports the type. */
 interface AppContext {
   framework: AgentFramework;
+  /** Resolved main-agent name (see index.ts resolveAgentName). Optional
+   *  because some callers (tui/webui refs) don't thread it; /puppet falls
+   *  back to the first registered agent, same as getAgentCM. */
+  agentName?: string;
   sessionManager: import('./session-manager.js').SessionManager;
   recipe: Recipe;
   branchState: BranchState;
@@ -149,6 +153,7 @@ export function handleCommand(command: string, app: AppContext): CommandResult {
           { text: '  /undo                  Revert last agent turn', style: 'system' },
           { text: '  /redo                  Re-apply undone action', style: 'system' },
           { text: '  /nudge [agent]         Run inference on current context (no new events)', style: 'system' },
+          { text: '  /puppet <tool> [json]  Admin: execute a tool AS the agent, store the pair', style: 'system' },
           { text: '  /checkpoint <name>     Save current state', style: 'system' },
           { text: '  /restore <name>        Restore to checkpoint', style: 'system' },
           { text: '  /branches              List Chronicle branches', style: 'system' },
@@ -193,6 +198,9 @@ export function handleCommand(command: string, app: AppContext): CommandResult {
 
     case 'nudge':
       return handleNudge(app, args[0]);
+
+    case 'puppet':
+      return handlePuppet(app, args);
 
     case 'redo':
       return handleRedo(app);
@@ -662,6 +670,67 @@ export function handleExport(app: AppContext): CommandResult {
  * `nudgeAgent`). The zero-pollution complement to /undo: rewind, then nudge,
  * and the agent takes another swing at exactly what it already sees.
  */
+/**
+ * /puppet <toolName> [json-input] — admin: execute one tool AS the main
+ * agent and store the tool_use + tool_result pair in its window, exactly as
+ * a model-initiated call (Framework.puppetToolCall). The call runs for real.
+ * Refused unless the agent is idle and the tool is on its surface. Does not
+ * wake the agent. Born from the princess exemplar surgery (2026-08-23):
+ * one first-person pair restores a capacity the model can't find on its own
+ * — older models especially. Disclosure to the resident is the operator's
+ * call; the precedent was disclosed first.
+ */
+function handlePuppet(app: AppContext, args: string[]): CommandResult {
+  const toolName = args[0];
+  if (!toolName) {
+    return {
+      lines: [
+        { text: 'Usage: /puppet <toolName> [json-input]', style: 'system' },
+        { text: '  Executes the tool AS the agent (for real) and stores the', style: 'system' },
+        { text: '  tool_use + tool_result pair in its window. Requires idle.', style: 'system' },
+      ],
+    };
+  }
+  const rawInput = args.slice(1).join(' ').trim();
+  let input: Record<string, unknown> = {};
+  if (rawInput) {
+    try {
+      const parsed = JSON.parse(rawInput);
+      if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+        return { lines: [{ text: 'puppet: input must be a JSON object', style: 'system' }] };
+      }
+      input = parsed;
+    } catch (e) {
+      return { lines: [{ text: `puppet: bad JSON input: ${e instanceof Error ? e.message : e}`, style: 'system' }] };
+    }
+  }
+  const agentName = app.agentName ?? app.framework.getAllAgents()[0]?.name;
+  if (!agentName) {
+    return { lines: [{ text: 'puppet: no registered agent', style: 'system' }] };
+  }
+  const asyncWork = (async (): Promise<CommandResult> => {
+    try {
+      const { toolUseId, result } = await app.framework.puppetToolCall(agentName, toolName, input);
+      const preview = result.isError
+        ? `ERROR: ${result.error ?? 'unknown'}`
+        : String(typeof result.data === 'string' ? result.data : JSON.stringify(result.data) ?? '').slice(0, 300);
+      return {
+        lines: [
+          { text: `puppet ${agentName}: ${toolName} → ${result.isError ? 'error' : 'ok'} (${toolUseId})`, style: 'system' },
+          { text: `  stored tool_use + tool_result in ${agentName}'s window (no wake).`, style: 'system' },
+          { text: `  result: ${preview.replace(/\n/g, ' ')}`, style: 'system' },
+        ],
+      };
+    } catch (e) {
+      return { lines: [{ text: `puppet failed: ${e instanceof Error ? e.message : e}`, style: 'system' }] };
+    }
+  })();
+  return {
+    lines: [{ text: `puppet: executing ${toolName} as ${agentName}...`, style: 'system' }],
+    asyncWork,
+  };
+}
+
 function handleNudge(app: AppContext, agentName?: string): CommandResult {
   const r = app.framework.nudgeAgent(agentName, 'host-console');
   if (!r.ok) {

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -205,6 +205,16 @@ export async function runHeadless(app: AppContext, argv: string[] = []): Promise
         for (const line of result.lines) {
           emit({ type: 'command-output', text: line.text, style: line.style ?? null });
         }
+        // Commands with async follow-up (fleet kill/restart, puppet) put
+        // their real outcome in asyncWork; without this await the IPC
+        // caller only ever saw the "...starting" line and the result was
+        // silently dropped.
+        if (result.asyncWork) {
+          const followUp = await result.asyncWork;
+          for (const line of followUp.lines) {
+            emit({ type: 'command-output', text: line.text, style: line.style ?? null });
+          }
+        }
         if (result.switchToSessionId) {
           await app.switchSession(result.switchToSessionId);
           emit({ type: 'command-output', text: 'Session switched.', style: 'system' });


### PR DESCRIPTION
## What

`/puppet <toolName> [json-input]` — executes the tool for real AS the main agent via `Framework.puppetToolCall` (agent-framework#123) and stores the `tool_use` + `tool_result` pair in its window. No wake. Works from the TUI and — the primary admin path — headless IPC:

```
python3 ipc.py cmd 30 "/puppet mcpl--eidoverse--look {}"
```

Refused unless the agent is idle and the tool is on its surface (guards live in the framework method). Falls back to the first registered agent when the caller doesn't thread `agentName` (same pattern as `getAgentCM`).

## Why

The princess exemplar surgery (2026-08-23): restoring a resident's lost capacity to use her tools took stop → chronicle surgery → restart to place one first-person tool_use/tool_result exemplar. This makes that repair one live command — and a general demonstration lever for older models that can't find an affordance.

## Drive-by fix

Headless IPC dropped `CommandResult.asyncWork` entirely — every async command (`/fleet kill`, `/fleet restart`, now `/puppet`) only ever emitted its "starting…" line over IPC and the real outcome was silently lost. The handler now awaits asyncWork and emits its lines.

Depends on: anima-research/agent-framework#123 (`puppetToolCall` + `puppet:tool-call` trace). Merge that first; this PR typechecks against it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XiTi13astLRVF95UcnzMJ1