### PR TITLE
feat(recipe): openai-compatible provider — any OpenAI chat-completions endpoint (Ollama, vLLM, NanoGPT, ...)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,29 @@ device-code flow if needed. No `OPENAI_API_KEY` is used for this provider. Use
 warns if the service reports that it fell back to Standard; Fast mode consumes
 subscription credits at a higher rate when applied.
 
+### OpenAI-compatible endpoints (Ollama, vLLM, Together, Groq, NanoGPT, ...)
+
+Any server speaking the OpenAI chat-completions API works through the generic
+`openai-compatible` provider — the recipe names the endpoint and the model:
+
+```json
+{
+  "agent": {
+    "provider": "openai-compatible",
+    "baseUrl": "http://localhost:11434/v1",
+    "model": "qwen3:32b",
+    "systemPrompt": "You are a helpful assistant."
+  }
+}
+```
+
+The API key is read from `OPENAI_COMPATIBLE_API_KEY` (falling back to
+`OPENAI_API_KEY`); local servers usually need none. `agent.model` is required —
+there is no default model for an arbitrary endpoint. Tool calls use the
+standard `tool_calls` format, so the endpoint must support function calling
+for tool-using recipes. Provider-side prompt caching and cache accounting
+depend on what the endpoint reports.
+
 ## What it provides
 
 - **Web UI**: browser operator console (`modules.webui`) — live chat with full interiority (thinking, tool calls, streaming), agent/fleet tree, context makeup + compression coverage, call ledger with cache verdicts and billing-grade costs, health/ops alerts, Chronicle branch tree, lessons, MCPL config, workspace files; scoped read-only observer access via device keys
@@ -157,6 +180,7 @@ npm install
 |----------|---------|-------------|
 | `ANTHROPIC_API_KEY` | (required) | Anthropic API key |
 | `OPENAI_API_KEY` | — | OpenAI Platform key for `openai-responses` recipes |
+| `OPENAI_COMPATIBLE_API_KEY` | falls back to `OPENAI_API_KEY` | Key for `openai-compatible` recipes; omit for local servers |
 | `CODEX_BINARY` | `codex` | Codex CLI executable for `openai-codex` subscription auth |
 | `CODEX_HOME` | `~/.codex` | Codex credential/config directory |
 | `CODEX_BASE_URL` | ChatGPT Codex backend | Optional subscription transport override |

--- a/README.md
+++ b/README.md
@@ -134,8 +134,10 @@ Any server speaking the OpenAI chat-completions API works through the generic
 }
 ```
 
-The API key is read from `OPENAI_COMPATIBLE_API_KEY` (falling back to
-`OPENAI_API_KEY`); local servers usually need none. `agent.model` is required —
+The API key is read from `OPENAI_COMPATIBLE_API_KEY` only — deliberately no
+`OPENAI_API_KEY` fallback: `baseUrl` is recipe-controlled, and a real OpenAI
+credential must never be sent silently to an arbitrary endpoint. Local
+servers usually need none. `agent.model` is required —
 there is no default model for an arbitrary endpoint. Tool calls use the
 standard `tool_calls` format, so the endpoint must support function calling
 for tool-using recipes. Provider-side prompt caching and cache accounting
@@ -180,7 +182,7 @@ npm install
 |----------|---------|-------------|
 | `ANTHROPIC_API_KEY` | (required) | Anthropic API key |
 | `OPENAI_API_KEY` | — | OpenAI Platform key for `openai-responses` recipes |
-| `OPENAI_COMPATIBLE_API_KEY` | falls back to `OPENAI_API_KEY` | Key for `openai-compatible` recipes; omit for local servers |
+| `OPENAI_COMPATIBLE_API_KEY` | — | Key for `openai-compatible` recipes (no `OPENAI_API_KEY` fallback by design); omit for local servers |
 | `CODEX_BINARY` | `codex` | Codex CLI executable for `openai-codex` subscription auth |
 | `CODEX_HOME` | `~/.codex` | Codex credential/config directory |
 | `CODEX_BASE_URL` | ChatGPT Codex backend | Optional subscription transport override |

--- a/changelog.d/openai-compatible-provider.added.md
+++ b/changelog.d/openai-compatible-provider.added.md
@@ -4,5 +4,7 @@
   wired. The recipe names the endpoint (`agent.baseUrl`, validated as an
   absolute http(s) URL at load) and the model (required — no default for an
   arbitrary endpoint); the key comes from `OPENAI_COMPATIBLE_API_KEY`
-  (fallback `OPENAI_API_KEY`) and may be absent for local servers.
+  only (no `OPENAI_API_KEY` fallback — `baseUrl` is recipe-controlled, so a
+  fallback would silently send a real OpenAI credential to an arbitrary
+  endpoint) and may be absent for local servers.
   `agent.baseUrl` with any other provider is rejected at load time.

--- a/changelog.d/openai-compatible-provider.added.md
+++ b/changelog.d/openai-compatible-provider.added.md
@@ -1,0 +1,8 @@
+- **`agent.provider: 'openai-compatible'`** — run an agent against any
+  OpenAI chat-completions endpoint (Ollama, vLLM, Together, Groq, NanoGPT,
+  ...) via membrane's existing `OpenAICompatibleAdapter`, which no host ever
+  wired. The recipe names the endpoint (`agent.baseUrl`, validated as an
+  absolute http(s) URL at load) and the model (required — no default for an
+  arbitrary endpoint); the key comes from `OPENAI_COMPATIBLE_API_KEY`
+  (fallback `OPENAI_API_KEY`) and may be absent for local servers.
+  `agent.baseUrl` with any other provider is rejected at load time.

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import {
   NativeFormatter,
   OpenAIResponsesAPIAdapter,
   OpenAIResponsesFormatter,
+  OpenAICompatibleAdapter,
   OpenRouterAdapter,
 } from '@animalabs/membrane';
 import { LoggingAnthropicAdapter } from './logging-adapter.js';
@@ -83,6 +84,7 @@ const config = {
   authToken: process.env.ANTHROPIC_AUTH_TOKEN,
   openaiApiKey: process.env.OPENAI_API_KEY,
   openrouterApiKey: process.env.OPENROUTER_API_KEY,
+  openaiCompatibleApiKey: process.env.OPENAI_COMPATIBLE_API_KEY || process.env.OPENAI_API_KEY,
   codexBinary: process.env.CODEX_BINARY,
   model: process.env.MODEL,
   dataDir: process.env.DATA_DIR || './data',
@@ -876,6 +878,16 @@ async function main() {
         fastMode: recipe.agent.codex?.fastMode ?? false,
       })
     : undefined;
+  // Generic OpenAI-compatible chat-completions endpoint (Ollama, vLLM, Together,
+  // Groq, NanoGPT, ...). The recipe carries the endpoint (agent.baseUrl,
+  // validated at load); the key is optional because local servers have none.
+  const openaiCompatibleAdapter = provider === 'openai-compatible'
+    ? new OpenAICompatibleAdapter({
+        baseURL: recipe.agent.baseUrl!,
+        apiKey: config.openaiCompatibleApiKey || undefined,
+        providerName: 'openai-compatible',
+      })
+    : undefined;
   const openrouterAdapter = provider === 'openrouter'
     ? new OpenRouterAdapter({
         apiKey: config.openrouterApiKey!,
@@ -936,6 +948,7 @@ async function main() {
     : bedrockAdapter
       ?? (mockAdapter ? new LoggingProviderAdapter(mockAdapter, llmLogPath) : undefined)
       ?? (openrouterAdapter ? new LoggingProviderAdapter(openrouterAdapter, llmLogPath) : undefined)
+      ?? (openaiCompatibleAdapter ? new LoggingProviderAdapter(openaiCompatibleAdapter, llmLogPath) : undefined)
       ?? (codexAdapter ? new LoggingProviderAdapter(codexAdapter, llmLogPath) : undefined)
       ?? new LoggingAnthropicAdapter(
         {

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,7 +84,10 @@ const config = {
   authToken: process.env.ANTHROPIC_AUTH_TOKEN,
   openaiApiKey: process.env.OPENAI_API_KEY,
   openrouterApiKey: process.env.OPENROUTER_API_KEY,
-  openaiCompatibleApiKey: process.env.OPENAI_COMPATIBLE_API_KEY || process.env.OPENAI_API_KEY,
+  // Deliberately NO fallback to OPENAI_API_KEY: agent.baseUrl is
+  // recipe-controlled, so a fallback would silently send a real OpenAI
+  // credential as a Bearer token to whatever endpoint a recipe names.
+  openaiCompatibleApiKey: process.env.OPENAI_COMPATIBLE_API_KEY,
   codexBinary: process.env.CODEX_BINARY,
   model: process.env.MODEL,
   dataDir: process.env.DATA_DIR || './data',

--- a/src/recipe.ts
+++ b/src/recipe.ts
@@ -129,8 +129,10 @@ export interface RecipeAgent {
    * `http://localhost:11434/v1` (Ollama), a vLLM server, Together, Groq,
    * NanoGPT... Required with `provider: 'openai-compatible'`, rejected with
    * any other provider (those have their own `*_BASE_URL` env overrides).
-   * The API key comes from `OPENAI_COMPATIBLE_API_KEY` (falling back to
-   * `OPENAI_API_KEY`); local servers may need none. `agent.model` is required
+   * The API key comes from `OPENAI_COMPATIBLE_API_KEY` only — deliberately no
+   * `OPENAI_API_KEY` fallback, since `baseUrl` is recipe-controlled and a real
+   * OpenAI credential must never travel silently to an arbitrary endpoint.
+   * Local servers may need none. `agent.model` is required
    * too — there is no sensible default model for an arbitrary endpoint.
    */
   baseUrl?: string;

--- a/src/recipe.ts
+++ b/src/recipe.ts
@@ -123,7 +123,17 @@ export interface RecipeAgent {
   /** Provider transport. Omitted preserves the historical Anthropic default.
    * 'mock' wires membrane's MockAdapter — canned/echo responses, no API key,
    * no provider spend; for exercising the full host loop offline. */
-  provider?: 'anthropic' | 'openai-responses' | 'openai-codex' | 'openrouter' | 'bedrock' | 'mock';
+  provider?: 'anthropic' | 'openai-responses' | 'openai-codex' | 'openrouter' | 'bedrock' | 'openai-compatible' | 'mock';
+  /**
+   * Base URL of an OpenAI-compatible chat-completions endpoint, e.g.
+   * `http://localhost:11434/v1` (Ollama), a vLLM server, Together, Groq,
+   * NanoGPT... Required with `provider: 'openai-compatible'`, rejected with
+   * any other provider (those have their own `*_BASE_URL` env overrides).
+   * The API key comes from `OPENAI_COMPATIBLE_API_KEY` (falling back to
+   * `OPENAI_API_KEY`); local servers may need none. `agent.model` is required
+   * too — there is no sensible default model for an arbitrary endpoint.
+   */
+  baseUrl?: string;
   /** Message formatter. 'native' (default) = structured user/assistant turns.
    * 'anthropic-xml' = classic prefill format ("participant: text" runs, XML
    * tools) — for migrating prefill-era bots (chapterx borgs) with their exact
@@ -1148,9 +1158,10 @@ export function validateRecipe(raw: unknown): Recipe {
       agent.provider !== 'openai-codex' &&
       agent.provider !== 'openrouter' &&
       agent.provider !== 'bedrock' &&
+      agent.provider !== 'openai-compatible' &&
       agent.provider !== 'mock') {
     throw new Error(
-      `Recipe agent.provider must be 'anthropic', 'openai-responses', 'openai-codex', 'openrouter', 'bedrock', or 'mock', ` +
+      `Recipe agent.provider must be 'anthropic', 'openai-responses', 'openai-codex', 'openrouter', 'bedrock', 'openai-compatible', or 'mock', ` +
       `got ${JSON.stringify(agent.provider)}.`,
     );
   }
@@ -1235,6 +1246,32 @@ export function validateRecipe(raw: unknown): Recipe {
     throw new Error(`Recipe agent.cacheTtl must be '5m' or '1h', got ${JSON.stringify(agent.cacheTtl)}.`);
   }
   agent.cacheTtl ??= '1h';
+
+  // openai-compatible: an endpoint the host knows nothing about, so the recipe
+  // must say where it is and which model to ask for. Fail at load time, not as
+  // a fetch to 'undefined/chat/completions' at first inference.
+  if (agent.provider === 'openai-compatible') {
+    if (typeof agent.baseUrl !== 'string' || !agent.baseUrl.trim()) {
+      throw new Error("Recipe agent.baseUrl is required when agent.provider is 'openai-compatible' (e.g. \"http://localhost:11434/v1\").");
+    }
+    let parsed: URL;
+    try {
+      parsed = new URL(agent.baseUrl);
+    } catch {
+      throw new Error(`Recipe agent.baseUrl must be an absolute http(s) URL, got ${JSON.stringify(agent.baseUrl)}.`);
+    }
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      throw new Error(`Recipe agent.baseUrl must use http or https, got ${JSON.stringify(agent.baseUrl)}.`);
+    }
+    if (typeof agent.model !== 'string' || !agent.model.trim()) {
+      throw new Error("Recipe agent.model is required when agent.provider is 'openai-compatible' (no default model for an arbitrary endpoint).");
+    }
+  } else if (agent.baseUrl !== undefined) {
+    throw new Error(
+      `Recipe agent.baseUrl only applies to agent.provider 'openai-compatible' (got provider ${JSON.stringify(agent.provider ?? 'anthropic')}); ` +
+      'other providers take their endpoint from ANTHROPIC_BASE_URL / OPENAI_BASE_URL / BEDROCK_BASE_URL.',
+    );
+  }
 
   // A keepalive that fires AFTER the entry has already expired is the worst of
   // both worlds: it pays a full 2x cache write on every poke, forever, and

--- a/test/recipe-openai-compatible.test.ts
+++ b/test/recipe-openai-compatible.test.ts
@@ -1,0 +1,54 @@
+/**
+ * `agent.provider: 'openai-compatible'` — membrane has shipped a generic
+ * OpenAI chat-completions adapter (Ollama, vLLM, Together, Groq, local
+ * servers...) that no host wired. The recipe must name the endpoint and the
+ * model, and both must be checked at load time: a missing baseUrl would
+ * otherwise surface as a fetch to `undefined/chat/completions` at first
+ * inference, and a missing model as whatever the endpoint's default happens
+ * to be.
+ */
+import { describe, expect, test } from 'bun:test';
+import { validateRecipe } from '../src/recipe.js';
+
+function recipe(agent: Record<string, unknown>) {
+  return { name: 'compat-test', agent: { systemPrompt: 'sys', ...agent } };
+}
+
+describe('recipe agent.provider openai-compatible', () => {
+  test('accepts an http local endpoint with a model', () => {
+    const r = validateRecipe(recipe({ provider: 'openai-compatible', baseUrl: 'http://localhost:11434/v1', model: 'qwen3:32b' }));
+    expect(r.agent.provider).toBe('openai-compatible');
+    expect(r.agent.baseUrl).toBe('http://localhost:11434/v1');
+    expect(r.agent.model).toBe('qwen3:32b');
+  });
+
+  test('accepts an https gateway', () => {
+    const r = validateRecipe(recipe({ provider: 'openai-compatible', baseUrl: 'https://nano-gpt.com/api/v1', model: 'xiaomi/mimo-v2.5-pro:thinking' }));
+    expect(r.agent.baseUrl).toBe('https://nano-gpt.com/api/v1');
+  });
+
+  test('requires baseUrl', () => {
+    expect(() => validateRecipe(recipe({ provider: 'openai-compatible', model: 'm' }))).toThrow(/agent\.baseUrl is required/);
+    expect(() => validateRecipe(recipe({ provider: 'openai-compatible', baseUrl: '   ', model: 'm' }))).toThrow(/agent\.baseUrl is required/);
+  });
+
+  test('requires an absolute http(s) URL', () => {
+    expect(() => validateRecipe(recipe({ provider: 'openai-compatible', baseUrl: 'localhost:11434/v1', model: 'm' }))).toThrow(/absolute http\(s\) URL|http or https/);
+    expect(() => validateRecipe(recipe({ provider: 'openai-compatible', baseUrl: 'ftp://host/v1', model: 'm' }))).toThrow(/http or https/);
+  });
+
+  test('requires an explicit model (no default for an arbitrary endpoint)', () => {
+    expect(() => validateRecipe(recipe({ provider: 'openai-compatible', baseUrl: 'http://localhost:11434/v1' }))).toThrow(/agent\.model is required/);
+  });
+
+  test('rejects baseUrl with any other provider', () => {
+    expect(() => validateRecipe(recipe({ provider: 'anthropic', baseUrl: 'http://x/v1' }))).toThrow(/only applies to agent\.provider 'openai-compatible'/);
+    expect(() => validateRecipe(recipe({ baseUrl: 'http://x/v1' }))).toThrow(/got provider "anthropic"/);
+    expect(() => validateRecipe(recipe({ provider: 'openai-codex', baseUrl: 'http://x/v1' }))).toThrow(/got provider "openai-codex"/);
+  });
+
+  test('other providers are untouched', () => {
+    expect(validateRecipe(recipe({ provider: 'openai-codex', model: 'gpt-5.4' })).agent.baseUrl).toBeUndefined();
+    expect(validateRecipe(recipe({})).agent.provider ?? 'anthropic').toBe('anthropic');
+  });
+});


### PR DESCRIPTION
## Problem

membrane ships `OpenAICompatibleAdapter` — a generic chat-completions transport whose own header names Ollama, vLLM, Together, Groq and local inference servers as its purpose — and no host ever wired it. Recipes had no way to run a local model or an OpenAI-compatible gateway short of abusing another provider's transport (e.g. pointing the OpenRouter adapter's base URL elsewhere, which mislabels the provider in the ledger and sends OpenRouter-specific headers).

## Changes

- **`agent.provider: 'openai-compatible'`**, constructing membrane's `OpenAICompatibleAdapter` wrapped in `LoggingProviderAdapter` like codex/openrouter, so `llm-calls.jsonl` records the provider truthfully.
- **`agent.baseUrl`** names the endpoint. Validated at load as an absolute http(s) URL; required for this provider; rejected with any other provider (those keep their `ANTHROPIC_BASE_URL` / `OPENAI_BASE_URL` / `BEDROCK_BASE_URL` env overrides).
- **`agent.model` is required** for this provider — there is no sensible default model for an arbitrary endpoint (fails at load, not as whatever the endpoint's default happens to be).
- Key from **`OPENAI_COMPATIBLE_API_KEY` only** — deliberately no `OPENAI_API_KEY` fallback: `baseUrl` is recipe-controlled, so a fallback would silently send a real OpenAI credential as a Bearer token to whatever endpoint a recipe names. Optional because local servers have none.
- README section + env-table row; changelog fragment.

Independent of #107 (`agent.retry` / `requestTimeoutMs`) semantically; mechanically, both insert their validation block at the same `recipe.ts` anchor, so whichever lands second rebases through a one-hunk keep-both conflict (the combined state runs green — verified in review).

## Tests

- New `test/recipe-openai-compatible.test.ts` (7): accepts http local + https gateway; requires `baseUrl`, absolute http(s), explicit `model`; rejects `baseUrl` with any other provider; other providers untouched.
- `bun test` (rebased on current `main`, deps via `bun.lock`): **735 pass / 4 fail on native Windows** — the 4 are the environment-specific cases that do not reproduce on macOS/Linux. `bunx tsc --noEmit`: **0 errors**.
- **Live**: a recipe with `provider: openai-compatible`, `baseUrl: https://nano-gpt.com/api/v1`, `model: xiaomi/mimo-v2.5-pro:thinking` booted headless, answered a WebSocket user message, and the ledger recorded `provider: openai-compatible | model: xiaomi/mimo-v2.5-pro:thinking`.

## Not verified

- Only one endpoint exercised live (NanoGPT). Ollama / vLLM / Groq share the same chat-completions surface but were not run.
- Native tool calls depend on the endpoint supporting `tool_calls`; not exercised live (the smoke recipe had no MCP servers).
- Prompt-cache accounting depends on what the endpoint reports in `usage`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
