### PR TITLE
fix(recipe): plumb compression recall budget

### DIFF
--- a/changelog.d/compression-recall-budget-plumbing.fixed.md
+++ b/changelog.d/compression-recall-budget-plumbing.fixed.md
@@ -1,0 +1,1 @@
+- Plumb `agent.strategy.compressionRecallBudgetTokens` through recipe validation and Framework strategy construction, with positive-integer validation instead of silently accepting an inert key.

--- a/src/framework-strategy.ts
+++ b/src/framework-strategy.ts
@@ -14,6 +14,7 @@ const PASSTHROUGH_KEYS: ReadonlyArray<keyof RecipeStrategy> = [
   'compressionRefusalCurveFallbacks',
   'compressionContextBudgetTokens',
   'compressionSourceOnly',
+  'compressionRecallBudgetTokens',
   'positionedRecallPairs',
   'recallHeaderTemplate',
   'targetChunkTokens',

--- a/src/recipe.ts
+++ b/src/recipe.ts
@@ -56,6 +56,9 @@ export interface RecipeStrategy {
    * recall, or non-target raw recent material). One call, not a refusal
    * ladder. Source-preserving; L1 only. Default off. */
   compressionSourceOnly?: boolean;
+  /** Token budget for prior recall-pair context in compression/merge
+   * requests (Context Manager `compressionRecallBudgetTokens`). */
+  compressionRecallBudgetTokens?: number;
   positionedRecallPairs?: boolean;
   recallHeaderTemplate?: string;
   targetChunkTokens?: number;
@@ -1309,6 +1312,16 @@ export function validateRecipe(raw: unknown): Recipe {
       && typeof strategy.compressionSourceOnly !== 'boolean'
     ) {
       throw new Error('Recipe agent.strategy.compressionSourceOnly must be a boolean.');
+    }
+    if (
+      strategy.compressionRecallBudgetTokens !== undefined
+      && (
+        typeof strategy.compressionRecallBudgetTokens !== 'number'
+        || !Number.isSafeInteger(strategy.compressionRecallBudgetTokens)
+        || strategy.compressionRecallBudgetTokens <= 0
+      )
+    ) {
+      throw new Error('Recipe agent.strategy.compressionRecallBudgetTokens must be a positive safe integer.');
     }
   }
 

--- a/test/framework-fkm-composition.test.ts
+++ b/test/framework-fkm-composition.test.ts
@@ -103,6 +103,7 @@ describe('framework FKM composition', () => {
         type: 'autobiographical',
         compressionRefusalCurveFallbacks: 2,
         compressionContextBudgetTokens: 19_000,
+        compressionRecallBudgetTokens: 17_000,
       },
     }));
 
@@ -118,11 +119,13 @@ describe('framework FKM composition', () => {
     });
     expect(reloaded!.agent.strategy?.compressionRefusalCurveFallbacks).toBe(2);
     expect(reloaded!.agent.strategy?.compressionContextBudgetTokens).toBe(19_000);
+    expect(reloaded!.agent.strategy?.compressionRecallBudgetTokens).toBe(17_000);
 
     const runtimeStrategy = buildFrameworkStrategy(reloaded!, 'model', 'America/Los_Angeles');
     const runtimeConfig = strategyConfigView(runtimeStrategy);
     expect(runtimeConfig.compressionRefusalCurveFallbacks).toBe(2);
     expect(runtimeConfig.compressionContextBudgetTokens).toBe(19_000);
+    expect(runtimeConfig.compressionRecallBudgetTokens).toBe(17_000);
 
     const agentConfig = buildFrameworkAgentConfig(reloaded!, 'agent', 'model', runtimeStrategy);
     expect(agentConfig.sameRoundThinkTextPolicy).toBe('private');
@@ -138,14 +141,17 @@ describe('framework FKM composition', () => {
         type: 'autobiographical',
         compressionRefusalCurveFallbacks: 0,
         compressionContextBudgetTokens: 50_000,
+        compressionRecallBudgetTokens: 41_000,
       },
     }));
     const otherStrategy = buildFrameworkStrategy(otherRecipe, 'other-model', 'America/Los_Angeles');
     const otherConfig = strategyConfigView(otherStrategy);
     expect(otherConfig.compressionRefusalCurveFallbacks).toBe(0);
     expect(otherConfig.compressionContextBudgetTokens).toBe(50_000);
+    expect(otherConfig.compressionRecallBudgetTokens).toBe(41_000);
     expect(otherConfig).not.toBe(runtimeConfig);
     expect(runtimeConfig.compressionRefusalCurveFallbacks).toBe(2);
     expect(runtimeConfig.compressionContextBudgetTokens).toBe(19_000);
+    expect(runtimeConfig.compressionRecallBudgetTokens).toBe(17_000);
   });
 });

--- a/test/recipe-compression-fallback.test.ts
+++ b/test/recipe-compression-fallback.test.ts
@@ -13,9 +13,11 @@ describe('compression recall-curve recipe settings', () => {
     const parsed = validateRecipe(recipe({
       compressionRefusalCurveFallbacks: 3,
       compressionContextBudgetTokens: 200_000,
+      compressionRecallBudgetTokens: 40_000,
     }));
     expect(parsed.agent.strategy?.compressionRefusalCurveFallbacks).toBe(3);
     expect(parsed.agent.strategy?.compressionContextBudgetTokens).toBe(200_000);
+    expect(parsed.agent.strategy?.compressionRecallBudgetTokens).toBe(40_000);
   });
 
   test('accepts zero as an explicit fallback disable', () => {
@@ -32,5 +34,11 @@ describe('compression recall-curve recipe settings', () => {
       .toThrow(/compressionContextBudgetTokens/);
     expect(() => validateRecipe(recipe({ compressionContextBudgetTokens: '200000' })))
       .toThrow(/compressionContextBudgetTokens/);
+    expect(() => validateRecipe(recipe({ compressionRecallBudgetTokens: 0 })))
+      .toThrow(/compressionRecallBudgetTokens/);
+    expect(() => validateRecipe(recipe({ compressionRecallBudgetTokens: 1.5 })))
+      .toThrow(/compressionRecallBudgetTokens/);
+    expect(() => validateRecipe(recipe({ compressionRecallBudgetTokens: '40000' })))
+      .toThrow(/compressionRecallBudgetTokens/);
   });
 });


### PR DESCRIPTION
Plumbs `agent.strategy.compressionRecallBudgetTokens` through recipe typing, positive-integer validation, persistence and Framework/Context Manager strategy construction. Prevents the setting from being silently accepted but inert.

Evidence:
- focused recipe/composition tests: 5/5
- exact current-main diff clean
- shared live-lineage backport committed as `1cadfff6…`; current-main reviewed head `540db44f…`

The local isolated typecheck currently reproduces standing sibling-package version mismatches (`puppetToolCall`, cacheKeepalive, proseRouting disabled) unrelated to this five-file patch; GitHub CI is authoritative for current-main composition.