### PR TITLE
fix(recipe): persist saved recipe unresolved + relock membrane 0.5.80 (activates cacheKeepalive)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "@animalabs/agent-framework": "^0.10.0",
         "@animalabs/chronicle": "^0.3.0",
         "@animalabs/context-manager": "^0.6.3",
-        "@animalabs/membrane": "^0.5.78",
+        "@animalabs/membrane": "^0.5.80",
         "@opentui/core": "^0.1.82",
       },
       "devDependencies": {
@@ -25,7 +25,7 @@
 
     "@animalabs/context-manager": ["@animalabs/context-manager@0.6.3", "", { "dependencies": { "@animalabs/chronicle": "^0.3.0", "@animalabs/membrane": "^0.5.69" } }, "sha512-zh60LgZxXzBbGrLpDHBAfGSPSL/H8mxz8nSWLOSh4pjiTOYbD0o0BjAM8CFz4LiaOIXnuSCbRoiv5UKsnrKwDw=="],
 
-    "@animalabs/membrane": ["@animalabs/membrane@0.5.79", "", { "dependencies": { "@anthropic-ai/sdk": "^0.52.0" } }, "sha512-wVto7V/WHqlG4P2FjyKv+WxqvhDi0NKb7iLlAdFTFnlCPfxrguDrUJoUx9MNCAjDSVjpwsb6c6rrokjnO0E+pw=="],
+    "@animalabs/membrane": ["@animalabs/membrane@0.5.80", "", { "dependencies": { "@anthropic-ai/sdk": "^0.52.0" } }, "sha512-D4xEij+J/3sJo2ZKFyjAeb0VuJl3QmygzEmi44J0nDNtmJSpUPYMJMaSid/ABj3dIs5EyXds/Ltr4qqyQ2DRTw=="],
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.52.0", "", { "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-d4c+fg+xy9e46c8+YnrrgIQR45CZlAi7PwdzIfDXDM6ACxEZli1/fxhURsq30ZpMZy6LvSkr41jGq5aF5TD7rQ=="],
 

--- a/changelog.d/fix-save-recipe-unresolved.fixed.md
+++ b/changelog.d/fix-save-recipe-unresolved.fixed.md
@@ -1,0 +1,16 @@
+- **Saved recipe snapshots no longer contain resolved secrets.** `loadRecipe`
+  substitutes every `${VAR}` — API tokens included — and the host then wrote
+  that fully resolved recipe to `$DATA_DIR/.recipe.json` at default file mode:
+  plaintext credentials in the exact directory deployments bind-mount and back
+  up (found by an external recipe review that verified live tokens in a backed
+  up `data/` directory on a production VM). The snapshot now keeps the
+  pre-substitution form — `${VAR}` references literal, a URL `systemPrompt`
+  kept as the URL — and a resumed session re-runs substitution, validation,
+  and the prompt fetch against the *current* environment, so secret rotation
+  and remote prompt updates take effect on restart without re-cooking. The
+  file is written 0600 and re-chmod'd 0600 on every save. Legacy resolved
+  snapshots (no `$unresolved` marker) still load verbatim, with no
+  substitution, so a literal `${...}` surviving in prose cannot fail them;
+  resuming an unresolved snapshot whose required env var has since disappeared
+  fails loudly naming the variable instead of silently starting the default
+  recipe.

--- a/changelog.d/membrane-0580-relock.changed.md
+++ b/changelog.d/membrane-0580-relock.changed.md
@@ -1,0 +1,9 @@
+- **membrane `^0.5.80`** (was `^0.5.78`, lockfile-resolved 0.5.79). Two
+  latent cache behaviors the host already configures become ACTIVE with this
+  relock: the prompt-cache keepalive (`agent.cacheKeepalive`, on by default —
+  previously passed to an adapter version with no such field and silently
+  ignored, so idle gaps over the 1h TTL repaid a full cache write on wake)
+  and the floating cache marker (incremental prompt caching inside the native
+  tool loop, membrane's default-on). Both reduce cost; neither changes
+  visible agent behavior. Also clears two of the four standing cross-package
+  `tsc` errors (the membrane-typing pair).

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@animalabs/agent-framework": "^0.10.0",
     "@animalabs/chronicle": "^0.3.0",
     "@animalabs/context-manager": "^0.6.3",
-    "@animalabs/membrane": "^0.5.78",
+    "@animalabs/membrane": "^0.5.80",
     "@opentui/core": "^0.1.82"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,7 +58,7 @@ import { generateSessionName } from './synesthete.js';
 import {
   type Recipe,
   DEFAULT_RECIPE,
-  loadRecipe,
+  loadRecipeDetailed,
   saveRecipe,
   loadSavedRecipe,
   clearSavedRecipe,
@@ -131,8 +131,10 @@ async function resolveRecipe(): Promise<Recipe> {
 
   if (source) {
     try {
-      const recipe = await loadRecipe(source);
-      saveRecipe(config.dataDir, recipe);
+      // Save the unresolved (pre-substitution) form: $DATA_DIR is typically
+      // host-mounted and backed up, so resolved secrets must never land there.
+      const { recipe, persistable } = await loadRecipeDetailed(source);
+      saveRecipe(config.dataDir, persistable);
       console.log(`Loaded recipe: ${recipe.name}${recipe.description ? ` — ${recipe.description}` : ''}`);
       return recipe;
     } catch (err) {
@@ -141,11 +143,21 @@ async function resolveRecipe(): Promise<Recipe> {
     }
   }
 
-  // Try saved recipe
-  const saved = loadSavedRecipe(config.dataDir);
-  if (saved) {
-    console.log(`Resuming recipe: ${saved.name}`);
-    return saved;
+  // Try saved recipe. Re-resolves ${VAR} references against the CURRENT
+  // environment, so a missing secret fails loudly here rather than starting
+  // a misconfigured agent on the default recipe.
+  try {
+    const saved = await loadSavedRecipe(config.dataDir);
+    if (saved) {
+      console.log(`Resuming recipe: ${saved.name}`);
+      return saved;
+    }
+  } catch (err) {
+    console.error(
+      `Failed to resume saved recipe from ${config.dataDir}:`,
+      err instanceof Error ? err.message : err,
+    );
+    process.exit(1);
   }
 
   return DEFAULT_RECIPE;

--- a/src/recipe.ts
+++ b/src/recipe.ts
@@ -11,7 +11,7 @@
  *   - Built-in default (generic assistant)
  */
 
-import { readFileSync, writeFileSync, existsSync, mkdirSync, unlinkSync } from 'node:fs';
+import { readFileSync, writeFileSync, existsSync, mkdirSync, unlinkSync, chmodSync } from 'node:fs';
 import { dirname, isAbsolute, resolve } from 'node:path';
 import { buildWorkspaceMounts } from './workspace-mounts.js';
 
@@ -953,6 +953,27 @@ export function substituteEnvVars(value: unknown, source: string): unknown {
 type RecipeSourceBase = { kind: 'file'; dir: string } | { kind: 'url'; base: string };
 
 /**
+ * A loaded recipe plus the form of it that is safe to persist.
+ *
+ * `recipe` is fully resolved: `${VAR}` env references substituted, relative
+ * child/extension paths made absolute, URL systemPrompt fetched. It is what
+ * the running host consumes — and it can contain secrets (API tokens pulled
+ * from the environment), so it must never be written to disk.
+ *
+ * `persistable` is the raw pre-substitution recipe JSON with only the
+ * source-relative paths (`modules.fleet.children[].recipe`,
+ * `extensions[*].path`) resolved to their final absolute form — those need
+ * the original source base, which a resumed session no longer has. Every
+ * `${VAR}` reference and any URL systemPrompt stay unresolved, so the file
+ * `saveRecipe` writes carries no secret material and re-resolves against the
+ * *current* environment on resume.
+ */
+export interface LoadedRecipe {
+  recipe: Recipe;
+  persistable: Record<string, unknown>;
+}
+
+/**
  * Load a recipe from a URL or local file path.
  * If the systemPrompt value is an HTTP(S) URL, fetches the text.
  * Recipe string values containing `${VAR}` patterns are substituted against
@@ -961,6 +982,15 @@ type RecipeSourceBase = { kind: 'file'; dir: string } | { kind: 'url'; base: str
  * parent recipe's directory (or URL base) so sibling recipes are portable.
  */
 export async function loadRecipe(source: string): Promise<Recipe> {
+  return (await loadRecipeDetailed(source)).recipe;
+}
+
+/**
+ * Like loadRecipe, but also returns the persistable (unresolved) form —
+ * see LoadedRecipe. Callers that snapshot the recipe to disk (index.ts's
+ * resolveRecipe) must save `persistable`, never `recipe`.
+ */
+export async function loadRecipeDetailed(source: string): Promise<LoadedRecipe> {
   let raw: unknown;
   let sourceBase: RecipeSourceBase;
 
@@ -976,11 +1006,54 @@ export async function loadRecipe(source: string): Promise<Recipe> {
     sourceBase = { kind: 'file', dir: dirname(path) };
   }
 
+  // Snapshot the pre-substitution form before substituteEnvVars walks the
+  // object — this is what gets persisted, so resolved secrets never do.
+  const persistable = structuredClone(raw) as Record<string, unknown>;
+
   raw = substituteEnvVars(raw, source);
   const recipe = validateRecipe(raw);
   resolveChildRecipePaths(recipe, sourceBase);
   resolveExtensionPaths(recipe, sourceBase);
-  return resolveSystemPrompt(recipe);
+  const resolved = await resolveSystemPrompt(recipe);
+  copyResolvedPathsIntoRaw(persistable, resolved);
+  return { recipe: resolved, persistable };
+}
+
+/**
+ * Copy the resolved `modules.fleet.children[].recipe` and
+ * `extensions[*].path` values from the resolved recipe into the raw
+ * pre-substitution snapshot. Those fields are resolved against the recipe's
+ * original source base (its directory or URL), which is gone by resume time
+ * — so the persisted form must carry them already-absolute. Substitution
+ * never changes object shape (it is a per-string replacement), so the two
+ * trees align index-for-index and key-for-key. Paths are not treated as
+ * secret: an env value that was interpolated into a child-recipe or
+ * extension path IS persisted in resolved form.
+ */
+function copyResolvedPathsIntoRaw(raw: Record<string, unknown>, recipe: Recipe): void {
+  const fleet = recipe.modules?.fleet;
+  const resolvedChildren = (typeof fleet === 'object' && fleet !== null) ? fleet.children : undefined;
+  if (Array.isArray(resolvedChildren)) {
+    const rawModules = raw.modules as Record<string, unknown> | undefined;
+    const rawFleet = rawModules?.fleet as Record<string, unknown> | undefined;
+    const rawChildren = (typeof rawFleet === 'object' && rawFleet !== null) ? rawFleet.children : undefined;
+    if (Array.isArray(rawChildren)) {
+      for (let i = 0; i < rawChildren.length && i < resolvedChildren.length; i++) {
+        const rawChild = rawChildren[i] as Record<string, unknown> | null;
+        if (rawChild && typeof rawChild === 'object' && typeof resolvedChildren[i]?.recipe === 'string') {
+          rawChild.recipe = resolvedChildren[i].recipe;
+        }
+      }
+    }
+  }
+
+  const rawExtensions = raw.extensions as Record<string, unknown> | undefined;
+  for (const [name, ext] of Object.entries(recipe.extensions ?? {})) {
+    const rawExt = rawExtensions?.[name] as Record<string, unknown> | undefined;
+    if (rawExt && typeof rawExt === 'object') {
+      rawExt.path = ext.path;
+    }
+  }
 }
 
 /**
@@ -1798,20 +1871,80 @@ function savedRecipePath(dataDir: string): string {
   return resolve(dataDir, '.recipe.json');
 }
 
-export function saveRecipe(dataDir: string, recipe: Recipe): void {
+/**
+ * Marker key stamped into saved `.recipe.json` snapshots that were written in
+ * unresolved form (post-fix). Its presence tells loadSavedRecipe to run the
+ * full substitute-and-validate pipeline on read; its absence means a legacy
+ * snapshot saved fully resolved, which must be loaded verbatim — running
+ * substitution over legacy content could hard-fail on a literal `${...}`
+ * that survived in prose (e.g. a systemPrompt documenting env-var syntax).
+ */
+export const SAVED_RECIPE_UNRESOLVED_KEY = '$unresolved';
+
+/**
+ * Snapshot a recipe to `$DATA_DIR/.recipe.json` so a later run without a
+ * recipe argument resumes the same configuration.
+ *
+ * Pass the `persistable` half of loadRecipeDetailed(), NOT the resolved
+ * recipe: `$DATA_DIR` is typically host-mounted and backed up, so the file
+ * must never contain substituted secrets. The snapshot keeps `${VAR}`
+ * references (and any URL systemPrompt) unresolved; loadSavedRecipe
+ * re-resolves them against the environment current at resume time.
+ *
+ * The file is written 0600 and chmod'd to 0600 even when it already exists,
+ * as defense in depth for legacy resolved snapshots being overwritten.
+ */
+export function saveRecipe(dataDir: string, persistable: Record<string, unknown>): void {
   mkdirSync(dataDir, { recursive: true });
-  writeFileSync(savedRecipePath(dataDir), JSON.stringify(recipe, null, 2) + '\n', 'utf-8');
+  const path = savedRecipePath(dataDir);
+  const withMarker = { [SAVED_RECIPE_UNRESOLVED_KEY]: true, ...persistable };
+  writeFileSync(path, JSON.stringify(withMarker, null, 2) + '\n', { encoding: 'utf-8', mode: 0o600 });
+  // writeFileSync's mode only applies on creation — enforce on overwrite too.
+  chmodSync(path, 0o600);
 }
 
-export function loadSavedRecipe(dataDir: string): Recipe | null {
+/**
+ * Load the `.recipe.json` snapshot for a resumed session, or null when there
+ * is none (or it is unreadable/invalid).
+ *
+ * Snapshots carrying SAVED_RECIPE_UNRESOLVED_KEY are re-resolved through the
+ * same pipeline loadRecipe uses — env substitution (so rotated secrets take
+ * effect on restart), validation, and URL systemPrompt fetch. A missing
+ * required `${VAR}` THROWS rather than returning null: silently falling back
+ * to the default recipe would start a misconfigured agent, and the loud
+ * failure names the variable to restore. A failed systemPrompt fetch throws
+ * for the same reason.
+ *
+ * Legacy snapshots (no marker — saved fully resolved by older versions) are
+ * validated and returned verbatim, exactly as before: no substitution, so a
+ * literal `${...}` that survived resolution in prose cannot fail the load.
+ */
+export async function loadSavedRecipe(dataDir: string): Promise<Recipe | null> {
   const path = savedRecipePath(dataDir);
   if (!existsSync(path)) return null;
+  let raw: unknown;
   try {
-    const raw = JSON.parse(readFileSync(path, 'utf-8'));
-    return validateRecipe(raw);
+    raw = JSON.parse(readFileSync(path, 'utf-8'));
   } catch {
     return null;
   }
+
+  if (!raw || typeof raw !== 'object' || !(SAVED_RECIPE_UNRESOLVED_KEY in raw)) {
+    // Legacy resolved snapshot: load verbatim (no substitution).
+    try {
+      return validateRecipe(raw);
+    } catch {
+      return null;
+    }
+  }
+
+  const { [SAVED_RECIPE_UNRESOLVED_KEY]: _marker, ...unresolved } = raw as Record<string, unknown>;
+  // Deliberately outside a try/catch: substitution and validation errors on
+  // a snapshot we wrote ourselves are actionable operator errors (a rotated
+  // secret removed from the environment), not corruption to shrug off.
+  const substituted = substituteEnvVars(unresolved, path);
+  const recipe = validateRecipe(substituted);
+  return resolveSystemPrompt(recipe);
 }
 
 export function clearSavedRecipe(dataDir: string): void {

--- a/test/framework-fkm-composition.test.ts
+++ b/test/framework-fkm-composition.test.ts
@@ -86,7 +86,7 @@ describe('framework FKM composition', () => {
     });
   });
 
-  test('composes validation, serialization, and AF/CM wiring for the merged FKM settings without cross-agent bleed', () => {
+  test('composes validation, serialization, and AF/CM wiring for the merged FKM settings without cross-agent bleed', async () => {
     const parsed = validateRecipe(recipe({
       provider: 'openai-responses',
       maxTokens: 4_096,
@@ -108,8 +108,10 @@ describe('framework FKM composition', () => {
 
     const dir = mkdtempSync(join(tmpdir(), 'connectome-fkm-'));
     tempDirs.push(dir);
-    saveRecipe(dir, parsed);
-    const reloaded = loadSavedRecipe(dir);
+    // Saving an already-resolved recipe through the new unresolved-snapshot
+    // path is legal: substitution over resolved content is a no-op.
+    saveRecipe(dir, parsed as unknown as Record<string, unknown>);
+    const reloaded = await loadSavedRecipe(dir);
     expect(reloaded).not.toBeNull();
 
     expect(reloaded!.agent.sameRoundThinkTextPolicy).toBe('private');

--- a/test/recipe-save-unresolved.test.ts
+++ b/test/recipe-save-unresolved.test.ts
@@ -1,0 +1,244 @@
+/**
+ * Tests for unresolved recipe persistence: the `.recipe.json` snapshot in
+ * $DATA_DIR must never contain substituted secrets.
+ *
+ * Motivating finding (external recipe review against a production VM):
+ * loadRecipe substituted every `${VAR}` — including access tokens — into the
+ * recipe, and resolveRecipe then serialised the RESOLVED recipe to
+ * $DATA_DIR/.recipe.json, a directory deployments bind-mount and back up.
+ *
+ * Contract under test:
+ *   - loadRecipeDetailed returns the resolved recipe for the runtime AND a
+ *     `persistable` pre-substitution form; saveRecipe writes the latter, so
+ *     the on-disk snapshot keeps `${VAR}` literals, never the secret values.
+ *   - loadSavedRecipe re-runs substitution against the CURRENT environment
+ *     (secret rotation takes effect on restart), hard-failing when a
+ *     required var has gone missing.
+ *   - Legacy snapshots (saved fully resolved by older versions, no marker)
+ *     still load verbatim — including ones with a literal `${...}` in prose.
+ *   - The snapshot file is chmod'd 0600 even when overwriting a legacy file.
+ *   - A URL systemPrompt is persisted as the URL and re-fetched on resume.
+ */
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, statSync, chmodSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import {
+  loadRecipe,
+  loadRecipeDetailed,
+  saveRecipe,
+  loadSavedRecipe,
+  SAVED_RECIPE_UNRESOLVED_KEY,
+} from '../src/recipe.js';
+
+const SECRET = 'tok-glpat-supersecret-12345';
+
+describe('unresolved recipe persistence', () => {
+  const originalEnv = process.env;
+  const originalFetch = globalThis.fetch;
+  let tmpDir: string;
+  let dataDir: string;
+  let recipePath: string;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    tmpDir = mkdtempSync(join(tmpdir(), 'conhost-save-unresolved-'));
+    dataDir = join(tmpDir, 'data');
+    recipePath = join(tmpDir, 'recipe.json');
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    globalThis.fetch = originalFetch;
+    try { rmSync(tmpDir, { recursive: true, force: true }); } catch { /* noop */ }
+  });
+
+  function writeSecretRecipe(): void {
+    writeFileSync(recipePath, JSON.stringify({
+      name: 'Secret Test',
+      agent: { systemPrompt: 'be helpful' },
+      mcpServers: {
+        gitlab: {
+          command: 'node',
+          env: { GITLAB_PERSONAL_ACCESS_TOKEN: '${CONHOST_TEST_SECRET}' },
+        },
+      },
+    }), 'utf-8');
+  }
+
+  test('resolved recipe carries the secret in memory; persistable keeps the ${VAR} literal', async () => {
+    process.env.CONHOST_TEST_SECRET = SECRET;
+    writeSecretRecipe();
+
+    const { recipe, persistable } = await loadRecipeDetailed(recipePath);
+    expect((recipe.mcpServers as any).gitlab.env.GITLAB_PERSONAL_ACCESS_TOKEN).toBe(SECRET);
+    expect((persistable.mcpServers as any).gitlab.env.GITLAB_PERSONAL_ACCESS_TOKEN)
+      .toBe('${CONHOST_TEST_SECRET}');
+  });
+
+  test('the saved .recipe.json never contains the substituted secret', async () => {
+    process.env.CONHOST_TEST_SECRET = SECRET;
+    writeSecretRecipe();
+
+    const { persistable } = await loadRecipeDetailed(recipePath);
+    saveRecipe(dataDir, persistable);
+
+    const onDisk = readFileSync(join(dataDir, '.recipe.json'), 'utf-8');
+    expect(onDisk).not.toContain(SECRET);
+    expect(onDisk).toContain('${CONHOST_TEST_SECRET}');
+    expect(JSON.parse(onDisk)[SAVED_RECIPE_UNRESOLVED_KEY]).toBe(true);
+  });
+
+  test('loadSavedRecipe re-resolves against the CURRENT environment (secret rotation)', async () => {
+    process.env.CONHOST_TEST_SECRET = SECRET;
+    writeSecretRecipe();
+    const { persistable } = await loadRecipeDetailed(recipePath);
+    saveRecipe(dataDir, persistable);
+
+    process.env.CONHOST_TEST_SECRET = 'tok-rotated-67890';
+    const resumed = await loadSavedRecipe(dataDir);
+    expect(resumed).not.toBeNull();
+    expect((resumed!.mcpServers as any).gitlab.env.GITLAB_PERSONAL_ACCESS_TOKEN)
+      .toBe('tok-rotated-67890');
+  });
+
+  test('loadSavedRecipe throws (not null) when a required var disappeared from the environment', async () => {
+    process.env.CONHOST_TEST_SECRET = SECRET;
+    writeSecretRecipe();
+    const { persistable } = await loadRecipeDetailed(recipePath);
+    saveRecipe(dataDir, persistable);
+
+    delete process.env.CONHOST_TEST_SECRET;
+    await expect(loadSavedRecipe(dataDir)).rejects.toThrow(/CONHOST_TEST_SECRET/);
+  });
+
+  test('saveRecipe writes the snapshot with mode 0600, and chmods a pre-existing looser file', async () => {
+    process.env.CONHOST_TEST_SECRET = SECRET;
+    writeSecretRecipe();
+    const { persistable } = await loadRecipeDetailed(recipePath);
+
+    saveRecipe(dataDir, persistable);
+    const path = join(dataDir, '.recipe.json');
+    expect(statSync(path).mode & 0o777).toBe(0o600);
+
+    // Legacy deployments have a world-readable resolved snapshot; an
+    // overwrite must tighten it even though writeFileSync's mode only
+    // applies at creation.
+    chmodSync(path, 0o644);
+    expect(statSync(path).mode & 0o777).toBe(0o644);
+    saveRecipe(dataDir, persistable);
+    expect(statSync(path).mode & 0o777).toBe(0o600);
+  });
+
+  test('round-trip with no ${} patterns is a faithful no-op resolution', async () => {
+    writeFileSync(recipePath, JSON.stringify({
+      name: 'Plain',
+      description: 'no env refs',
+      agent: { systemPrompt: 'hello', model: 'claude-opus-4-6' },
+    }), 'utf-8');
+    const { recipe, persistable } = await loadRecipeDetailed(recipePath);
+    saveRecipe(dataDir, persistable);
+    const resumed = await loadSavedRecipe(dataDir);
+    expect(resumed).not.toBeNull();
+    expect(resumed!.name).toBe('Plain');
+    expect(resumed!.agent.systemPrompt).toBe(recipe.agent.systemPrompt);
+    expect(resumed!.agent.model).toBe('claude-opus-4-6');
+  });
+
+  test('relative fleet child recipe paths are persisted absolute (resume has no source base)', async () => {
+    writeFileSync(recipePath, JSON.stringify({
+      name: 'Fleet Parent',
+      agent: { systemPrompt: 'parent' },
+      modules: {
+        fleet: { children: [{ name: 'child-a', recipe: 'child.json' }] },
+      },
+    }), 'utf-8');
+
+    const { recipe, persistable } = await loadRecipeDetailed(recipePath);
+    const expected = resolve(tmpDir, 'child.json');
+    expect((recipe.modules!.fleet as any).children[0].recipe).toBe(expected);
+    expect(((persistable.modules as any).fleet.children[0]).recipe).toBe(expected);
+
+    saveRecipe(dataDir, persistable);
+    const resumed = await loadSavedRecipe(dataDir);
+    expect((resumed!.modules!.fleet as any).children[0].recipe).toBe(expected);
+  });
+
+  describe('URL systemPrompt', () => {
+    test('persisted as the URL and re-fetched on resume, picking up prompt updates', async () => {
+      let fetchCount = 0;
+      globalThis.fetch = (async (input: any) => {
+        expect(String(input)).toBe('https://prompts.example/agent.txt');
+        fetchCount++;
+        return new Response(fetchCount === 1 ? 'FETCHED PROMPT v1' : 'FETCHED PROMPT v2');
+      }) as typeof fetch;
+
+      writeFileSync(recipePath, JSON.stringify({
+        name: 'URL Prompt',
+        agent: { systemPrompt: 'https://prompts.example/agent.txt' },
+      }), 'utf-8');
+
+      const { recipe, persistable } = await loadRecipeDetailed(recipePath);
+      expect(recipe.agent.systemPrompt).toBe('FETCHED PROMPT v1');
+      expect((persistable.agent as any).systemPrompt).toBe('https://prompts.example/agent.txt');
+
+      saveRecipe(dataDir, persistable);
+      const onDisk = readFileSync(join(dataDir, '.recipe.json'), 'utf-8');
+      expect(onDisk).not.toContain('FETCHED PROMPT');
+
+      const resumed = await loadSavedRecipe(dataDir);
+      expect(resumed!.agent.systemPrompt).toBe('FETCHED PROMPT v2');
+      expect(fetchCount).toBe(2);
+    });
+  });
+
+  describe('legacy resolved snapshots (no marker)', () => {
+    test('load verbatim with no substitution', async () => {
+      // Simulate an older host's save: fully resolved, no marker.
+      const legacy = {
+        name: 'Legacy',
+        agent: { systemPrompt: 'resolved prompt' },
+        mcpServers: { gitlab: { command: 'node', env: { TOKEN: SECRET } } },
+      };
+      mkdirSync(dataDir, { recursive: true });
+      writeFileSync(join(dataDir, '.recipe.json'), JSON.stringify(legacy, null, 2) + '\n', 'utf-8');
+
+      const resumed = await loadSavedRecipe(dataDir);
+      expect(resumed).not.toBeNull();
+      expect((resumed!.mcpServers as any).gitlab.env.TOKEN).toBe(SECRET);
+    });
+
+    test('a surviving literal ${...} in prose does not hard-fail the load', async () => {
+      delete process.env.DEFINITELY_NOT_SET_ANYWHERE;
+      const legacy = {
+        name: 'Legacy Prose',
+        agent: {
+          systemPrompt: 'To configure, set ${DEFINITELY_NOT_SET_ANYWHERE} in your .env file.',
+        },
+      };
+      mkdirSync(dataDir, { recursive: true });
+      writeFileSync(join(dataDir, '.recipe.json'), JSON.stringify(legacy) + '\n', 'utf-8');
+
+      const resumed = await loadSavedRecipe(dataDir);
+      expect(resumed).not.toBeNull();
+      expect(resumed!.agent.systemPrompt).toContain('${DEFINITELY_NOT_SET_ANYWHERE}');
+    });
+
+    test('corrupt JSON still returns null rather than throwing', async () => {
+      mkdirSync(dataDir, { recursive: true });
+      writeFileSync(join(dataDir, '.recipe.json'), '{not json', 'utf-8');
+      expect(await loadSavedRecipe(dataDir)).toBeNull();
+    });
+
+    test('missing snapshot returns null', async () => {
+      expect(await loadSavedRecipe(dataDir)).toBeNull();
+    });
+  });
+
+  test('loadRecipe wrapper still returns the resolved recipe', async () => {
+    process.env.CONHOST_TEST_SECRET = SECRET;
+    writeSecretRecipe();
+    const recipe = await loadRecipe(recipePath);
+    expect((recipe.mcpServers as any).gitlab.env.GITLAB_PERSONAL_ACCESS_TOKEN).toBe(SECRET);
+  });
+});


### PR DESCRIPTION
## Problem

`loadRecipe` substitutes every `${VAR}` in the recipe against `process.env` — API tokens included — and `resolveRecipe` (src/index.ts) then wrote that fully **resolved** recipe to `$DATA_DIR/.recipe.json` at default file mode. Deployments bind-mount `$DATA_DIR` to the host and back it up, so plaintext credentials (e.g. `GITLAB_PERSONAL_ACCESS_TOKEN`) landed in the exact directory people snapshot.

The motivating finding came from an external recipe review that verified live plaintext tokens sitting in a backed-up `data/` directory on a production VM.

## Changes

- **`loadRecipeDetailed()`** (src/recipe.ts) returns both the resolved recipe (runtime-only, never written to disk) and a `persistable` pre-substitution snapshot. `loadRecipe` stays as a thin wrapper, so the fleet-module and web-ui call sites are untouched.
- **`saveRecipe` writes the persistable form**, stamped with a `$unresolved` marker key, at mode 0600 — and `chmod`s to 0600 on overwrite too (writeFileSync's `mode` only applies at creation), so a legacy world-readable resolved snapshot gets tightened the next time a recipe is saved over it.
- **Source-relative paths** (`modules.fleet.children[].recipe`, `extensions[*].path`) are copied into the snapshot in their resolved absolute form: the original source base (recipe dir / URL) is gone by resume time. Deliberate consequence: paths are not treated as secret — an env value interpolated into a path is persisted resolved.
- **URL `systemPrompt` is persisted as the URL**, not the fetched text, and re-fetched on resume. Deliberate choice, consistent with re-resolution: prompt updates (like secret rotation) take effect on restart. Tradeoff: resuming while the prompt URL is unreachable now fails loudly, where a legacy snapshot resumed from cached text.
- **`loadSavedRecipe` (now async)** runs the same substitute → validate → prompt-fetch pipeline for marked snapshots, so a resumed session re-resolves from the **current** environment — secret rotation takes effect on restart without re-cooking. A required `${VAR}` that has since disappeared **throws naming the variable** (surfaced in index.ts as a clean error + exit 1) instead of silently starting the default recipe with a misconfigured agent.
- **Back-compat:** legacy resolved snapshots (no marker) load exactly as before — validated verbatim, **no substitution** — so a literal `${...}` that survived in prose (e.g. a systemPrompt documenting env-var syntax) cannot start hard-failing. Covered by test. Additionally, substitution over already-resolved content on the new path is verified a no-op by the updated framework-fkm-composition round-trip test.

**Second commit — membrane 0.5.80 relock** (`e385093`): membrane 0.5.80 (released today; #51 there) is the first release containing `AnthropicAdapterConfig.cacheKeepalive`, which `src/index.ts` has been passing since #97 — silently ignored by the 0.5.79 the lockfile resolved. Range bumped to `^0.5.80`, relocked, and the stale nested 0.5.79 copies bun left under agent-framework/context-manager dropped (their `^0.5.78` ranges accept 0.5.80; with the duplicate gone the `Membrane` types unify again). Activates the keepalive AND membrane's default-on floating cache marker — both cost reducers, no visible behavior change. Bundled here since both commits are about recipe env/config doing what it says on the tin.

Fleet children are unaffected mechanically: each child process resolves and snapshots its own recipe through the same index.ts path, so child `data/` dirs get the same fix.

## Tests

Baselines established on clean upstream/main (b4f9e34) in this worktree:

- `bun test` baseline: **717 pass / 0 fail** (79 files)
- `bunx tsc --noEmit` baseline: **4 errors** (pre-existing cross-package: cache-keepalive-log.ts KeepaliveEvent export, commands.ts puppetToolCall, framework-agent-config.ts proseRouting "disabled", index.ts cacheKeepalive)

After the change:

- `bun test`: **730 pass / 0 fail** (80 files) — failure count identical to baseline, +13 new tests (re-verified after the relock commit: unchanged)
- `bunx tsc --noEmit`: **2 errors** after the relock (baseline 4) — the two membrane-typing errors (cache-keepalive-log.ts, index.ts cacheKeepalive) are cured by 0.5.80; the remaining 2 (commands.ts puppetToolCall, framework-agent-config.ts proseRouting "disabled") await an agent-framework release
- New suite `test/recipe-save-unresolved.test.ts` fails on unfixed code: with src/ stashed back to upstream/main it runs **0 pass / 1 fail** (import error — the API under test doesn't exist there). The core assertions (secret string absent from the written `.recipe.json`, `${VAR}` literal present, mode 0600, rotation picked up on reload, missing-var rejection, legacy prose-`${...}` snapshot loads without substitution, URL prompt persisted as URL and re-fetched) all pass on the fixed code.

## Not verified

- No live host boot: I did not run `bun src/index.ts` end-to-end against a real recipe/provider, so the index.ts resolveRecipe wiring (save persistable, await loadSavedRecipe, exit-1 on resume failure) is exercised only through the recipe-layer tests and typecheck, not a running session.
- No real production migration: legacy-snapshot behavior is covered by fixture tests, not by resuming an actual pre-fix VM's `data/` directory.
- The 0600 chmod path was tested on Linux (WSL2) only; behavior on Windows filesystems not exercised.
- URL-recipe loading (recipe fetched over http) is exercised only via the existing suite; the new persistable path for URL-sourced recipes is covered by code inspection and the URL-systemPrompt test, not a URL-sourced recipe fixture.

---

- [x] Changelog fragments added — `changelog.d/fix-save-recipe-unresolved.fixed.md`, `changelog.d/membrane-0580-relock.changed.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CMG3QdxSwp66tn7fLRaJzz

