### PR TITLE
feat: accept disabled prose routing recipes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- Recipes accept `agent.proseRouting: "disabled"` for tool-only external publication when paired with a supporting Agent Framework release.
+
 ### Fixed
 
 - **Prompt-cache keepalive events all go to stderr**, so every one of them lands

--- a/src/recipe.ts
+++ b/src/recipe.ts
@@ -182,7 +182,7 @@ export interface RecipeAgent {
    * `>>>destination` envelope routes through the authorized channel registry.
    * Default 'locus'.
    */
-  proseRouting?: 'locus' | 'explicit' | 'hybrid';
+  proseRouting?: 'locus' | 'explicit' | 'hybrid' | 'disabled';
   /**
    * Extra Anthropic beta flags sent as the `anthropic-beta` header on every
    * request (e.g. `["context-1m-2025-08-07"]` for the 1M context window on
@@ -1031,9 +1031,10 @@ export function validateRecipe(raw: unknown): Recipe {
     agent.proseRouting !== undefined &&
     agent.proseRouting !== 'locus' &&
     agent.proseRouting !== 'explicit' &&
-    agent.proseRouting !== 'hybrid'
+    agent.proseRouting !== 'hybrid' &&
+    agent.proseRouting !== 'disabled'
   ) {
-    throw new Error(`Recipe agent.proseRouting must be 'locus', 'explicit', or 'hybrid', got ${JSON.stringify(agent.proseRouting)}.`);
+    throw new Error(`Recipe agent.proseRouting must be 'locus', 'explicit', 'hybrid', or 'disabled', got ${JSON.stringify(agent.proseRouting)}.`);
   }
 
   if (agent.timezone !== undefined) {

--- a/test/recipe-hybrid-prose-routing.test.ts
+++ b/test/recipe-hybrid-prose-routing.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'bun:test';
 import { validateRecipe } from '../src/recipe.js';
 const base = (proseRouting?: unknown) => ({ name: 'test', agent: { systemPrompt: '', ...(proseRouting === undefined ? {} : { proseRouting }) } });
-describe('hybrid prose routing recipe', () => {
-  it('accepts locus, explicit, hybrid, and omission', () => {
+describe('prose routing recipe', () => {
+  it('accepts locus, explicit, hybrid, disabled, and omission', () => {
     expect(validateRecipe(base()).agent.proseRouting).toBeUndefined();
-    for (const mode of ['locus', 'explicit', 'hybrid'] as const) expect(validateRecipe(base(mode)).agent.proseRouting).toBe(mode);
+    for (const mode of ['locus', 'explicit', 'hybrid', 'disabled'] as const) expect(validateRecipe(base(mode)).agent.proseRouting).toBe(mode);
   });
   it('rejects unknown modes', () => {
     expect(() => validateRecipe(base('triple-magic'))).toThrow(/proseRouting/);


### PR DESCRIPTION
## Summary
- accept and validate `agent.proseRouting: "disabled"`
- forward it to Agent Framework unchanged

## Evidence
- recipe test 2/2
- copied discriminator on base 1/2 (rejects `disabled`)
- composed typecheck against the Agent Framework branch clean
- diff-check clean
