### PR TITLE
fix(keepalive): log every event to stderr, where operators actually look

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+### Fixed
+
+- **Prompt-cache keepalive events all go to stderr**, so every one of them lands
+  in `service-stderr.log` beside `[inference-refusal]` instead of being split by
+  severity across two sinks. Routine `refreshed` events previously went to
+  stdout — which the host unit leaves on the journal — so the log an operator
+  actually greps showed nothing. Observed on fable-cm 2026-08-23: the keepalive
+  refreshed a 523,102-token prefix three times, correctly and with zero cache
+  writes, while a monitor tailing `service-stderr.log` reported no activity for
+  three hours. A background spender that can't be found in the operator's log is
+  indistinguishable from one that never ran.
+
 ### Added
 
 - **`agent.cacheKeepalive` — hold an idle agent's 1h prompt cache warm.** With

--- a/src/cache-keepalive-log.ts
+++ b/src/cache-keepalive-log.ts
@@ -1,0 +1,41 @@
+// Where prompt-cache keepalive events get written.
+//
+// Every event goes to STDERR, deliberately and without exception.
+//
+// The host's systemd unit routes `StandardError` to
+// `<data>/service-stderr.log` and leaves stdout on the journal. That file is
+// where an operator actually looks — it is where `[inference-refusal]` and the
+// `[autobiographical]` lines live. Splitting keepalive events across two sinks
+// by severity means the routine ones land somewhere nobody greps.
+//
+// This is not hypothetical. On 2026-08-23 the keepalive ran correctly on
+// fable-cm for three hours — three clean refreshes, 523,102 tokens read each,
+// zero writes — while a monitor tailing service-stderr.log reported
+// `keepalive=0` the entire time, because `refreshed` was going to stdout. An
+// operator would have concluded the feature was dead. A background spender
+// that cannot be found in the log an operator reads is indistinguishable from
+// one that never ran.
+//
+// Volume does not justify splitting them: one refresh per lineage per ~50
+// minutes is nothing next to the compression chatter already in that file.
+
+import type { KeepaliveEvent } from '@animalabs/membrane';
+
+export const KEEPALIVE_LOG_PREFIX = '[cache-keepalive]';
+
+/** Render one event as a single log line. */
+export function formatKeepaliveEvent(event: KeepaliveEvent): string {
+  return `${KEEPALIVE_LOG_PREFIX} ${JSON.stringify(event)}`;
+}
+
+/**
+ * Write one keepalive event to the operator-visible log.
+ *
+ * `sink` exists for tests; production always uses stderr via the default.
+ */
+export function logKeepaliveEvent(
+  event: KeepaliveEvent,
+  sink: (line: string) => void = (line) => console.error(line),
+): void {
+  sink(formatKeepaliveEvent(event));
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,6 +67,7 @@ import {
 import { createBranchState, resetBranchState, handleExport, type BranchState } from './commands.js';
 import { buildFrameworkAgentConfig, membraneCachingOverride } from './framework-agent-config.js';
 import { buildFrameworkStrategy, buildConversationsConfig } from './framework-strategy.js';
+import { logKeepaliveEvent } from './cache-keepalive-log.js';
 import { loadExtensions } from './extensions.js';
 
 export type { AppContext };
@@ -974,17 +975,11 @@ async function main() {
             ...(recipe.agent.cacheKeepalive?.refreshAfterMinutes !== undefined
               ? { refreshAfterMs: recipe.agent.cacheKeepalive.refreshAfterMinutes * 60_000 }
               : {}),
-            onEvent: (event: import('@animalabs/membrane').KeepaliveEvent) => {
-              // Surfaced in service-stderr.log. A background spender must be
-              // legible without reading the billing dashboard — and the
-              // 'ineffective'/'disabled' lines are the ones that matter.
-              const detail = JSON.stringify(event);
-              if (event.type === 'refreshed' || event.type === 'expired') {
-                console.log(`[cache-keepalive] ${detail}`);
-              } else {
-                console.warn(`[cache-keepalive] ${detail}`);
-              }
-            },
+            // Every event — routine refreshes included — goes to stderr, so
+            // all of them land in service-stderr.log next to
+            // [inference-refusal]. See cache-keepalive-log.ts for why this is
+            // not severity-routed.
+            onEvent: logKeepaliveEvent,
           },
         },
         llmLogPath,

--- a/test/cache-keepalive-log.test.ts
+++ b/test/cache-keepalive-log.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Keepalive events must ALL reach stderr.
+ *
+ * The host unit routes StandardError to service-stderr.log and leaves stdout on
+ * the journal, so an event written with console.log lands where no operator
+ * greps. That actually happened on fable-cm 2026-08-23: the keepalive refreshed
+ * a 523k prefix three times, correctly, while a monitor tailing
+ * service-stderr.log reported zero activity for three hours.
+ *
+ * These tests fail if anyone re-introduces severity routing.
+ */
+import { describe, test, expect } from 'bun:test';
+import {
+  logKeepaliveEvent,
+  formatKeepaliveEvent,
+  KEEPALIVE_LOG_PREFIX,
+} from '../src/cache-keepalive-log.js';
+import type { KeepaliveEvent } from '@animalabs/membrane';
+
+const EVENTS: KeepaliveEvent[] = [
+  { type: 'refreshed', key: 'k1', lane: 'stream', readTokens: 523102, idleMs: 2987020 },
+  { type: 'expired', key: 'k1', idleMs: 21600000 },
+  { type: 'ineffective', key: 'k1', reason: 'wrote-instead-of-read', readTokens: 0, writeTokens: 523102 },
+  { type: 'skipped', key: 'k1', reason: 'no-1h-breakpoint' },
+  { type: 'error', key: 'k1', error: '400 invalid_request_error', consecutive: 1 },
+  { type: 'disabled', reason: '3 consecutive keepalive failures' },
+];
+
+describe('keepalive event logging', () => {
+  test('every event type is written, none silently dropped', () => {
+    for (const event of EVENTS) {
+      const lines: string[] = [];
+      logKeepaliveEvent(event, (l) => lines.push(l));
+      expect(lines.length).toBe(1);
+    }
+  });
+
+  test('routine refreshes are logged, not filtered as noise', () => {
+    // The regression this guards: treating `refreshed` as too chatty to log
+    // leaves no positive evidence the feature ran at all.
+    const lines: string[] = [];
+    logKeepaliveEvent(EVENTS[0]!, (l) => lines.push(l));
+    expect(lines[0]).toContain('refreshed');
+    expect(lines[0]).toContain('523102');
+  });
+
+  test('lines carry the greppable prefix', () => {
+    for (const event of EVENTS) {
+      expect(formatKeepaliveEvent(event).startsWith(KEEPALIVE_LOG_PREFIX)).toBe(true);
+    }
+  });
+
+  test('the payload is machine-readable JSON after the prefix', () => {
+    const line = formatKeepaliveEvent(EVENTS[2]!);
+    const json = line.slice(KEEPALIVE_LOG_PREFIX.length).trim();
+    const parsed = JSON.parse(json) as { type: string; reason: string; writeTokens: number };
+    expect(parsed.type).toBe('ineffective');
+    expect(parsed.reason).toBe('wrote-instead-of-read');
+    expect(parsed.writeTokens).toBe(523102);
+  });
+
+  test('DEFAULT SINK IS STDERR for every event type — not stdout', () => {
+    // The actual bug. console.error -> stderr -> service-stderr.log;
+    // console.log -> stdout -> journal, where nobody looks.
+    const origLog = console.log;
+    const origErr = console.error;
+    const origWarn = console.warn;
+    const toStdout: string[] = [];
+    const toStderr: string[] = [];
+    try {
+      console.log = (...a: unknown[]) => { toStdout.push(String(a[0])); };
+      console.error = (...a: unknown[]) => { toStderr.push(String(a[0])); };
+      console.warn = (...a: unknown[]) => { toStderr.push(String(a[0])); };
+      for (const event of EVENTS) logKeepaliveEvent(event);
+    } finally {
+      console.log = origLog;
+      console.error = origErr;
+      console.warn = origWarn;
+    }
+    expect(toStderr.length).toBe(EVENTS.length);
+    expect(toStdout.length).toBe(0);
+  });
+});


### PR DESCRIPTION
The host unit routes `StandardError` to `<data>/service-stderr.log` and leaves stdout on the journal. Keepalive events were severity-routed — `refreshed`/`expired` via `console.log`, everything else via `console.warn` — so the routine ones landed in a sink nobody greps.

## What this looked like in production

On fable-cm, 2026-08-23, the keepalive worked perfectly:

```
08:52:06  refreshed  read=523,102  idle=49.2m
09:42:06  refreshed  read=523,102  idle=49.8m
10:32:06  refreshed  read=523,102  idle=49.8m
```

Exactly 50 minutes apart, every one a pure cache read with **zero** writes. Meanwhile a monitor tailing `service-stderr.log` reported `keepalive=0` for three straight hours. The only available evidence said the feature was dead.

That's the same failure mode the keepalive module itself was written to guard against, one level up: an instrument pointed at the wrong place returns a plausible, confident, wrong answer. And it's worse here than ordinary log noise, because **"no keepalive activity" is also exactly what a genuinely broken keepalive looks like** — the two states were indistinguishable to an operator.

## Change

Every event to stderr, no severity routing. Volume doesn't argue otherwise: one refresh per lineage per ~50 minutes is nothing beside the compression chatter already in that file.

Extracted into `src/cache-keepalive-log.ts` so the routing is testable rather than inline in a 1000-line boot path.

## Tests

5 tests covering: every event type is written, routine `refreshed` isn't filtered as noise, the greppable prefix, JSON parseability of the payload, and the load-bearing one — **default sink is stderr for every event type, never stdout**.

That last test was confirmed to **FAIL** against the old severity-routed implementation before being kept (1 fail / 4 pass), so it can actually catch the regression rather than merely passing.

Typecheck adds 0 new errors vs. baseline.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KxYS1YL6FjQk6XhBeitAsQ