### PR TITLE
fix: QA command family (multi-word names, delete confirm, in-flight guard, mcp env) + honest HTTP errors + count_tokens model

### DIFF
--- a/changelog.d/qa-command-family.fixed.md
+++ b/changelog.d/qa-command-family.fixed.md
@@ -1,0 +1,25 @@
+- Name-taking commands (`/checkpoint`, `/restore`, `/checkout`,
+  `/session switch`, `/session delete`) parse the rest of the line instead of
+  only the first token, so multi-word names round-trip with
+  `/session rename` instead of silently truncating (`/checkpoint my test
+  point` used to save a checkpoint named `my`).
+- `/session delete` requires `--confirm`: the bare command echoes exactly
+  which session matched (name, id, message count) before anything
+  irreversible happens. `/help` documents that switch/delete accept ids.
+- Head-moving commands (`/undo`, `/redo`, `/checkout`, `/restore`,
+  `/branchto`, `/newtopic`) are refused while a turn is in flight — moving
+  the head mid-stream committed the streaming reply onto the wrong branch,
+  detached from its request (orphaned Chronicle nodes), including when the
+  move came from a second client on the same session.
+- `/mcp add` on an existing server preserves its env vars and `toolPrefix`
+  (and reports the kept env keys); previously a command update silently
+  wiped the server's env, which only surfaced when the server next started
+  without its tokens.
+- Checkpoints are visible: `/branches` lists them alongside branches, and
+  bare `/checkpoint` lists existing checkpoints (matching bare `/restore`).
+- `/budget` displays small values exactly instead of flooring to `0k`
+  (`/budget 50` used to report "set to 0k" while rejecting `/budget 0`).
+- `/clear` clears the WebUI transcript view (client-side, like the TUI's
+  scrollback wipe) instead of appending a "(cleared)" line while clearing
+  nothing; `/help` and the headless reply now say what `/clear` actually
+  does — display only, history and context kept.

--- a/changelog.d/qa-honest-http-errors.fixed.md
+++ b/changelog.d/qa-honest-http-errors.fixed.md
@@ -1,0 +1,12 @@
+- The WebUI HTTP surface answers honestly: unknown `/debug/*` paths (typos,
+  casing, trailing slashes) return a JSON 404 instead of the SPA shell with
+  a 200; missing `/assets/*` files return 404 instead of HTML (which
+  produced a blank page with a MIME error on stale bundle hashes); non-GET
+  methods get 405 with an `Allow` header. SPA client-side routes still fall
+  back to the shell.
+- The context-makeup panel's exact token count calls `count_tokens` with the
+  model the agent actually runs (provider/Bedrock prefixes normalized away)
+  instead of a hardcoded id that 404'd on every install and silently nulled
+  `exactTotalTokens`. `COUNT_TOKENS_MODEL` remains as an explicit override;
+  non-Anthropic models report `count_tokens_unsupported_model` instead of
+  counting against the wrong tokenizer.

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -121,6 +121,35 @@ function getAgentCM(framework: AgentFramework, agentName?: string): ContextManag
   return all[0]?.getContextManager() ?? null;
 }
 
