### PR TITLE
chore(changelog): land entries as per-change fragments in changelog.d/

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,8 +19,9 @@
 
 ---
 
-- [ ] `CHANGELOG.md` updated under `## Unreleased` — or this change is
-      internal-only / test-only / docs-only (apply the `no-changelog` label).
+- [ ] Changelog fragment added — `changelog.d/<slug>.<breaking|added|changed|fixed>.md`
+      (see `changelog.d/README.md`) — or this change is internal-only /
+      test-only / docs-only (apply the `no-changelog` label).
 
 <!-- AI-assisted contributions are welcome and normal here — see
      CONTRIBUTING.md for the attribution convention (footer + Co-Authored-By). -->

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -18,15 +18,17 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Require CHANGELOG.md update when src/ changes
+      - name: Require changelog fragment when src/ changes
         run: |
           base="${{ github.event.pull_request.base.sha }}"
           head="${{ github.event.pull_request.head.sha }}"
           changed=$(git diff --name-only "$base...$head")
           echo "Changed files:"
           echo "$changed"
-          if echo "$changed" | grep -q '^src/' && ! echo "$changed" | grep -qx 'CHANGELOG.md'; then
-            echo "::error::This PR touches src/ but not CHANGELOG.md. Add an entry under 'Unreleased' (see CONTRIBUTING.md), or apply the 'no-changelog' label if the change is internal-only."
+          if echo "$changed" | grep -q '^src/' \
+             && ! echo "$changed" | grep -Eq '^changelog\.d/[^/]+\.(breaking|added|changed|fixed)\.md$' \
+             && ! echo "$changed" | grep -qx 'CHANGELOG.md'; then
+            echo "::error::This PR touches src/ but carries no changelog entry. Add a fragment changelog.d/<slug>.<breaking|added|changed|fixed>.md (see CONTRIBUTING.md), or apply the 'no-changelog' label if the change is internal-only."
             exit 1
           fi
           echo "OK"

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -23,10 +23,13 @@ jobs:
           base="${{ github.event.pull_request.base.sha }}"
           head="${{ github.event.pull_request.head.sha }}"
           changed=$(git diff --name-only "$base...$head")
+          # Fragments must be *added* — a deleted or renamed fragment also
+          # appears in --name-only and must not satisfy the check.
+          added=$(git diff --name-only --diff-filter=A "$base...$head")
           echo "Changed files:"
           echo "$changed"
           if echo "$changed" | grep -q '^src/' \
-             && ! echo "$changed" | grep -Eq '^changelog\.d/[^/]+\.(breaking|added|changed|fixed)\.md$' \
+             && ! echo "$added" | grep -Eq '^changelog\.d/[^/]+\.(breaking|added|changed|fixed)\.md$' \
              && ! echo "$changed" | grep -qx 'CHANGELOG.md'; then
             echo "::error::This PR touches src/ but carries no changelog entry. Add a fragment changelog.d/<slug>.<breaking|added|changed|fixed>.md (see CONTRIBUTING.md), or apply the 'no-changelog' label if the change is internal-only."
             exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+Entries land with the change that causes them, as fragment files in
+[`changelog.d/`](changelog.d/) that are folded into a version section at
+release time — see [CONTRIBUTING.md](CONTRIBUTING.md#changelog).
+
 ## Unreleased
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ plus, when applicable, **Not verified**, **Out of scope**, and
 - **Tests accompany behavior changes.** Review scrutinizes test substance,
   not mere presence — a test that can't fail on the unfixed code will be
   called out.
-- **Changelog entry** under `## Unreleased` for anything behavior-affecting
+- **Changelog fragment** in `changelog.d/` for anything behavior-affecting
   (see below).
 
 Conventional-commit-style titles (`feat(recipe): …`, `fix(subagent): …`) are
@@ -80,33 +80,55 @@ that don't fail on unfixed code, or with claims the branch itself disproves.
 
 ## Changelog
 
-`CHANGELOG.md` keeps a standing `## Unreleased` section with
-`### Breaking` / `### Added` / `### Changed` / `### Fixed` subsections
-(loosely [Keep a Changelog](https://keepachangelog.com/)).
+Changelog entries land as **fragment files** in
+[`changelog.d/`](changelog.d/) — one file per change — and are folded into
+`CHANGELOG.md` (loosely [Keep a Changelog](https://keepachangelog.com/)) at
+release time. One file per change is what keeps concurrent work from
+conflicting: when every PR edited the same `## Unreleased` section, any PR
+that outlived another merge hit a conflict in `CHANGELOG.md`; distinct files
+never do.
 
-- **The entry lands with the change** — same commit, or at least the same
+- **Format:** `changelog.d/<slug>.<breaking|added|changed|fixed>.md`,
+  containing one or more markdown bullets (`- …`), written exactly as they
+  should appear in `CHANGELOG.md` (continuation lines indent two spaces).
+  The slug just has to be unique among pending fragments — the PR number or
+  branch name works (`100-prose-routing.added.md`). The release script
+  refuses unrecognized category suffixes rather than silently stranding an
+  entry.
+- **The fragment lands with the change** — same commit, or at least the same
   PR. This binds direct pushes to `main` just as much as PRs. On PRs, CI
-  enforces it softly: touching `src/` without touching `CHANGELOG.md` fails
-  the `changelog` check unless the `no-changelog` label is applied.
+  enforces it softly: touching `src/` without adding a fragment (or editing
+  `CHANGELOG.md`) fails the `changelog` check unless the `no-changelog`
+  label is applied.
 - **What needs an entry:** anything an operator, recipe author, or module
   developer would notice — behavior, config/recipe schema, CLI, tool
   surfaces, defaults. Internal refactors, test-only, and docs-only changes
   don't.
-- **Breaking entries are audience-scoped.** Name the audience in the heading
-  (`### Breaking (recipe authors only)`) and cover: **who needs to act**,
+- **Breaking entries are audience-scoped.** Open the bullet by naming who
+  needs to act (`- **Recipe authors:** …`) and cover: **who needs to act**,
   **migration**, and **unchanged** (what readers might fear broke but
   didn't). The fleet recipe-path entry in `CHANGELOG.md` is the canonical
   example of the format.
+- **Editing `## Unreleased` in `CHANGELOG.md` directly still works** and is
+  merged with the fragments at release time — it remains the right place to
+  restructure pending entries, and the escape hatch for anything the
+  fragment format can't express (e.g. an audience-qualified
+  `### Breaking (recipe authors only)` heading, which `breaking` fragments
+  will then join). Keep one `## Unreleased` heading — the release script
+  refuses more than one, since only the first is ever cut.
 - **Releases** (maintainers): `npm version <patch|minor|major>` does the
-  whole cut — the `version` hook retitles `Unreleased` to
-  `## X.Y.Z — YYYY-MM-DD` (keeping a fresh `Unreleased` above it, and
-  refusing to release when there are no entries), then npm commits and tags.
-  `git push --follow-tags` triggers CI, which refuses a tag with no matching
-  changelog section, publishes `@animalabs/connectome-host` to npm, and
-  creates the GitHub release with that section as its notes. The two release
-  jobs are independent: some consumers run github-clone checkouts, so
-  release notes must exist even when npm publish fails. Version bumps are a
-  maintainer release-time action, not part of feature PRs.
+  whole cut — the `version` hook folds the pending fragments plus any
+  entries filed directly under `Unreleased` into `## X.Y.Z — YYYY-MM-DD`
+  (subsections emitted in `### Breaking` / `### Added` / `### Changed` /
+  `### Fixed` order), deletes the consumed fragments, keeps a fresh empty
+  `Unreleased` above, and refuses to release when there is nothing to
+  release; npm then commits and tags. `git push --follow-tags` triggers CI,
+  which refuses a tag with no matching changelog section, publishes
+  `@animalabs/connectome-host` to npm, and creates the GitHub release with
+  that section as its notes. The two release jobs are independent: some
+  consumers run github-clone checkouts, so release notes must exist even
+  when npm publish fails. Version bumps are a maintainer release-time
+  action, not part of feature PRs.
 
 ## Building and testing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,13 +88,19 @@ conflicting: when every PR edited the same `## Unreleased` section, any PR
 that outlived another merge hit a conflict in `CHANGELOG.md`; distinct files
 never do.
 
-- **Format:** `changelog.d/<slug>.<breaking|added|changed|fixed>.md`,
-  containing one or more markdown bullets (`- …`), written exactly as they
-  should appear in `CHANGELOG.md` (continuation lines indent two spaces).
-  The slug just has to be unique among pending fragments — the PR number or
-  branch name works (`100-prose-routing.added.md`). The release script
-  refuses unrecognized category suffixes rather than silently stranding an
-  entry.
+- **Format:** `changelog.d/<slug>.<breaking|added|changed|fixed>.md`, a flat
+  file directly in `changelog.d/`, containing one or more markdown bullets
+  (`- …`) written exactly as they should appear in `CHANGELOG.md`:
+  continuation lines indent two spaces, nested bullets are fine, headings
+  and horizontal rules are refused (even indented — a heading inside a
+  fragment would corrupt the section structure). The slug just has to be
+  unique among pending fragments and filesystem-safe — the PR number works,
+  and so does the branch name with `/` replaced by `-`
+  (`100-prose-routing.added.md`, `fix-retry-backoff.fixed.md`). The release
+  script scans the directory fail-closed: a subdirectory, an unrecognized
+  category suffix, or any other stray file aborts the release rather than
+  silently stranding an entry.
+
 - **The fragment lands with the change** — same commit, or at least the same
   PR. This binds direct pushes to `main` just as much as PRs. On PRs, CI
   enforces it softly: touching `src/` without adding a fragment (or editing

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -1,0 +1,22 @@
+# Pending changelog fragments
+
+One file per change, so concurrent branches never conflict the way shared
+`CHANGELOG.md` edits do. At release time `npm version` folds every fragment
+here into the new version section of `CHANGELOG.md` and deletes it.
+
+**Name:** `<slug>.<breaking|added|changed|fixed>.md` — the slug just has to
+be unique among pending fragments; the PR number or branch name works
+(`100-prose-routing.added.md`).
+
+**Content:** one or more markdown bullets, exactly as they should appear in
+`CHANGELOG.md`:
+
+```markdown
+- Recipes accept `agent.proseRouting: "disabled"` for tool-only external
+  publication (#100). Continuation lines indent two spaces.
+```
+
+Breaking fragments open by naming who needs to act:
+`- **Recipe authors:** …`.
+
+See [CONTRIBUTING.md](../CONTRIBUTING.md#changelog) for what needs an entry.

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -4,12 +4,18 @@ One file per change, so concurrent branches never conflict the way shared
 `CHANGELOG.md` edits do. At release time `npm version` folds every fragment
 here into the new version section of `CHANGELOG.md` and deletes it.
 
-**Name:** `<slug>.<breaking|added|changed|fixed>.md` — the slug just has to
-be unique among pending fragments; the PR number or branch name works
-(`100-prose-routing.added.md`).
+**Name:** `<slug>.<breaking|added|changed|fixed>.md`, as a flat file directly
+in this directory. The slug just has to be unique among pending fragments and
+filesystem-safe: the PR number works, and so does the branch name with `/`
+replaced by `-` (`100-prose-routing.added.md`, `fix-retry-backoff.fixed.md`). The
+release script refuses subdirectories and any other stray file here, so a
+misplaced entry fails the release loudly instead of being left out.
 
 **Content:** one or more markdown bullets, exactly as they should appear in
-`CHANGELOG.md`:
+`CHANGELOG.md`. Continuation lines indent two spaces (nested bullets are
+fine); headings and horizontal rules are refused even when indented, since a
+heading inside a fragment would corrupt the section structure:
+
 
 ```markdown
 - Recipes accept `agent.proseRouting: "disabled"` for tool-only external

--- a/changelog.d/changelog-fragments.changed.md
+++ b/changelog.d/changelog-fragments.changed.md
@@ -1,0 +1,5 @@
+- Changelog entries now land as per-change fragment files in `changelog.d/`
+  (`<slug>.<breaking|added|changed|fixed>.md`), folded into the version
+  section at release time — concurrent PRs no longer conflict in
+  `CHANGELOG.md`. Editing `## Unreleased` directly still works and is merged
+  at the same point.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "bun src/index.ts",
     "dev": "bun --watch src/index.ts",
     "test": "bun test",
-    "version": "bun scripts/release-changelog.ts && git add CHANGELOG.md",
+    "version": "bun scripts/release-changelog.ts && git add CHANGELOG.md changelog.d",
     "build:web": "npm --prefix web install && npm --prefix web run build",
     "build:web:ci": "npm ci --prefix web && npm --prefix web run build",
     "relock:web": "rm -rf web/node_modules web/package-lock.json && npm --prefix web install",

--- a/scripts/release-changelog.ts
+++ b/scripts/release-changelog.ts
@@ -43,33 +43,56 @@ interface Fragment {
   body: string;
 }
 
+// Fragment grammar: every non-blank line starts a bullet or continues one
+// (indented two or more spaces; nested bullets included). Headings and
+// horizontal rules are refused even when indented — a '## ' line would
+// splice a fake section boundary into the released changelog, and an
+// indented one still renders as a heading inside the entry.
+const isBulletStart = (l: string): boolean => /^[-*] /.test(l);
+const isContinuation = (l: string): boolean => /^ {2,}\S/.test(l);
+const isBlockConstruct = (l: string): boolean =>
+  /^\s*#{1,6}(\s|$)/.test(l) || /^\s*([-=*_])\1{2,}\s*$/.test(l);
+
+// The directory is scanned fail-closed: anything that is not README.md or
+// a well-formed fragment file aborts the release, so an entry can never be
+// silently left out (e.g. a fragment created under a 'fix/' subdirectory
+// because the slug was taken verbatim from a branch name).
 const fragments: Fragment[] = [];
 if (existsSync(FRAGMENT_DIR)) {
-  for (const name of readdirSync(FRAGMENT_DIR).sort()) {
-    if (name === "README.md" || !name.endsWith(".md")) continue;
+  const entries = readdirSync(FRAGMENT_DIR, { withFileTypes: true }).sort(
+    (a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0),
+  );
+  for (const entry of entries) {
+    const { name } = entry;
+    if (name === "README.md") continue;
+    if (!entry.isFile()) {
+      fail(
+        `${FRAGMENT_DIR}/${name}: not a file. Fragments are flat files directly ` +
+          `in ${FRAGMENT_DIR}/ — a slug cannot contain '/'; use the PR number, ` +
+          "or the branch name with '/' replaced by '-'.",
+      );
+    }
     const m = name.match(/\.(breaking|added|changed|fixed)\.md$/);
     if (!m) {
       fail(
-        `${FRAGMENT_DIR}/${name}: unrecognized category — name fragments ` +
+        `${FRAGMENT_DIR}/${name}: unrecognized file — name fragments ` +
           `'<slug>.<${CATEGORIES.join("|")}>.md' so the entry is not silently stranded.`,
       );
     }
     const body = readFileSync(join(FRAGMENT_DIR, name), "utf8").trim();
     if (!body) fail(`${FRAGMENT_DIR}/${name}: empty fragment.`);
-    // Every line must start a bullet or continue one (indented). A line of
-    // top-level prose — or worse, a '## ' heading — would splice a fake
-    // section boundary into the released changelog.
-    const badLine = body
+    const offending = body
       .split("\n")
-      .find((l) => l.trim() !== "" && !/^[-*] /.test(l) && !/^\s/.test(l));
-    if (!/^[-*] /.test(body) || badLine !== undefined) {
+      .find(
+        (l) =>
+          l.trim() !== "" &&
+          (!(isBulletStart(l) || isContinuation(l)) || isBlockConstruct(l)),
+      );
+    if (offending !== undefined) {
       fail(
         `${FRAGMENT_DIR}/${name}: a fragment is one or more markdown bullets ` +
-          `('- …', continuation lines indented)` +
-          (badLine !== undefined && /^[-*] /.test(body)
-            ? ` — offending line: '${badLine}'`
-            : "") +
-          ".",
+          "('- …'; continuation lines indented two spaces; no headings or " +
+          `rules) — offending line: '${offending}'.`,
       );
     }
     fragments.push({ name, category: m[1] as Category, body });

--- a/scripts/release-changelog.ts
+++ b/scripts/release-changelog.ts
@@ -1,32 +1,163 @@
 // Runs as npm's `version` lifecycle hook (see package.json): at that point
 // package.json already carries the new version, and files staged here are
 // included in the release commit that `npm version` then creates and tags.
-import { readFileSync, writeFileSync } from "node:fs";
+//
+// Folds the pending fragments in changelog.d/ (one file per change,
+// `<slug>.<breaking|added|changed|fixed>.md`) together with anything filed
+// directly under the standing `## Unreleased` section into a new
+// `## X.Y.Z — YYYY-MM-DD` section, deletes the consumed fragments, and
+// leaves a fresh empty `## Unreleased` above it. Refuses to release when
+// there is nothing to release, or when the input's shape is ambiguous.
+import {
+  existsSync,
+  readdirSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
 
 const { version } = JSON.parse(readFileSync("package.json", "utf8"));
 const path = "CHANGELOG.md";
+const FRAGMENT_DIR = "changelog.d";
+// Canonical subsection order; a fragment's category must be one of these.
+const CATEGORIES = ["breaking", "added", "changed", "fixed"] as const;
+type Category = (typeof CATEGORIES)[number];
+const HEADINGS: Record<Category, string> = {
+  breaking: "Breaking",
+  added: "Added",
+  changed: "Changed",
+  fixed: "Fixed",
+};
+
 const text = readFileSync(path, "utf8");
 
-const header = text.match(/^## Unreleased[ \t]*$/m);
-if (!header || header.index === undefined) {
-  console.error("CHANGELOG.md: no '## Unreleased' section — add one before releasing.");
+const fail = (msg: string): never => {
+  console.error(`release-changelog: ${msg}`);
   process.exit(1);
+};
+
+interface Fragment {
+  name: string;
+  category: Category;
+  body: string;
 }
+
+const fragments: Fragment[] = [];
+if (existsSync(FRAGMENT_DIR)) {
+  for (const name of readdirSync(FRAGMENT_DIR).sort()) {
+    if (name === "README.md" || !name.endsWith(".md")) continue;
+    const m = name.match(/\.(breaking|added|changed|fixed)\.md$/);
+    if (!m) {
+      fail(
+        `${FRAGMENT_DIR}/${name}: unrecognized category — name fragments ` +
+          `'<slug>.<${CATEGORIES.join("|")}>.md' so the entry is not silently stranded.`,
+      );
+    }
+    const body = readFileSync(join(FRAGMENT_DIR, name), "utf8").trim();
+    if (!body) fail(`${FRAGMENT_DIR}/${name}: empty fragment.`);
+    if (!/^[-*] /.test(body)) {
+      fail(
+        `${FRAGMENT_DIR}/${name}: a fragment is one or more markdown bullets ('- …').`,
+      );
+    }
+    fragments.push({ name, category: m[1] as Category, body });
+  }
+}
+
+// Exactly one Unreleased heading. A second one silently strands entries:
+// only the first is ever cut, so anything filed under a later heading is
+// never released and never reaches the GitHub release notes.
+const headings = [...text.matchAll(/^## Unreleased[ \t]*$/gm)];
+if (headings.length === 0) {
+  fail("no '## Unreleased' section in CHANGELOG.md — add one before releasing.");
+}
+if (headings.length > 1) {
+  const lines = headings.map((m) => text.slice(0, m.index).split("\n").length);
+  fail(
+    `${headings.length} '## Unreleased' headings (lines ${lines.join(", ")}). ` +
+      "Only the first is released; fold them into one before releasing.",
+  );
+}
+const [header] = headings;
 
 const escaped = version.replace(/[.]/g, "\\.");
 if (new RegExp(`^## ${escaped}([^0-9]|$)`, "m").test(text)) {
-  console.error(`CHANGELOG.md: a '## ${version}' section already exists.`);
-  process.exit(1);
+  fail(`a '## ${version}' section already exists.`);
 }
 
 const afterHeader = text.slice(header.index + header[0].length);
 const nextSection = afterHeader.search(/^## /m);
-const unreleasedBody = nextSection === -1 ? afterHeader : afterHeader.slice(0, nextSection);
-if (!/^\s*[-*] /m.test(unreleasedBody)) {
-  console.error(`CHANGELOG.md: '## Unreleased' has no entries — nothing to release as ${version}.`);
-  process.exit(1);
+const oldBody = nextSection === -1 ? afterHeader : afterHeader.slice(0, nextSection);
+const rest = nextSection === -1 ? "" : afterHeader.slice(nextSection);
+
+// Merge fragment bullets into the Unreleased body's subsection structure.
+// Directly-filed entries are kept; a fragment joins the first subsection
+// whose title starts with its category (so audience-qualified headings like
+// '### Breaking (recipe authors only)' still attract 'breaking' fragments),
+// or a new canonical subsection. Output is emitted in canonical order.
+function mergeFragments(body: string, frags: Fragment[]): string {
+  interface Part {
+    title: string;
+    lines: string[];
+  }
+  const preamble: string[] = [];
+  const parts: Part[] = [];
+  let current: Part | null = null;
+  for (const line of body.split("\n")) {
+    const h = line.match(/^###\s+(.*)$/);
+    if (h) {
+      current = { title: h[1].trim(), lines: [] };
+      parts.push(current);
+    } else if (current) {
+      current.lines.push(line);
+    } else {
+      preamble.push(line);
+    }
+  }
+  for (const f of frags) {
+    let part = parts.find((p) => p.title.toLowerCase().startsWith(f.category));
+    if (!part) {
+      part = { title: HEADINGS[f.category], lines: [] };
+      parts.push(part);
+    }
+    part.lines.push("", ...f.body.split("\n"));
+  }
+  const rank = (t: string): number => {
+    const i = CATEGORIES.findIndex((c) => t.toLowerCase().startsWith(c));
+    return i === -1 ? CATEGORIES.length : i;
+  };
+  const chunks: string[] = [];
+  const pre = preamble.join("\n").trim();
+  if (pre) chunks.push(pre);
+  for (const p of [...parts].sort((a, b) => rank(a.title) - rank(b.title))) {
+    const content = p.lines.join("\n").replace(/\n{3,}/g, "\n\n").trim();
+    chunks.push(content ? `### ${p.title}\n\n${content}` : `### ${p.title}`);
+  }
+  return chunks.join("\n\n");
 }
 
+const merged = mergeFragments(oldBody, fragments);
+if (!/^\s*[-*] /m.test(merged)) {
+  fail(
+    `nothing to release as ${version} — no fragments in ${FRAGMENT_DIR}/ ` +
+      "and no entries under '## Unreleased'.",
+  );
+}
+
+// Spliced by index rather than string-replaced: `text.replace("## Unreleased", …)`
+// would hit the first *substring* occurrence, which is not necessarily the
+// heading the regex matched (an inline mention of `## Unreleased` in prose
+// comes first) and would inject the version heading into the wrong place.
 const date = new Date().toISOString().slice(0, 10);
-writeFileSync(path, text.replace(header[0], `## Unreleased\n\n## ${version} — ${date}`));
-console.log(`CHANGELOG.md: cut Unreleased into '## ${version} — ${date}'.`);
+writeFileSync(
+  path,
+  text.slice(0, header.index) +
+    `## Unreleased\n\n## ${version} — ${date}\n\n${merged}\n\n` +
+    rest,
+);
+for (const f of fragments) unlinkSync(join(FRAGMENT_DIR, f.name));
+console.log(
+  `CHANGELOG.md: released '## ${version} — ${date}' from ${fragments.length} ` +
+    `fragment(s) plus the Unreleased section.`,
+);

--- a/scripts/release-changelog.ts
+++ b/scripts/release-changelog.ts
@@ -56,9 +56,20 @@ if (existsSync(FRAGMENT_DIR)) {
     }
     const body = readFileSync(join(FRAGMENT_DIR, name), "utf8").trim();
     if (!body) fail(`${FRAGMENT_DIR}/${name}: empty fragment.`);
-    if (!/^[-*] /.test(body)) {
+    // Every line must start a bullet or continue one (indented). A line of
+    // top-level prose — or worse, a '## ' heading — would splice a fake
+    // section boundary into the released changelog.
+    const badLine = body
+      .split("\n")
+      .find((l) => l.trim() !== "" && !/^[-*] /.test(l) && !/^\s/.test(l));
+    if (!/^[-*] /.test(body) || badLine !== undefined) {
       fail(
-        `${FRAGMENT_DIR}/${name}: a fragment is one or more markdown bullets ('- …').`,
+        `${FRAGMENT_DIR}/${name}: a fragment is one or more markdown bullets ` +
+          `('- …', continuation lines indented)` +
+          (badLine !== undefined && /^[-*] /.test(body)
+            ? ` — offending line: '${badLine}'`
+            : "") +
+          ".",
       );
     }
     fragments.push({ name, category: m[1] as Category, body });

--- a/scripts/release-changelog.ts
+++ b/scripts/release-changelog.ts
@@ -17,8 +17,7 @@ import {
 } from "node:fs";
 import { join } from "node:path";
 
-const { version } = JSON.parse(readFileSync("package.json", "utf8"));
-const path = "CHANGELOG.md";
+const CHANGELOG = "CHANGELOG.md";
 const FRAGMENT_DIR = "changelog.d";
 // Canonical subsection order; a fragment's category must be one of these.
 const CATEGORIES = ["breaking", "added", "changed", "fixed"] as const;
@@ -30,11 +29,13 @@ const HEADINGS: Record<Category, string> = {
   fixed: "Fixed",
 };
 
-const text = readFileSync(path, "utf8");
-
+// Refusals throw and are reported at the entry point, which then lets the
+// process end on its own with exitCode 1. process.exit() would race the
+// stderr write when stderr is a pipe (asynchronous on macOS), leaving the
+// caller a bare failure status with no reason attached.
+class ReleaseError extends Error {}
 const fail = (msg: string): never => {
-  console.error(`release-changelog: ${msg}`);
-  process.exit(1);
+  throw new ReleaseError(msg);
 };
 
 interface Fragment {
@@ -45,20 +46,25 @@ interface Fragment {
 
 // Fragment grammar: every non-blank line starts a bullet or continues one
 // (indented two or more spaces; nested bullets included). Headings and
-// horizontal rules are refused even when indented — a '## ' line would
-// splice a fake section boundary into the released changelog, and an
-// indented one still renders as a heading inside the entry.
+// thematic breaks are refused wherever they appear — at top level a '## '
+// line would splice a fake section boundary into the released changelog,
+// and as item content ('- ## x', '  ## x') they still render as headings.
 const isBulletStart = (l: string): boolean => /^[-*] /.test(l);
 const isContinuation = (l: string): boolean => /^ {2,}\S/.test(l);
+const itemContent = (l: string): string => l.replace(/^\s*(?:[-*]\s+)?/, "");
+const isHeading = (s: string): boolean => /^#{1,6}(\s|$)/.test(s);
+// Thematic breaks may carry interior whitespace ('- - -', '* * *').
+const isRule = (s: string): boolean => /^([-*_=])(\s*\1){2,}\s*$/.test(s);
 const isBlockConstruct = (l: string): boolean =>
-  /^\s*#{1,6}(\s|$)/.test(l) || /^\s*([-=*_])\1{2,}\s*$/.test(l);
+  isRule(l.trim()) || isHeading(itemContent(l));
 
 // The directory is scanned fail-closed: anything that is not README.md or
 // a well-formed fragment file aborts the release, so an entry can never be
 // silently left out (e.g. a fragment created under a 'fix/' subdirectory
 // because the slug was taken verbatim from a branch name).
-const fragments: Fragment[] = [];
-if (existsSync(FRAGMENT_DIR)) {
+function collectFragments(): Fragment[] {
+  const fragments: Fragment[] = [];
+  if (!existsSync(FRAGMENT_DIR)) return fragments;
   const entries = readdirSync(FRAGMENT_DIR, { withFileTypes: true }).sort(
     (a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0),
   );
@@ -97,33 +103,8 @@ if (existsSync(FRAGMENT_DIR)) {
     }
     fragments.push({ name, category: m[1] as Category, body });
   }
+  return fragments;
 }
-
-// Exactly one Unreleased heading. A second one silently strands entries:
-// only the first is ever cut, so anything filed under a later heading is
-// never released and never reaches the GitHub release notes.
-const headings = [...text.matchAll(/^## Unreleased[ \t]*$/gm)];
-if (headings.length === 0) {
-  fail("no '## Unreleased' section in CHANGELOG.md — add one before releasing.");
-}
-if (headings.length > 1) {
-  const lines = headings.map((m) => text.slice(0, m.index).split("\n").length);
-  fail(
-    `${headings.length} '## Unreleased' headings (lines ${lines.join(", ")}). ` +
-      "Only the first is released; fold them into one before releasing.",
-  );
-}
-const [header] = headings;
-
-const escaped = version.replace(/[.]/g, "\\.");
-if (new RegExp(`^## ${escaped}([^0-9]|$)`, "m").test(text)) {
-  fail(`a '## ${version}' section already exists.`);
-}
-
-const afterHeader = text.slice(header.index + header[0].length);
-const nextSection = afterHeader.search(/^## /m);
-const oldBody = nextSection === -1 ? afterHeader : afterHeader.slice(0, nextSection);
-const rest = nextSection === -1 ? "" : afterHeader.slice(nextSection);
 
 // Merge fragment bullets into the Unreleased body's subsection structure.
 // Directly-filed entries are kept; a fragment joins the first subsection
@@ -141,7 +122,7 @@ function mergeFragments(body: string, frags: Fragment[]): string {
   for (const line of body.split("\n")) {
     const h = line.match(/^###\s+(.*)$/);
     if (h) {
-      current = { title: h[1].trim(), lines: [] };
+      current = { title: (h[1] ?? "").trim(), lines: [] };
       parts.push(current);
     } else if (current) {
       current.lines.push(line);
@@ -171,27 +152,70 @@ function mergeFragments(body: string, frags: Fragment[]): string {
   return chunks.join("\n\n");
 }
 
-const merged = mergeFragments(oldBody, fragments);
-if (!/^\s*[-*] /m.test(merged)) {
-  fail(
-    `nothing to release as ${version} — no fragments in ${FRAGMENT_DIR}/ ` +
-      "and no entries under '## Unreleased'.",
+function main(): void {
+  const { version } = JSON.parse(readFileSync("package.json", "utf8")) as {
+    version: string;
+  };
+  const text = readFileSync(CHANGELOG, "utf8");
+  const fragments = collectFragments();
+
+  // Exactly one Unreleased heading. A second one silently strands entries:
+  // only the first is ever cut, so anything filed under a later heading is
+  // never released and never reaches the GitHub release notes.
+  const headings = [...text.matchAll(/^## Unreleased[ \t]*$/gm)];
+  if (headings.length === 0) {
+    fail(`no '## Unreleased' section in ${CHANGELOG} — add one before releasing.`);
+  }
+  if (headings.length > 1) {
+    const lines = headings.map((m) => text.slice(0, m.index ?? 0).split("\n").length);
+    fail(
+      `${headings.length} '## Unreleased' headings (lines ${lines.join(", ")}). ` +
+        "Only the first is released; fold them into one before releasing.",
+    );
+  }
+  const header = headings[0]!;
+  const headerIndex = header.index ?? 0;
+
+  const escaped = version.replace(/[.]/g, "\\.");
+  if (new RegExp(`^## ${escaped}([^0-9]|$)`, "m").test(text)) {
+    fail(`a '## ${version}' section already exists.`);
+  }
+
+  const afterHeader = text.slice(headerIndex + header[0].length);
+  const nextSection = afterHeader.search(/^## /m);
+  const oldBody = nextSection === -1 ? afterHeader : afterHeader.slice(0, nextSection);
+  const rest = nextSection === -1 ? "" : afterHeader.slice(nextSection);
+
+  const merged = mergeFragments(oldBody, fragments);
+  if (!/^[ \t]*[-*] /m.test(merged)) {
+    fail(
+      `nothing to release as ${version} — no fragments in ${FRAGMENT_DIR}/ ` +
+        "and no entries under '## Unreleased'.",
+    );
+  }
+
+  // Spliced by index rather than string-replaced: `text.replace("## Unreleased", …)`
+  // would hit the first *substring* occurrence, which is not necessarily the
+  // heading the regex matched (an inline mention of `## Unreleased` in prose
+  // comes first) and would inject the version heading into the wrong place.
+  const date = new Date().toISOString().slice(0, 10);
+  writeFileSync(
+    CHANGELOG,
+    text.slice(0, headerIndex) +
+      `## Unreleased\n\n## ${version} — ${date}\n\n${merged}\n\n` +
+      rest,
+  );
+  for (const f of fragments) unlinkSync(join(FRAGMENT_DIR, f.name));
+  console.log(
+    `${CHANGELOG}: released '## ${version} — ${date}' from ${fragments.length} ` +
+      "fragment(s) plus the Unreleased section.",
   );
 }
 
-// Spliced by index rather than string-replaced: `text.replace("## Unreleased", …)`
-// would hit the first *substring* occurrence, which is not necessarily the
-// heading the regex matched (an inline mention of `## Unreleased` in prose
-// comes first) and would inject the version heading into the wrong place.
-const date = new Date().toISOString().slice(0, 10);
-writeFileSync(
-  path,
-  text.slice(0, header.index) +
-    `## Unreleased\n\n## ${version} — ${date}\n\n${merged}\n\n` +
-    rest,
-);
-for (const f of fragments) unlinkSync(join(FRAGMENT_DIR, f.name));
-console.log(
-  `CHANGELOG.md: released '## ${version} — ${date}' from ${fragments.length} ` +
-    `fragment(s) plus the Unreleased section.`,
-);
+try {
+  main();
+} catch (e) {
+  if (!(e instanceof ReleaseError)) throw e;
+  console.error(`release-changelog: ${e.message}`);
+  process.exitCode = 1;
+}

--- a/test/release-changelog.test.ts
+++ b/test/release-changelog.test.ts
@@ -159,6 +159,14 @@ test("accepts nested bullets and multi-line continuations", () => {
   assert.equal(section(changelog(dir), "1.1.0"), "### Fixed\n\n- one\n  - nested\n  more text\n- two");
 });
 
+test("accepts bullet content that merely resembles headings or rules", () => {
+  const body = "- **Module authors:** bold opener.\n- -1 is now the sentinel.\n- #123 is referenced inline.\n- ***emphasis*** then text.\n";
+  const dir = setup({ fragments: { "r.fixed.md": body } });
+  const r = run(dir);
+  assert.equal(r.status, 0, r.stderr);
+  assert.equal(section(changelog(dir), "1.1.0"), `### Fixed\n\n${body.trim()}`);
+});
+
 const refusals: Array<[string, Fixture, RegExp]> = [
   ["nothing to release", {}, /nothing to release as 1\.1\.0/],
   ["duplicate version section", { version: "1.0.0", fragments: { "a.fixed.md": "- x\n" } }, /'## 1\.0\.0' section already exists/],
@@ -171,6 +179,11 @@ const refusals: Array<[string, Fixture, RegExp]> = [
   ["top-level heading after a bullet", { fragments: { "h.fixed.md": "- ok\n\n## 9.9.9 — fake\n" } }, /offending line: '## 9\.9\.9 — fake'/],
   ["indented ATX heading", { fragments: { "h.fixed.md": "- ok\n  ## 8.8.8 — injected\n  - beneath\n" } }, /offending line: '  ## 8\.8\.8 — injected'/],
   ["indented setext underline / rule", { fragments: { "s.fixed.md": "- ok\n  ---\n" } }, /offending line: '  ---'/],
+  ["spaced thematic break shaped like a bullet", { fragments: { "s.fixed.md": "- ok\n- - -\n" } }, /offending line: '- - -'/],
+  ["asterisk thematic break with spaces", { fragments: { "s.fixed.md": "- ok\n* * *\n" } }, /offending line: '\* \* \*'/],
+  ["rule as bullet content", { fragments: { "s.fixed.md": "- ---\n" } }, /offending line: '- ---'/],
+  ["heading as bullet content", { fragments: { "h.fixed.md": "- ## 9.9.9 — embedded heading\n" } }, /offending line: '- ## 9\.9\.9 — embedded heading'/],
+  ["heading as nested bullet content", { fragments: { "h.fixed.md": "- ok\n  - ### nested heading\n" } }, /offending line: '  - ### nested heading'/],
   ["tab-indented continuation", { fragments: { "t.fixed.md": "- ok\n\tcontinued\n" } }, /offending line: '\tcontinued'/],
   ["no Unreleased heading", { changelog: "# Changelog\n\n## 1.0.0 — 2026-01-01\n\n- x\n", fragments: { "a.fixed.md": "- x\n" } }, /no '## Unreleased' section/],
   ["two Unreleased headings", { changelog: BASE_CHANGELOG + "\n## Unreleased\n\n- stranded\n", fragments: { "a.fixed.md": "- x\n" } }, /2 '## Unreleased' headings/],

--- a/test/release-changelog.test.ts
+++ b/test/release-changelog.test.ts
@@ -1,0 +1,189 @@
+// Black-box coverage of scripts/release-changelog.ts: each case runs the
+// real script in a throwaway directory, so assembly, validation, and the
+// deletion of consumed fragments are all exercised exactly as `npm version`
+// would run them.
+import { test } from "bun:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT = fileURLToPath(
+  new URL("../scripts/release-changelog.ts", import.meta.url),
+);
+
+const BASE_CHANGELOG = [
+  "# Changelog",
+  "",
+  "Intro that mentions ## Unreleased inline, which must not count as a heading.",
+  "",
+  "## Unreleased",
+  "",
+  "## 1.0.0 — 2026-01-01",
+  "",
+  "### Fixed",
+  "",
+  "- Old entry.",
+  "",
+].join("\n");
+
+interface Fixture {
+  version?: string;
+  changelog?: string;
+  fragments?: Record<string, string>;
+}
+
+function setup(f: Fixture): string {
+  const dir = mkdtempSync(join(tmpdir(), "release-changelog-"));
+  writeFileSync(
+    join(dir, "package.json"),
+    JSON.stringify({ name: "fixture", version: f.version ?? "1.1.0" }),
+  );
+  writeFileSync(join(dir, "CHANGELOG.md"), f.changelog ?? BASE_CHANGELOG);
+  mkdirSync(join(dir, "changelog.d"));
+  writeFileSync(join(dir, "changelog.d", "README.md"), "# Pending fragments\n");
+  for (const [name, body] of Object.entries(f.fragments ?? {})) {
+    const path = join(dir, "changelog.d", name);
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, body);
+  }
+  return dir;
+}
+
+function run(dir: string): { status: number; stdout: string; stderr: string } {
+  try {
+    const stdout = execFileSync(process.execPath, [SCRIPT], {
+      cwd: dir,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return { status: 0, stdout, stderr: "" };
+  } catch (e) {
+    const err = e as { status: number; stdout?: string; stderr?: string };
+    return { status: err.status, stdout: err.stdout ?? "", stderr: err.stderr ?? "" };
+  }
+}
+
+function section(text: string, version: string): string {
+  const lines = text.split("\n");
+  const start = lines.findIndex((l) => l.startsWith(`## ${version} — `));
+  assert.notEqual(start, -1, `no '## ${version}' section in:\n${text}`);
+  const rest = lines.slice(start + 1);
+  const end = rest.findIndex((l) => l.startsWith("## "));
+  return rest.slice(0, end === -1 ? undefined : end).join("\n").trim();
+}
+
+const changelog = (dir: string) => readFileSync(join(dir, "CHANGELOG.md"), "utf8");
+const pending = (dir: string) => readdirSync(join(dir, "changelog.d")).sort();
+
+test("folds fragments into a versioned section in canonical order and deletes them", () => {
+  const dir = setup({
+    fragments: {
+      "z-later.fixed.md": "- Fixed thing.\n",
+      "a-first.added.md": "- Added thing,\n  continued on an indented line.\n",
+      "m.breaking.md": "- **Module authors:** breaking thing.\n",
+    },
+  });
+  const r = run(dir);
+  assert.equal(r.status, 0, r.stderr);
+  const text = changelog(dir);
+  assert.equal(
+    section(text, "1.1.0"),
+    [
+      "### Breaking",
+      "",
+      "- **Module authors:** breaking thing.",
+      "",
+      "### Added",
+      "",
+      "- Added thing,",
+      "  continued on an indented line.",
+      "",
+      "### Fixed",
+      "",
+      "- Fixed thing.",
+    ].join("\n"),
+  );
+  assert.match(text, /^## Unreleased\n\n## 1\.1\.0 — \d{4}-\d{2}-\d{2}\n/m, "fresh empty Unreleased above the cut");
+  assert.ok(text.startsWith("# Changelog\n\nIntro that mentions"), "file header preserved");
+  assert.equal(section(text, "1.0.0"), "### Fixed\n\n- Old entry.", "older section untouched");
+  assert.deepEqual(pending(dir), ["README.md"], "consumed fragments deleted, README kept");
+});
+
+test("merges fragments into directly-filed Unreleased entries, reordering subsections canonically", () => {
+  const dir = setup({
+    changelog: BASE_CHANGELOG.replace(
+      "## Unreleased\n",
+      "## Unreleased\n\n### Fixed\n\n- Manual fix.\n\n### Added\n\n- Manual add.\n",
+    ),
+    fragments: { "x.fixed.md": "- Fragment fix.\n" },
+  });
+  const r = run(dir);
+  assert.equal(r.status, 0, r.stderr);
+  assert.equal(
+    section(changelog(dir), "1.1.0"),
+    "### Added\n\n- Manual add.\n\n### Fixed\n\n- Manual fix.\n\n- Fragment fix.",
+  );
+});
+
+test("breaking fragments join an audience-qualified Breaking heading", () => {
+  const dir = setup({
+    changelog: BASE_CHANGELOG.replace(
+      "## Unreleased\n",
+      "## Unreleased\n\n### Fixed\n\n- Manual fix.\n\n### Breaking (module authors only)\n\n- Manual break.\n",
+    ),
+    fragments: { "b.breaking.md": "- Fragment break.\n" },
+  });
+  const r = run(dir);
+  assert.equal(r.status, 0, r.stderr);
+  assert.equal(
+    section(changelog(dir), "1.1.0"),
+    "### Breaking (module authors only)\n\n- Manual break.\n\n- Fragment break.\n\n### Fixed\n\n- Manual fix.",
+  );
+});
+
+test("accepts nested bullets and multi-line continuations", () => {
+  const dir = setup({
+    fragments: { "n.fixed.md": "- one\n  - nested\n  more text\n- two\n" },
+  });
+  const r = run(dir);
+  assert.equal(r.status, 0, r.stderr);
+  assert.equal(section(changelog(dir), "1.1.0"), "### Fixed\n\n- one\n  - nested\n  more text\n- two");
+});
+
+const refusals: Array<[string, Fixture, RegExp]> = [
+  ["nothing to release", {}, /nothing to release as 1\.1\.0/],
+  ["duplicate version section", { version: "1.0.0", fragments: { "a.fixed.md": "- x\n" } }, /'## 1\.0\.0' section already exists/],
+  ["unrecognized category suffix", { fragments: { "oops.md": "- x\n" } }, /changelog\.d\/oops\.md: unrecognized file/],
+  ["stray non-markdown file", { fragments: { "notes.txt": "hi\n", "a.fixed.md": "- x\n" } }, /changelog\.d\/notes\.txt: unrecognized file/],
+  ["empty fragment", { fragments: { "e.fixed.md": "\n" } }, /changelog\.d\/e\.fixed\.md: empty fragment/],
+  ["fragment nested under a branch-name directory", { fragments: { "fix/foo.fixed.md": "- x\n", "a.fixed.md": "- y\n" } }, /changelog\.d\/fix: not a file/],
+  ["plain prose", { fragments: { "p.fixed.md": "prose only\n" } }, /offending line: 'prose only'/],
+  ["prose after a valid bullet", { fragments: { "p.fixed.md": "- ok\nrogue prose\n" } }, /offending line: 'rogue prose'/],
+  ["top-level heading after a bullet", { fragments: { "h.fixed.md": "- ok\n\n## 9.9.9 — fake\n" } }, /offending line: '## 9\.9\.9 — fake'/],
+  ["indented ATX heading", { fragments: { "h.fixed.md": "- ok\n  ## 8.8.8 — injected\n  - beneath\n" } }, /offending line: '  ## 8\.8\.8 — injected'/],
+  ["indented setext underline / rule", { fragments: { "s.fixed.md": "- ok\n  ---\n" } }, /offending line: '  ---'/],
+  ["tab-indented continuation", { fragments: { "t.fixed.md": "- ok\n\tcontinued\n" } }, /offending line: '\tcontinued'/],
+  ["no Unreleased heading", { changelog: "# Changelog\n\n## 1.0.0 — 2026-01-01\n\n- x\n", fragments: { "a.fixed.md": "- x\n" } }, /no '## Unreleased' section/],
+  ["two Unreleased headings", { changelog: BASE_CHANGELOG + "\n## Unreleased\n\n- stranded\n", fragments: { "a.fixed.md": "- x\n" } }, /2 '## Unreleased' headings/],
+];
+
+for (const [name, fixture, message] of refusals) {
+  test(`refuses ${name} without touching anything`, () => {
+    const dir = setup(fixture);
+    const before = { changelog: changelog(dir), pending: pending(dir) };
+    const r = run(dir);
+    assert.equal(r.status, 1, `expected refusal, got exit ${r.status}:\n${r.stdout}${r.stderr}`);
+    assert.match(r.stderr, message);
+    assert.equal(changelog(dir), before.changelog, "CHANGELOG.md must be untouched");
+    assert.deepEqual(pending(dir), before.pending, "no fragment may be deleted on refusal");
+  });
+}


### PR DESCRIPTION
## Problem

Every PR inserts changelog prose at the same textual location (the top of `## Unreleased` in `CHANGELOG.md`), so any PR that outlives another merge conflicts there. Full rationale and design in the agent-framework companion, anima-research/agent-framework#128 — this PR lands the same scheme here.

## Changes

Entries now land as **one uniquely-named file per change** — `changelog.d/<slug>.<breaking|added|changed|fixed>.md`, containing the entry's markdown bullets verbatim. Distinct files never conflict in git.

- **`scripts/release-changelog.ts`** (the `bun`-run `version` hook) folds pending fragments *plus* anything filed directly under `## Unreleased` into the new `## X.Y.Z — date` section (subsections in Breaking/Added/Changed/Fixed order; fragments join the first subsection whose title starts with their category, including audience-qualified `### Breaking (…)` headings), deletes the consumed fragments, and refuses: no/multiple `Unreleased` headings, duplicate version section, nothing to release, unrecognized category suffix, empty or non-bullet fragment. **The logic is ported by hand from agent-framework's `release-changelog.mjs`** (commit `0185475` there) into this repo's TypeScript script; parity was verified by running the ported script under `bun` through the same 8 test legs as the AF PR (transcripts below) and eyeballing the two implementations side by side — the TS version differs only in type annotations and this repo's existing style. The port also picks up two hardening pieces conhost's older script predated: refusing multiple `## Unreleased` headings, and splicing the version heading by match index instead of first-substring `replace`.
- **`changelog.yml`** soft check now passes on a well-formed new fragment *or* a `CHANGELOG.md` edit (transition-friendly for in-flight PRs; `no-changelog` label escape unchanged). `changelog.d/README.md` and badly-named fragments do not satisfy it. The `^src/` path condition is kept as-is.
- **`publish.yml` is untouched** — the tag-time section guard and the `github-release` awk both read the assembled versioned section, which exists at tag time exactly as before (verified against assembled output below).
- **Migration needs no flag day**: direct `## Unreleased` edits remain a supported input, merged at release time. The entries currently under Unreleased on main stay where they are and release normally — including main's current duplicate `### Added`/`### Fixed` subsections, which the merge preserves in order (fragments join the first matching one).
- CONTRIBUTING.md `## Changelog` section restructured (repo-specific prose kept), PR-template checkbox updated, `CHANGELOG.md` header gains the pointer sentence, `changelog.d/README.md` documents the format in-place, and this PR dogfoods the scheme with its own fragment (`changelog-fragments.changed.md`).

Companion to anima-research/agent-framework#128 and its siblings in membrane, context-manager, and chronicle — each repo's scheme is self-contained, safe to merge in any order.

## Tests

Ported script run with `bun` on copies in a scratch dir, through the 8 legs from the AF PR:

1. **Clean cut** — 3 test fragments (breaking/added/fixed) + the dogfood changed fragment + main's real Unreleased entries:
   ```
   CHANGELOG.md: released '## 0.8.0 — 2026-08-24' from 4 fragment(s) plus the Unreleased section.
   exit=0
   ```
   Subsection order in the assembled section: `Breaking, Added, Added, Added, Changed, Fixed, Fixed` (main's duplicate headings preserved in place; fragments joined the first match; continuation lines intact). Fragments deleted, `README.md` kept.
2. **Refuse-duplicate** — `release-changelog: a '## 0.8.0' section already exists.` exit=1.
3. **Refuse-empty** — `release-changelog: nothing to release as 0.9.0 — no fragments in changelog.d/ and no entries under '## Unreleased'.` exit=1.
4. **Fragments-only cut** (empty Unreleased, breaking+added fragments) — clean canonical-ordered section, fragments deleted, exit=0.
5. **Refuse bad category suffix** (`oops.md`) — `unrecognized category — name fragments '<slug>.<breaking|added|changed|fixed>.md' …` exit=1. (Also: empty fragment → `empty fragment.` exit=1.)
6. **Refuse non-bullet fragment** — `a fragment is one or more markdown bullets ('- …').` exit=1.
7. **publish.yml tag guard + github-release awk** simulated on the assembled 0.8.0 output: `tag guard: PASS`, `awk extraction: non-empty, 147 lines`.
8. **changelog.yml grep logic** on six changed-file sets: src+fragment PASS, src+CHANGELOG PASS (legacy), src-alone FAIL, src+`changelog.d/README.md`-only FAIL, src+badly-named-fragment FAIL, docs-only PASS.

Bonus (refusal new to this repo's script): appending a second `## Unreleased` → `release-changelog: 2 '## Unreleased' headings (lines 7, 756). Only the first is released; fold them into one before releasing.` exit=1.

## Not verified

A real `npm version` release run end-to-end — the next actual release is the live exercise, same status as the existing tag-time guards. The `changelog` check runs live on this PR itself.

---

- [x] Changelog fragment added — `changelog.d/changelog-fragments.changed.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
