### PR TITLE
Stamp compression debt (x-gate-debt-chunks) onto gate-bound calls

### DIFF
--- a/changelog.d/debt-stamp-header.added.md
+++ b/changelog.d/debt-stamp-header.added.md
@@ -1,0 +1,5 @@
+- Gate-bound Anthropic calls carry an `x-gate-debt-chunks` header with the
+  live compression-debt pending-chunk count (membrane `dynamicHeaders`,
+  antra-tess/membrane#65) — the gateway records it per ledger row and strips
+  it before the vendor; unreadable state sends no header rather than a guess
+  (#109).

--- a/changelog.d/debt-stamp-header.added.md
+++ b/changelog.d/debt-stamp-header.added.md
@@ -1,5 +1,6 @@
 - Gate-bound Anthropic calls carry an `x-gate-debt-chunks` header with the
   live compression-debt pending-chunk count (membrane `dynamicHeaders`,
   antra-tess/membrane#65) — the gateway records it per ledger row and strips
-  it before the vendor; unreadable state sends no header rather than a guess
-  (#109).
+  it before the vendor. Double-gated on `GATE_TELEMETRY=1` AND a configured
+  `ANTHROPIC_BASE_URL`, so the stamp can never reach a vendor endpoint;
+  unreadable state sends no header rather than a guess (#109).

--- a/src/gate-telemetry.ts
+++ b/src/gate-telemetry.ts
@@ -1,0 +1,31 @@
+/**
+ * Household-gateway telemetry headers (x-gate-* stamps).
+ *
+ * The data boundary these headers exist under: a household inference gateway
+ * records them into its ledger and STRIPS them before the vendor — the vendor
+ * must never see them. That boundary is only real if the host refuses to
+ * attach the stamps anywhere else, so attachment is double-gated:
+ *
+ *   1. `GATE_TELEMETRY=1` — the operator's explicit declaration that the
+ *      configured base URL is such a gateway. Absent/false ⇒ never attach.
+ *   2. `ANTHROPIC_BASE_URL` actually set — the flag alone must not stamp
+ *      traffic that would go to the vendor's default endpoint.
+ *
+ * Fail-closed on both (review finding on the first wiring: the stamp was
+ * attached unconditionally, so with no base URL configured the value went
+ * straight to the vendor).
+ */
+
+/** Truthy env-flag parse: unset/''/'0'/'false' (any case) are off. */
+function envFlag(value: string | undefined): boolean {
+  return value !== undefined && value !== '' && value !== '0' && value.toLowerCase() !== 'false';
+}
+
+export function gateTelemetryHeaders(
+  env: Record<string, string | undefined>,
+  pendingDebtChunks: () => number | null,
+): (() => Record<string, number | null>) | undefined {
+  if (!envFlag(env.GATE_TELEMETRY)) return undefined;
+  if (!env.ANTHROPIC_BASE_URL) return undefined;
+  return () => ({ 'x-gate-debt-chunks': pendingDebtChunks() });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ import {
 } from '@animalabs/membrane';
 import { LoggingAnthropicAdapter } from './logging-adapter.js';
 import { LoggingProviderAdapter } from './logging-provider-wrapper.js';
+import { gateTelemetryHeaders } from './gate-telemetry.js';
 import { LoggingBedrockAdapter } from './logging-bedrock-adapter.js';
 import { CodexSubscriptionAdapter } from './codex-subscription-adapter.js';
 import { CallLedger } from './call-ledger.js';
@@ -945,6 +946,8 @@ async function main() {
     }
   };
 
+  const gateTelemetryDynamicHeaders = gateTelemetryHeaders(process.env, pendingDebtChunks);
+
   const adapter = provider === 'openai-responses'
     ? new LoggingProviderAdapter(
         new OpenAIResponsesAPIAdapter({
@@ -982,11 +985,15 @@ async function main() {
                   : {}),
               }),
           baseURL: process.env.ANTHROPIC_BASE_URL || undefined,
+          // Double-gated (see src/gate-telemetry.ts): GATE_TELEMETRY=1 AND a
+          // configured base URL, so the stamp can only ever go to a
+          // gateway the operator has declared — never to the vendor's
+          // default endpoint (review finding on the first wiring).
           // Cast note: @animalabs/membrane on npm (0.5.80) predates the
           // dynamicHeaders field (antra-tess/membrane#65); drop the cast when
           // the release lands. Harmless either way — an older membrane
           // ignores unknown config keys.
-          ...({ dynamicHeaders: () => ({ 'x-gate-debt-chunks': pendingDebtChunks() }) } as object),
+          ...(gateTelemetryDynamicHeaders ? ({ dynamicHeaders: gateTelemetryDynamicHeaders } as object) : {}),
           // Hold this agent's cached prefix warm across idle gaps. Only fires
           // when the entry is actually near expiry, so a busy agent costs
           // nothing; only the 1h-TTL primary lane is eligible (the module

--- a/src/index.ts
+++ b/src/index.ts
@@ -920,6 +920,31 @@ async function main() {
           : {}),
       })
     : undefined;
+  // -- x-gate-debt-chunks stamp (membrane dynamicHeaders, antra-tess/membrane#65)
+  // The gate records compression-debt per ledger row; debt only changes at
+  // calls, so the per-call series is its full-resolution history ("spoke ->
+  // chunk appeared -> chewed" vs "solver repacked -> queue spiked"). The value
+  // is the SAME reduction /healthz reports (cm getCompressionDebt). Late-bound
+  // through appRef because the framework outlives adapter construction and is
+  // replaced on session switch. Whenever it is unreadable — no framework yet,
+  // multi-agent process (whose debt would we even claim?), no strategy — the
+  // header is simply not sent: an unstamped call is honest, a guessed one lies.
+  let appRefForDebt: AppContext | null = null;
+  const pendingDebtChunks = (): number | null => {
+    try {
+      const agents = appRefForDebt?.framework.getAllAgents() ?? [];
+      if (agents.length !== 1) return null;
+      const strategy = (agents[0] as unknown as {
+        getContextManager?: () => { getStrategy?: () => { getCompressionDebt?: () => unknown } };
+      }).getContextManager?.()?.getStrategy?.();
+      const d = strategy?.getCompressionDebt?.() as { pendingChunks?: unknown } | undefined;
+      const n = d?.pendingChunks;
+      return typeof n === 'number' && Number.isFinite(n) && n >= 0 ? Math.round(n) : null;
+    } catch {
+      return null;
+    }
+  };
+
   const adapter = provider === 'openai-responses'
     ? new LoggingProviderAdapter(
         new OpenAIResponsesAPIAdapter({
@@ -957,6 +982,11 @@ async function main() {
                   : {}),
               }),
           baseURL: process.env.ANTHROPIC_BASE_URL || undefined,
+          // Cast note: @animalabs/membrane on npm (0.5.80) predates the
+          // dynamicHeaders field (antra-tess/membrane#65); drop the cast when
+          // the release lands. Harmless either way — an older membrane
+          // ignores unknown config keys.
+          ...({ dynamicHeaders: () => ({ 'x-gate-debt-chunks': pendingDebtChunks() }) } as object),
           // Hold this agent's cached prefix warm across idle gaps. Only fires
           // when the entry is actually near expiry, so a busy agent costs
           // nothing; only the 1h-TTL primary lane is eligible (the module
@@ -1064,6 +1094,8 @@ async function main() {
       getWebUiModule(this.framework)?.setApp(this);
     },
   };
+
+  appRefForDebt = app;
 
   // Off-path refusal dragnet → ops alerts (observability M3): refusals on
   // non-streamed calls (compression/summarizer drains, maintenance) never

--- a/test/gate-telemetry.test.ts
+++ b/test/gate-telemetry.test.ts
@@ -1,0 +1,34 @@
+/**
+ * The x-gate-* stamp must be impossible to send to a vendor: attachment is
+ * double-gated on the operator's explicit GATE_TELEMETRY declaration AND a
+ * configured base URL. Review finding on the first wiring: the stamp was
+ * attached unconditionally, so with ANTHROPIC_BASE_URL unset the household
+ * value went to the vendor's default endpoint.
+ */
+import { describe, expect, it } from 'bun:test';
+import { gateTelemetryHeaders } from '../src/gate-telemetry.js';
+
+const debt = () => 7;
+
+describe('gateTelemetryHeaders', () => {
+  it('default vendor endpoint (no base URL): never attaches, even when flagged', () => {
+    expect(gateTelemetryHeaders({ GATE_TELEMETRY: '1' }, debt)).toBeUndefined();
+  });
+
+  it('base URL without the operator declaration: never attaches', () => {
+    expect(gateTelemetryHeaders({ ANTHROPIC_BASE_URL: 'https://gateway.example/anthropic' }, debt)).toBeUndefined();
+    expect(gateTelemetryHeaders({ GATE_TELEMETRY: '0', ANTHROPIC_BASE_URL: 'https://gateway.example/anthropic' }, debt)).toBeUndefined();
+    expect(gateTelemetryHeaders({ GATE_TELEMETRY: 'false', ANTHROPIC_BASE_URL: 'https://gateway.example/anthropic' }, debt)).toBeUndefined();
+  });
+
+  it('declared gateway: attaches a live stamp', () => {
+    const fn = gateTelemetryHeaders({ GATE_TELEMETRY: '1', ANTHROPIC_BASE_URL: 'https://gateway.example/anthropic' }, debt);
+    expect(fn).toBeDefined();
+    expect(fn!()).toEqual({ 'x-gate-debt-chunks': 7 });
+  });
+
+  it('unreadable debt stays null (membrane drops null values — unstamped, never guessed)', () => {
+    const fn = gateTelemetryHeaders({ GATE_TELEMETRY: '1', ANTHROPIC_BASE_URL: 'https://gateway.example/anthropic' }, () => null);
+    expect(fn!()).toEqual({ 'x-gate-debt-chunks': null });
+  });
+});


### PR DESCRIPTION
Host half of the per-call compression-debt telemetry (scope: debt only; attribution-style headers deliberately excluded pending a separate consent decision).

- Reads the same `cm getCompressionDebt().pendingChunks` reduction `/healthz` reports, late-bound via the app context (survives session switches).
- Sends it through membrane's new `dynamicHeaders` (antra-tess/membrane#65) as `x-gate-debt-chunks`; the gateway records it per ledger row (receiver + dashboard sparkline already deployed) and strips it before the vendor.
- Fail-honest: no framework / multi-agent process / no strategy → no header, never a guess. Keepalive replays never carry a stale stamp (contract tested on the membrane side).
- No-op until the membrane release lands — older membrane ignores unknown config keys, so merge order is free.
- Anthropic adapter only; bedrock path is a named follow-up.

Why per-call: debt only changes at calls, so the per-call series is its full-resolution history — it distinguishes "spoke → chunk appeared → compression chewed it" from "a repack spiked the queue".

`tsc --noEmit` clean, `bun test` 732 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)