+/**
+ * Refuse head-moving commands while the main agent's turn is in flight.
+ *
+ * Moving the Chronicle head (undo/redo/checkout/restore/branchto/newtopic)
+ * is not atomic with respect to a streaming generation: the in-flight reply
+ * commits onto whatever branch is current WHEN IT COMPLETES, so a head move
+ * mid-stream detaches the reply from its request — it lands on the new
+ * branch attached to the wrong parent (orphaned node), including when the
+ * move is issued from a second client on the same session. The supported
+ * sequence is: stop the generation, then move the head.
+ *
+ * Returns null when the command may proceed. Agents without a state field
+ * (stubs, minimal harnesses) are treated as idle.
+ */
+function inFlightGuard(app: AppContext, cmd: string): CommandResult | null {
+  const framework = app.framework;
+  const agent = (app.agentName ? framework.getAgent(app.agentName) : undefined)
+    ?? framework.getAllAgents()[0];
+  const status = (agent as { state?: { status?: string } } | undefined)?.state?.status;
+  if (status === undefined || status === 'idle') return null;
+  return {
+    lines: [
+      { text: `/${cmd} refused: a turn is in flight (${(agent as { name?: string }).name ?? 'agent'}: ${status}).`, style: 'system' },
+      { text: '  Moving the head mid-generation would attach the streaming reply to the wrong', style: 'system' },
+      { text: '  branch/request. Stop the generation first, then retry.', style: 'system' },
+    ],
+  };
+}
+
 export function handleCommand(command: string, app: AppContext): CommandResult {
   const parts = command.slice(1).split(/\s+/);
   const cmd = parts[0]!;
@@ -147,16 +176,16 @@ export function handleCommand(command: string, app: AppContext): CommandResult {
           { text: '--- Commands ---', style: 'system' },
           { text: '  /quit, /q              Exit the app', style: 'system' },
           { text: '  /status                Show agent status', style: 'system' },
-          { text: '  /clear                 Clear conversation', style: 'system' },
+          { text: '  /clear                 Clear this client\'s display (history/context are kept)', style: 'system' },
           { text: '  /lessons               Show lesson library', style: 'system' },
           { text: '  /export                Export lessons to ./output/ (JSON + markdown)', style: 'system' },
           { text: '  /undo                  Revert last agent turn', style: 'system' },
           { text: '  /redo                  Re-apply undone action', style: 'system' },
           { text: '  /nudge [agent]         Run inference on current context (no new events)', style: 'system' },
           { text: '  /puppet <tool> [json]  Admin: execute a tool AS the agent, store the pair', style: 'system' },
-          { text: '  /checkpoint <name>     Save current state', style: 'system' },
-          { text: '  /restore <name>        Restore to checkpoint', style: 'system' },
-          { text: '  /branches              List Chronicle branches', style: 'system' },
+          { text: '  /checkpoint [name]     Save current state (no name: list checkpoints)', style: 'system' },
+          { text: '  /restore [name]        Restore to checkpoint (no name: list checkpoints)', style: 'system' },
+          { text: '  /branches              List Chronicle branches and checkpoints', style: 'system' },
           { text: '  /checkout <name>       Switch to branch', style: 'system' },
           { text: '  /history [n]           Show state transitions (last n)', style: 'system' },
           { text: '  /find <text>           Search messages for text', style: 'system' },
@@ -170,9 +199,9 @@ export function handleCommand(command: string, app: AppContext): CommandResult {
           { text: '  /session               Show current session', style: 'system' },
           { text: '  /session list          List all sessions', style: 'system' },
           { text: '  /session new [name]    Create new session', style: 'system' },
-          { text: '  /session switch <name> Switch to session', style: 'system' },
+          { text: '  /session switch <name or id> Switch to session', style: 'system' },
           { text: '  /session rename <name> Rename current session', style: 'system' },
-          { text: '  /session delete <name> Delete a session', style: 'system' },
+          { text: '  /session delete <name or id> --confirm  Delete a session (irreversible)', style: 'system' },
           { text: '  /recipe                Show current recipe info', style: 'system' },
           { text: '  /newtopic [context]    Reset head window (auto-summarize if empty)', style: 'system' },
           { text: '  /usage                 Show session token usage and costs', style: 'system' },
@@ -182,7 +211,12 @@ export function handleCommand(command: string, app: AppContext): CommandResult {
       };
 
     case 'clear':
-      return { lines: [{ text: '(cleared)', style: 'system' }] };
+      // Display-clearing is client-side: the TUI wipes its scrollback and
+      // the SPA wipes its transcript view before this handler is ever
+      // reached. This line is only seen by surfaces with no display to
+      // clear (headless), where it honestly reports that nothing else —
+      // Chronicle, context — was touched.
+      return { lines: [{ text: '(display cleared on clients; history and context are kept)', style: 'system' }] };
 
     case 'status':
       return handleStatus(framework);
@@ -194,7 +228,7 @@ export function handleCommand(command: string, app: AppContext): CommandResult {
       return handleExport(app);
 
     case 'undo':
-      return handleUndo(app);
+      return inFlightGuard(app, cmd) ?? handleUndo(app);
 
     case 'nudge':
       return handleNudge(app, args[0]);
@@ -203,25 +237,29 @@ export function handleCommand(command: string, app: AppContext): CommandResult {
       return handlePuppet(app, args);
 
     case 'redo':
-      return handleRedo(app);
+      return inFlightGuard(app, cmd) ?? handleRedo(app);
 
+    // Name-taking commands join the REST of the line, not just the first
+    // token: names may contain spaces (/checkpoint my test point), and
+    // /session rename already accepts multi-word names — parsing them
+    // differently made multi-word names silently truncate here.
     case 'checkpoint':
-      return handleCheckpoint(app, args[0]);
+      return handleCheckpoint(app, args.join(' ') || undefined);
 
     case 'restore':
-      return handleRestore(app, args[0]);
+      return inFlightGuard(app, cmd) ?? handleRestore(app, args.join(' ') || undefined);
 
     case 'branches':
-      return handleBranches(framework);
+      return handleBranches(app);
 
     case 'checkout':
-      return handleCheckout(framework, args[0]);
+      return inFlightGuard(app, cmd) ?? handleCheckout(framework, args.join(' ') || undefined);
 
     case 'history':
       return handleHistory(framework, args[0]);
 
     case 'branchto':
-      return handleBranchTo(app, args[0]);
+      return inFlightGuard(app, cmd) ?? handleBranchTo(app, args[0]);
 
     case 'find':
       return handleFind(framework, args.join(' '));
@@ -242,7 +280,7 @@ export function handleCommand(command: string, app: AppContext): CommandResult {
       return handleRecipe(app);
 
     case 'newtopic':
-      return handleNewTopic(app, args);
+      return inFlightGuard(app, cmd) ?? handleNewTopic(app, args);
 
     case 'usage':
       return handleUsage(app);
@@ -310,12 +348,14 @@ function handleSession(app: AppContext, args: string[]): CommandResult {
       return handleSessionNew(app, args.slice(1).join(' ') || undefined);
     case 'switch':
     case 'sw':
-      return handleSessionSwitch(app, args[1]);
+      // Rest-of-line, matching rename: session names may contain spaces, and
+      // a session renamed to a multi-word name must stay reachable by name.
+      return handleSessionSwitch(app, args.slice(1).join(' ') || undefined);
     case 'rename':
       return handleSessionRename(app, args.slice(1).join(' ') || undefined);
     case 'delete':
     case 'rm':
-      return handleSessionDelete(app, args[1]);
+      return handleSessionDelete(app, args.slice(1));
     default:
       return { lines: [{ text: `Unknown /session subcommand: ${sub}. Try /session list.`, style: 'system' }] };
   }
@@ -411,14 +451,32 @@ function handleSessionRename(app: AppContext, name?: string): CommandResult {
   return { lines: [{ text: `Session renamed to "${name}".`, style: 'system' }] };
 }
 
-function handleSessionDelete(app: AppContext, nameOrId?: string): CommandResult {
+function handleSessionDelete(app: AppContext, args: string[]): CommandResult {
+  // Deletion is irreversible, so it takes an explicit second step: the bare
+  // command shows exactly what matched (name + id + message count) and asks
+  // for --confirm. This also defuses the truncated-name amplifier: a typo'd
+  // or partial name can match a DIFFERENT session, and without the echo the
+  // wrong one died silently.
+  const confirmed = args[args.length - 1] === '--confirm';
+  const nameOrId = (confirmed ? args.slice(0, -1) : args).join(' ') || undefined;
+
   if (!nameOrId) {
-    return { lines: [{ text: 'Usage: /session delete <name or id>', style: 'system' }] };
+    return { lines: [{ text: 'Usage: /session delete <name or id> [--confirm]', style: 'system' }] };
   }
 
   const session = app.sessionManager.findSession(nameOrId);
   if (!session) {
     return { lines: [{ text: `Session "${nameOrId}" not found.`, style: 'system' }] };
+  }
+
+  if (!confirmed) {
+    const msgs = session.messageCount !== undefined ? `, ${session.messageCount} msgs` : '';
+    return {
+      lines: [
+        { text: `Will delete session "${session.name}" [${session.id}]${msgs} — irreversible.`, style: 'system' },
+        { text: `To proceed: /session delete ${session.id} --confirm`, style: 'system' },
+      ],
+    };
   }
 
   try {
@@ -526,14 +584,16 @@ function handleBudget(framework: AgentFramework, arg?: string): CommandResult {
   }
 
   if (!arg) {
-    // Show current budgets
+    // Show current budgets. fmtTokens is exact below 1000 — flooring to "0k"
+    // hid real small values and made the display contradict the validator
+    // (which rejects 0 but accepts 50).
     const lines: Line[] = [{ text: '--- Stream Token Budgets ---', style: 'system' }];
     for (const agent of agents) {
       const budget = agent.maxStreamTokens;
       const last = agent.lastStreamInputTokens;
       const pct = budget > 0 ? ((last / budget) * 100).toFixed(0) : '—';
       lines.push({
-        text: `  ${agent.name}: ${(budget / 1000).toFixed(0)}k (last: ${(last / 1000).toFixed(0)}k, ${pct}%)`,
+        text: `  ${agent.name}: ${fmtTokens(budget)} (last: ${fmtTokens(last)}, ${pct}%)`,
         style: 'system',
       });
     }
@@ -559,12 +619,8 @@ function handleBudget(framework: AgentFramework, arg?: string): CommandResult {
     agent.maxStreamTokens = tokens;
   }
 
-  const display = tokens >= 1_000_000
-    ? `${(tokens / 1_000_000).toFixed(1)}m`
-    : `${(tokens / 1_000).toFixed(0)}k`;
-
   return {
-    lines: [{ text: `Stream budget set to ${display} tokens for all agents.`, style: 'system' }],
+    lines: [{ text: `Stream budget set to ${fmtTokens(tokens)} tokens for all agents.`, style: 'system' }],
   };
 }
 
@@ -838,7 +894,17 @@ function handleRedo(app: AppContext): CommandResult {
 
 function handleCheckpoint(app: AppContext, name?: string): CommandResult {
   if (!name) {
-    return { lines: [{ text: 'Usage: /checkpoint <name>', style: 'system' }] };
+    // Bare /checkpoint lists what exists — same affordance as bare /restore —
+    // so the lifecycle is discoverable from either end.
+    const names = [...app.branchState.checkpoints.keys()];
+    return {
+      lines: [
+        { text: 'Usage: /checkpoint <name>', style: 'system' },
+        ...(names.length > 0
+          ? [{ text: `Saved checkpoints: ${names.join(', ')}`, style: 'system' as const }]
+          : []),
+      ],
+    };
   }
 
   const cm = getAgentCM(app.framework);
@@ -934,8 +1000,8 @@ function handleRestore(app: AppContext, name?: string): CommandResult {
   };
 }
 
-function handleBranches(framework: AgentFramework): CommandResult {
-  const cm = getAgentCM(framework);
+function handleBranches(app: AppContext): CommandResult {
+  const cm = getAgentCM(app.framework);
   if (!cm) return { lines: [{ text: 'No agent context manager.', style: 'system' }] };
 
   const branches = cm.listBranches();
@@ -948,6 +1014,19 @@ function handleBranches(framework: AgentFramework): CommandResult {
       text: `  ${b.name} (head: ${b.head})${marker}`,
       style: 'system',
     });
+  }
+
+  // Checkpoints are positions (branch + message), not branches — but they're
+  // part of the same mental model, and being invisible here made the whole
+  // checkpoint lifecycle run blind: created → not listed anywhere → restored
+  // on faith. Session-scoped, in-memory (cleared on session switch/restart).
+  const cps = [...app.branchState.checkpoints.entries()];
+  if (cps.length > 0) {
+    lines.push({ text: `--- Checkpoints (${cps.length}, this session) ---`, style: 'system' });
+    for (const [name, point] of cps) {
+      const at = point.messageId ? ` @ [${point.messageId}]` : '';
+      lines.push({ text: `  ${name} → ${point.branchName}${at}`, style: 'system' });
+    }
   }
 
   return { lines };
@@ -1137,13 +1216,27 @@ function handleMcpAdd(args: string[]): CommandResult {
 
   const [id, command, ...cmdArgs] = args;
   const servers = readMcplServersFile(DEFAULT_CONFIG_PATH);
-  const isOverwrite = id! in servers;
-  servers[id!] = { command: command!, ...(cmdArgs.length > 0 ? { args: cmdArgs } : {}) };
+  const prev = servers[id!];
+  // Overwrite replaces the command line (command + args, which travel as one
+  // unit) but PRESERVES env and other settings: env is edited via /mcp env
+  // and the panel editor, whose contract is "cleared only by explicit empty
+  // save" — a command update silently dropping tokens/settings broke working
+  // servers in a way that only surfaced at next start.
+  servers[id!] = {
+    ...prev,
+    command: command!,
+    ...(cmdArgs.length > 0 ? { args: cmdArgs } : {}),
+  };
+  if (cmdArgs.length === 0) delete servers[id!]!.args;
   saveMcplServers(DEFAULT_CONFIG_PATH, servers);
 
+  const keptEnv = prev?.env ? Object.keys(prev.env) : [];
   return {
     lines: [
-      { text: `${isOverwrite ? 'Updated' : 'Added'} server "${id}". Restart to apply.`, style: 'system' },
+      { text: `${prev ? 'Updated' : 'Added'} server "${id}". Restart to apply.`, style: 'system' },
+      ...(keptEnv.length > 0
+        ? [{ text: `  (kept env: ${keptEnv.join(', ')})`, style: 'system' as const }]
+        : []),
     ],
   };
 }

--- a/src/modules/web-ui-module.ts
+++ b/src/modules/web-ui-module.ts
@@ -902,6 +902,15 @@ export class WebUiModule implements Module {
 
   private async handleHttp(req: Request, server: ReturnType<typeof Bun.serve>): Promise<Response> {
     const url = new URL(req.url);
+
+    // Every HTTP route here is read-only — mutation happens over the WS.
+    // Wrong methods used to fall through to the same handlers (a POST
+    // /debug/context behaved exactly like the GET), which lies to API
+    // consumers probing the surface.
+    if (req.method !== 'GET' && req.method !== 'HEAD') {
+      return new Response('Method Not Allowed', { status: 405, headers: { allow: 'GET, HEAD' } });
+    }
+
     const isRetrievalTraceRoute = url.pathname === '/debug/retrieval'
       || url.pathname === '/debug/retrieval/view';
 
@@ -1073,9 +1082,20 @@ export class WebUiModule implements Module {
       return this.serveWorkspaceFile(url.pathname.slice('/files/'.length));
     }
 
-    // Static SPA
+    // API namespace exhausted: anything still unmatched under /debug/ is a
+    // typo, wrong casing, or trailing slash — an honest 404 beats the SPA
+    // shell with a 200, which API consumers can't tell from data. (This was
+    // also the mechanism that swallowed real failures like the tokenizer
+    // 404 — the client saw 200/HTML instead of the error.)
+    if (url.pathname.startsWith('/debug/')) {
+      return Response.json({ error: `Unknown debug route: ${url.pathname}` }, { status: 404 });
+    }
+
+    // Static SPA. Bundle assets get real 404s: falling back to index.html
+    // for a missing /assets/*.js serves HTML where the browser expects JS —
+    // a blank page with a MIME error instead of a diagnosable miss.
     const requested = url.pathname === '/' ? '/index.html' : url.pathname;
-    return this.serveStatic(requested);
+    return this.serveStatic(requested, { spaFallback: !url.pathname.startsWith('/assets/') });
   }
 
   /** The minimal app slice the shared panel-data layer needs, or null before
@@ -1281,7 +1301,11 @@ export class WebUiModule implements Module {
     }
   }
 
-  private async serveStatic(requestedPath: string): Promise<Response> {
+  private async serveStatic(
+    requestedPath: string,
+    opts: { spaFallback?: boolean } = {},
+  ): Promise<Response> {
+    const spaFallback = opts.spaFallback ?? true;
     // Path containment: resolve and verify the result is still under staticRoot.
     // Plain startsWith without a separator is unsafe — both `<root>` and
     // `<root>-evil/...` pass `startsWith('<root>')`. The current callers
@@ -1297,11 +1321,15 @@ export class WebUiModule implements Module {
     try {
       const s = await stat(safePath);
       if (s.isDirectory()) {
-        return this.serveStatic(join(requestedPath, 'index.html'));
+        return this.serveStatic(join(requestedPath, 'index.html'), opts);
       }
       const data = await readFile(safePath);
       return new Response(data, { headers: { 'content-type': mimeFor(safePath) } });
     } catch {
+      // Missing bundle assets are honest misses, not SPA routes.
+      if (!spaFallback) {
+        return new Response('Not Found', { status: 404 });
+      }
       // Fall back to index.html so the SPA can handle client-side routing.
       try {
         const indexPath = join(sharedServer!.staticRoot, 'index.html');

--- a/src/web/panel-data.ts
+++ b/src/web/panel-data.ts
@@ -829,6 +829,23 @@ export function buildContextCoverageSnapshot(
   };
 }
 
+/**
+ * Best-effort mapping from an agent's configured model string to a bare
+ * Anthropic API model id for /v1/messages/count_tokens. Handles membrane /
+ * OpenRouter provider prefixes ("anthropic/claude-…", "…/anthropic/claude-…")
+ * and Bedrock ids ("us.anthropic.claude-…-v1:0"). Returns null for
+ * non-Anthropic models — exact counting is unsupported there, and reporting
+ * that honestly beats 404ing against a wrong tokenizer.
+ */
+export function anthropicCountModel(agentModel: string | undefined): string | null {
+  if (!agentModel) return null;
+  let m = agentModel;
+  const slash = m.lastIndexOf('/');
+  if (slash >= 0) m = m.slice(slash + 1);
+  m = m.replace(/^(us|eu|apac)\./, '').replace(/^anthropic\./, '').replace(/-v\d+:\d+$/, '');
+  return m.startsWith('claude') ? m : null;
+}
+
 /** Summary-tree coverage and queued work, with no message or summary text. */
 export function buildContextCoverage(app: PanelAppRef, agentName: string): ContextCoverageSnapshot {
   const agent = requireAgent(app, agentName);
@@ -874,8 +891,15 @@ export async function buildContextMakeup(app: PanelAppRef, agentName: string): P
     : (typeof sysRaw === 'string' ? sysRaw : undefined);
 
   let exactTotalTokens: number | null = null;
-  const countModel = process.env.COUNT_TOKENS_MODEL || 'anthropic/claude-opus-4.5';
+  // Count against the model the agent actually runs, not a hardcoded id:
+  // a stale/foreign id 404s and exact counts silently degrade to null on
+  // every install. COUNT_TOKENS_MODEL stays as an explicit operator override.
+  const countModel = process.env.COUNT_TOKENS_MODEL
+    || anthropicCountModel((agent as { model?: string }).model);
   let countSource = 'count_tokens';
+  if (!countModel) {
+    return { agent: agentName, stats, exactTotalTokens, countModel, countSource: 'count_tokens_unsupported_model' };
+  }
   try {
     const base = (process.env.ANTHROPIC_BASE_URL || 'https://api.anthropic.com').replace(/\/$/, '');
     const res = await fetch(base + '/v1/messages/count_tokens', {

--- a/test/commands-qa-family.test.ts
+++ b/test/commands-qa-family.test.ts
@@ -1,0 +1,239 @@
+import { describe, test, expect, afterEach } from 'bun:test';
+import { existsSync, readFileSync, writeFileSync, unlinkSync } from 'node:fs';
+import { handleCommand, createBranchState } from '../src/commands.js';
+import { DEFAULT_CONFIG_PATH } from '../src/mcpl-config.js';
+
+// Regression tests for the QA-reported command family:
+// - first-token argument parsing truncated multi-word names on
+//   /checkpoint, /restore, /checkout, /session switch, /session delete
+//   (while /session rename accepted them — making renamed sessions
+//   unreachable by name);
+// - /session delete executed irreversibly with no confirmation;
+// - /mcp add on an existing server silently wiped its env vars;
+// - head-moving commands ran while a generation was in flight, letting
+//   the streaming reply commit onto the wrong branch (orphaned nodes);
+// - /budget displayed small values as "0k" (50 → "0k") while rejecting 0.
+
+interface StubMessage { id: string; participant: string; content: unknown[] }
+
+function makeStubWorld(agentStatus: string | undefined = 'idle') {
+  const messagesByBranch = new Map<string, StubMessage[]>([['main', []]]);
+  let currentName = 'main';
+  let msgCounter = 0;
+
+  const cm = {
+    currentBranch: () => ({ id: currentName, name: currentName, head: messagesByBranch.get(currentName)!.length }),
+    listBranches: () => [...messagesByBranch.keys()].map(name => ({ id: name, name, head: messagesByBranch.get(name)!.length })),
+    queryMessages: (_q: unknown) => ({ messages: messagesByBranch.get(currentName)! }),
+    branchAt: (messageId: string, newName: string): string => {
+      const msgs = messagesByBranch.get(currentName)!;
+      const idx = msgs.findIndex(m => m.id === messageId);
+      if (idx === -1) throw new Error(`Message not found: ${messageId}`);
+      messagesByBranch.set(newName, msgs.slice(0, idx + 1));
+      return newName;
+    },
+    switchBranch: async (name: string): Promise<void> => {
+      if (!messagesByBranch.has(name)) throw new Error(`No such branch: ${name}`);
+      currentName = name;
+    },
+  };
+
+  const agent = {
+    name: 'stub-agent',
+    ...(agentStatus !== undefined ? { state: { status: agentStatus } } : {}),
+    getContextManager: () => cm,
+  };
+
+  const deleted: string[] = [];
+  const sessions = [
+    { id: 'aaaa1111', name: 'Renamed Multi Word Name', manuallyNamed: true, createdAt: 't', lastAccessedAt: 't', messageCount: 3 },
+    { id: 'bbbb2222', name: 'other', manuallyNamed: true, createdAt: 't', lastAccessedAt: 't', messageCount: 1 },
+  ];
+
+  const app = {
+    framework: {
+      getAgent: () => undefined,
+      getAllAgents: () => [agent],
+      getAllModules: () => [],
+    },
+    sessionManager: {
+      listSessions: () => sessions,
+      getActiveSession: () => sessions[1],
+      findSession: (nameOrId: string) =>
+        sessions.find(s => s.id === nameOrId || s.id.startsWith(nameOrId) || s.name === nameOrId),
+      deleteSession: (id: string) => { deleted.push(id); },
+    },
+    branchState: createBranchState(),
+  } as any;
+
+  const addMessage = (participant = 'user'): StubMessage => {
+    const msg: StubMessage = { id: `m${++msgCounter}`, participant, content: [] };
+    messagesByBranch.get(currentName)!.push(msg);
+    return msg;
+  };
+
+  const text = (r: { lines: Array<{ text: string }> }) => r.lines.map(l => l.text).join('\n');
+
+  return { cm, app, addMessage, deleted, text, currentName: () => currentName };
+}
+
+describe('multi-word names: rest-of-line parsing', () => {
+  test('/checkpoint saves the full multi-word name', () => {
+    const { app, addMessage } = makeStubWorld();
+    addMessage(); addMessage('agent');
+    handleCommand('/checkpoint my test point', app);
+    expect(app.branchState.checkpoints.has('my test point')).toBe(true);
+    expect(app.branchState.checkpoints.has('my')).toBe(false);
+  });
+
+  test('/restore finds a multi-word checkpoint', async () => {
+    const { app, addMessage, text } = makeStubWorld();
+    addMessage(); addMessage('agent');
+    handleCommand('/checkpoint some check point', app);
+    addMessage(); addMessage('agent');
+    const r = handleCommand('/restore some check point', app);
+    expect(text(r)).not.toContain('not found');
+    await r.asyncWork;
+  });
+
+  test('/session switch reaches a multi-word-renamed session', () => {
+    const { app, text } = makeStubWorld();
+    const r = handleCommand('/session switch Renamed Multi Word Name', app);
+    expect(text(r)).toContain('Switching to session');
+    expect(r.switchToSessionId).toBe('aaaa1111');
+  });
+
+  test('/checkout passes the full name through (not found reported honestly)', () => {
+    const { app, text } = makeStubWorld();
+    const r = handleCommand('/checkout my branch name', app);
+    expect(text(r)).toContain('Branch "my branch name" not found');
+  });
+});
+
+describe('/session delete confirmation', () => {
+  test('bare delete shows the match and asks for --confirm, deletes nothing', () => {
+    const { app, deleted, text } = makeStubWorld();
+    const r = handleCommand('/session delete other', app);
+    expect(deleted).toEqual([]);
+    expect(text(r)).toContain('irreversible');
+    expect(text(r)).toContain('--confirm');
+    expect(text(r)).toContain('bbbb2222');
+  });
+
+  test('delete with --confirm deletes', () => {
+    const { app, deleted } = makeStubWorld();
+    handleCommand('/session delete other --confirm', app);
+    expect(deleted).toEqual(['bbbb2222']);
+  });
+
+  test('multi-word name + --confirm parses both correctly', () => {
+    const { app, deleted } = makeStubWorld();
+    handleCommand('/session delete Renamed Multi Word Name --confirm', app);
+    expect(deleted).toEqual(['aaaa1111']);
+  });
+});
+
+describe('in-flight guard on head-moving commands', () => {
+  for (const cmd of ['/undo', '/redo', '/checkout main', '/newtopic', '/branchto m1']) {
+    test(`${cmd} is refused while streaming`, () => {
+      const { app, addMessage, text } = makeStubWorld('streaming');
+      addMessage(); addMessage('agent');
+      const r = handleCommand(cmd, app);
+      expect(text(r)).toContain('refused: a turn is in flight');
+      expect(r.asyncWork).toBeUndefined();
+    });
+  }
+
+  test('/undo proceeds when idle', () => {
+    const { app, addMessage, text } = makeStubWorld('idle');
+    addMessage(); addMessage('agent');
+    const r = handleCommand('/undo', app);
+    expect(text(r)).toContain('Undoing');
+  });
+
+  test('agents without state (stubs) are treated as idle', () => {
+    const { app, addMessage, text } = makeStubWorld(undefined);
+    addMessage(); addMessage('agent');
+    const r = handleCommand('/undo', app);
+    expect(text(r)).toContain('Undoing');
+  });
+});
+
+describe('checkpoint visibility', () => {
+  test('/branches lists checkpoints alongside branches', () => {
+    const { app, addMessage, text } = makeStubWorld();
+    addMessage(); addMessage('agent');
+    handleCommand('/checkpoint visible point', app);
+    const r = handleCommand('/branches', app);
+    expect(text(r)).toContain('Checkpoints (1');
+    expect(text(r)).toContain('visible point');
+  });
+
+  test('bare /checkpoint lists existing checkpoints', () => {
+    const { app, addMessage, text } = makeStubWorld();
+    addMessage(); addMessage('agent');
+    handleCommand('/checkpoint alpha', app);
+    const r = handleCommand('/checkpoint', app);
+    expect(text(r)).toContain('alpha');
+  });
+});
+
+describe('/budget honest display', () => {
+  function makeBudgetApp(maxStreamTokens: number, last = 0) {
+    return {
+      framework: {
+        getAgent: () => undefined,
+        getAllAgents: () => [{ name: 'a', maxStreamTokens, lastStreamInputTokens: last, getContextManager: () => null }],
+        getAllModules: () => [],
+      },
+      branchState: createBranchState(),
+    } as any;
+  }
+
+  test('small values display exactly, not as 0k', () => {
+    const app = makeBudgetApp(1000);
+    const r = handleCommand('/budget 50', app);
+    expect(r.lines[0]!.text).toContain('50 tokens');
+    expect(r.lines[0]!.text).not.toContain('0k');
+  });
+
+  test('show branch displays small budgets exactly', () => {
+    const app = makeBudgetApp(50, 12);
+    const r = handleCommand('/budget', app);
+    expect(r.lines.map(l => l.text).join('\n')).toContain('a: 50 (last: 12');
+  });
+});
+
+describe('/mcp add preserves env on overwrite', () => {
+  // handleMcp* read/write DEFAULT_CONFIG_PATH (cwd/mcpl-servers.json, which
+  // is gitignored). Skip rather than clobber if a real config exists.
+  const hadFile = existsSync(DEFAULT_CONFIG_PATH);
+  const original = hadFile ? readFileSync(DEFAULT_CONFIG_PATH, 'utf-8') : null;
+
+  afterEach(() => {
+    if (original !== null) writeFileSync(DEFAULT_CONFIG_PATH, original);
+    else if (existsSync(DEFAULT_CONFIG_PATH)) unlinkSync(DEFAULT_CONFIG_PATH);
+  });
+
+  test('overwriting the command keeps env vars and reports them', () => {
+    const app = { framework: { getAllAgents: () => [], getAllModules: () => [] }, branchState: createBranchState() } as any;
+    handleCommand('/mcp add envtest echo hello', app);
+    handleCommand('/mcp env envtest FOO=bar SECRET=hunter2', app);
+    const r = handleCommand('/mcp add envtest echo goodbye', app);
+
+    const saved = JSON.parse(readFileSync(DEFAULT_CONFIG_PATH, 'utf-8')).mcplServers;
+    expect(saved.envtest.env).toEqual({ FOO: 'bar', SECRET: 'hunter2' });
+    expect(saved.envtest.command).toBe('echo');
+    expect(saved.envtest.args).toEqual(['goodbye']);
+    expect(r.lines.map(l => l.text).join('\n')).toContain('kept env: FOO, SECRET');
+  });
+
+  test('old args are dropped when the new command line has none', () => {
+    const app = { framework: { getAllAgents: () => [], getAllModules: () => [] }, branchState: createBranchState() } as any;
+    handleCommand('/mcp add argtest echo one two', app);
+    handleCommand('/mcp add argtest ls', app);
+    const saved = JSON.parse(readFileSync(DEFAULT_CONFIG_PATH, 'utf-8')).mcplServers;
+    expect(saved.argtest.command).toBe('ls');
+    expect(saved.argtest.args).toBeUndefined();
+  });
+});

--- a/test/count-tokens-model.test.ts
+++ b/test/count-tokens-model.test.ts
@@ -1,0 +1,31 @@
+import { describe, test, expect } from 'bun:test';
+import { anthropicCountModel } from '../src/web/panel-data.js';
+
+// Regression: the makeup panel's exact token count used to call count_tokens
+// with a hardcoded provider-prefixed id, which the Anthropic endpoint 404s —
+// so exactTotalTokens was silently null on every install. The count model is
+// now derived from the model the agent actually runs.
+
+describe('anthropicCountModel', () => {
+  test('strips a membrane/OpenRouter provider prefix', () => {
+    expect(anthropicCountModel('anthropic/claude-opus-4-6')).toBe('claude-opus-4-6');
+  });
+
+  test('passes a bare Anthropic id through', () => {
+    expect(anthropicCountModel('claude-sonnet-5')).toBe('claude-sonnet-5');
+  });
+
+  test('normalizes a Bedrock id (region + vendor prefix + version suffix)', () => {
+    expect(anthropicCountModel('us.anthropic.claude-3-sonnet-20240229-v1:0'))
+      .toBe('claude-3-sonnet-20240229');
+  });
+
+  test('returns null for non-Anthropic models', () => {
+    expect(anthropicCountModel('openai/gpt-5.6-sol')).toBeNull();
+    expect(anthropicCountModel('gemini-2.5-pro')).toBeNull();
+  });
+
+  test('returns null for undefined', () => {
+    expect(anthropicCountModel(undefined)).toBeNull();
+  });
+});

--- a/test/web-ui-module.test.ts
+++ b/test/web-ui-module.test.ts
@@ -330,6 +330,47 @@ describe('WebUiModule HTTP', () => {
     const body = res.status < 500 ? await res.text() : '';
     expect(body).not.toContain('pwned');
   });
+
+  // Honest-error regression set: unknown API routes and missing bundle
+  // assets used to fall through to the SPA shell with a 200, and wrong
+  // methods executed the GET handlers.
+
+  test('unknown /debug/* route returns a JSON 404, not the SPA shell', async () => {
+    for (const path of ['/debug/context/', '/debug/CONTEXT', '/debug/nonexistent']) {
+      const res = await fetch(`http://127.0.0.1:${handle.port}${path}`, {
+        headers: { authorization: basicAuthHeader(BASIC_USER, BASIC_PASS) },
+      });
+      expect(res.status).toBe(404);
+      expect(res.headers.get('content-type')).toContain('application/json');
+    }
+  });
+
+  test('missing /assets/* returns 404, not HTML', async () => {
+    const res = await fetch(`http://127.0.0.1:${handle.port}/assets/nonexistent.js`, {
+      headers: { authorization: basicAuthHeader(BASIC_USER, BASIC_PASS) },
+    });
+    expect(res.status).toBe(404);
+    expect(res.headers.get('content-type') ?? '').not.toContain('text/html');
+  });
+
+  test('non-GET methods get 405 with Allow header', async () => {
+    for (const method of ['POST', 'DELETE', 'PUT']) {
+      const res = await fetch(`http://127.0.0.1:${handle.port}/debug/context`, {
+        method,
+        headers: { authorization: basicAuthHeader(BASIC_USER, BASIC_PASS) },
+      });
+      expect(res.status).toBe(405);
+      expect(res.headers.get('allow')).toContain('GET');
+    }
+  });
+
+  test('SPA client-side routes still fall back to the shell', async () => {
+    const res = await fetch(`http://127.0.0.1:${handle.port}/totally/fake/route`, {
+      headers: { authorization: basicAuthHeader(BASIC_USER, BASIC_PASS) },
+    });
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain('<!doctype html>');
+  });
 });
 
 describe('WebUiModule WebSocket', () => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1058,6 +1058,15 @@ export function App() {
     if (!text) return;
     setDraft('');
     if (text.startsWith('/')) {
+      // /clear is display-local (the TUI clears its scrollback the same
+      // way): wipe this client's transcript view without touching the
+      // Chronicle or other clients. Sending it to the host was a no-op
+      // that APPENDED a "(cleared)" line — the opposite of clearing.
+      if (text === '/clear' || text.startsWith('/clear ')) {
+        setMessages(produce((arr) => { arr.length = 0; }));
+        setStreamLines([]);
+        return;
+      }
       wire.send({ type: 'command', command: text });
       return;
     }


### PR DESCRIPTION
Fixes for eight findings from the QA track (staging tracker: qa-staging #2, #3, #5, #9, #10, #11, #12, #14, #18, #19-display).

## Command surface (src/commands.ts)

- **Rest-of-line parsing** for name-taking commands: `/checkpoint`, `/restore`, `/checkout`, `/session switch`, `/session delete`. First-token parsing truncated multi-word names — silently for the destructive `/checkpoint` case — and a session renamed to a multi-word name (rename already joined the line) became unreachable by name. (staging #3, #15-adjacent)
- **`/session delete` requires `--confirm`** and first echoes exactly which session matched (name + id + message count). Typo → truncated-name match → no confirmation → irreversible delete was a one-step data-loss path. (staging #9)
- **In-flight guard**: `/undo /redo /checkout /restore /branchto /newtopic` are refused while the main agent's turn is in flight. A head move mid-stream let the completing reply commit onto the new branch attached to the wrong parent — orphaned Chronicle nodes — including when the move came from a second client on the same session. Matches the intended "stop first, then move" semantics. (staging #2 both facets, #14)
- **`/mcp add` preserves env + toolPrefix on overwrite** and reports the kept env keys. A command-line update silently wiped a working server's env; the miss only surfaced at next start. (staging #18)
- **Checkpoint lifecycle observable**: `/branches` lists checkpoints (name → branch @ position), bare `/checkpoint` lists existing ones like bare `/restore` does. (staging #10)
- **`/budget` honest display**: small values render exactly (`50`) instead of flooring to `0k` — which contradicted the validator that rejects `0`. Display-only; the enforcement question is filed separately upstream. (staging #19, display half)
- **`/clear`**: the SPA now clears its transcript view client-side (same semantics as the TUI's scrollback wipe) instead of sending a no-op that *appended* a "(cleared)" line; `/help` and the headless reply say what it actually does — display only, history/context kept. (staging #5)

## HTTP surface (web-ui-module)

- Unknown `/debug/*` paths (typos, casing, trailing slash) → JSON **404** instead of 200 + SPA shell — the shell-as-200 also swallowed real API failures (it's how the count_tokens 404 stayed invisible). Missing `/assets/*` → **404** instead of HTML-with-MIME-mismatch (blank page on stale bundle hash). Non-GET → **405** with `Allow`. SPA client-side routes still get the shell. (staging #12)
- **count_tokens model derived from the agent's model** (provider/Bedrock prefixes normalized) instead of a hardcoded id that 404s on every install and silently nulls `exactTotalTokens`. `COUNT_TOKENS_MODEL` stays as an explicit override; non-Anthropic models report `count_tokens_unsupported_model` instead of counting against a wrong tokenizer. (staging #11)

Tests: +25 (new `commands-qa-family`, `count-tokens-model`, four new web-ui cases); full suite green (761 pass). Web SPA typechecks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJqQexFkLtKBiTs2nVEeA8