### PR TITLE
feat: plumb source-only compression recipe flag

### DIFF
--- a/changelog.d/103-source-only-compression.added.md
+++ b/changelog.d/103-source-only-compression.added.md
@@ -1,0 +1,1 @@
+- Recipes accept the default-off `agent.strategy.compressionSourceOnly` flag and pass it through to Context Manager's residence-scoped L1 compression request builder (#103).

--- a/src/framework-strategy.ts
+++ b/src/framework-strategy.ts
@@ -13,6 +13,7 @@ const PASSTHROUGH_KEYS: ReadonlyArray<keyof RecipeStrategy> = [
   'maxSpeculativeL1s',
   'compressionRefusalCurveFallbacks',
   'compressionContextBudgetTokens',
+  'compressionSourceOnly',
   'positionedRecallPairs',
   'recallHeaderTemplate',
   'targetChunkTokens',

--- a/src/recipe.ts
+++ b/src/recipe.ts
@@ -51,6 +51,11 @@ export interface RecipeStrategy {
   /** Complete provider-request admission ceiling for compression fallbacks,
    * including the output reserve. */
   compressionContextBudgetTokens?: number;
+  /** Residence-scoped direct source-only L1 compression: the summarizer sees
+   * only the compression marker + exact target chunk + directive (no head,
+   * recall, or non-target raw recent material). One call, not a refusal
+   * ladder. Source-preserving; L1 only. Default off. */
+  compressionSourceOnly?: boolean;
   positionedRecallPairs?: boolean;
   recallHeaderTemplate?: string;
   targetChunkTokens?: number;
@@ -1298,6 +1303,12 @@ export function validateRecipe(raw: unknown): Recipe {
       )
     ) {
       throw new Error('Recipe agent.strategy.compressionContextBudgetTokens must be a positive safe integer.');
+    }
+    if (
+      strategy.compressionSourceOnly !== undefined
+      && typeof strategy.compressionSourceOnly !== 'boolean'
+    ) {
+      throw new Error('Recipe agent.strategy.compressionSourceOnly must be a boolean.');
     }
   }
 

--- a/test/recipe-source-only.test.ts
+++ b/test/recipe-source-only.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'bun:test';
+import { validateRecipe } from '../src/recipe.js';
+import { buildFrameworkStrategy } from '../src/framework-strategy.js';
+
+function recipe(strategy: Record<string, unknown>) {
+  return {
+    name: 'source-only-test',
+    agent: { systemPrompt: 'sys', strategy: { type: 'autobiographical', ...strategy } },
+  };
+}
+
+describe('compressionSourceOnly recipe flag', () => {
+  test('preserves the flag through validation', () => {
+    expect(validateRecipe(recipe({ compressionSourceOnly: true }))
+      .agent.strategy?.compressionSourceOnly).toBe(true);
+    expect(validateRecipe(recipe({ compressionSourceOnly: false }))
+      .agent.strategy?.compressionSourceOnly).toBe(false);
+    // absent stays undefined — every other resident is unaffected
+    expect(validateRecipe(recipe({})).agent.strategy?.compressionSourceOnly).toBeUndefined();
+  });
+
+  test('rejects a non-boolean value', () => {
+    expect(() => validateRecipe(recipe({ compressionSourceOnly: 'yes' })))
+      .toThrow(/compressionSourceOnly/);
+    expect(() => validateRecipe(recipe({ compressionSourceOnly: 1 })))
+      .toThrow(/compressionSourceOnly/);
+  });
+
+  test('plumbs through PASSTHROUGH_KEYS into the built strategy config', () => {
+    const parsed = validateRecipe(recipe({ compressionSourceOnly: true, summaryParticipant: 'mythos' }));
+    const built = buildFrameworkStrategy(parsed, 'claude-fable-5', 'UTC');
+    // buildFrameworkStrategy copies PASSTHROUGH_KEYS onto the strategy options;
+    // the flag must reach the AutobiographicalStrategy config.
+    const cfg = (built as unknown as { config?: Record<string, unknown> }).config
+      ?? (built as unknown as Record<string, unknown>);
+    expect(cfg.compressionSourceOnly).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Plumbs Context Manager's default-off `compressionSourceOnly` strategy flag through recipe validation and strategy construction.

## Evidence

- boolean preserve/reject/plumb tests: 3/3
- current-main patch applies cleanly
- paired CM PR carries runtime implementation and full suite

Default off; no resident changes until separately configured.
