### PR TITLE
feat: add fail-closed kv-unified recipe plumbing

### DIFF
--- a/changelog.d/kv-unified-config.added.md
+++ b/changelog.d/kv-unified-config.added.md
@@ -1,0 +1,1 @@
+- Add complete fail-closed recipe validation and strategy passthrough for `foldingStrategy: "kv-unified"`; partial policies, invalid occupancy bands, unsafe approximation grids, and implicit treeification are rejected at load time.

--- a/src/framework-strategy.ts
+++ b/src/framework-strategy.ts
@@ -35,6 +35,7 @@ const PASSTHROUGH_KEYS: ReadonlyArray<keyof RecipeStrategy> = [
   'compressionSlackRatio',
   'overBudgetGraceRatio',
   'foldingStrategy',
+  'kvUnified',
   'speculativeProduction',
   'l1HoldbackChunks',
   'summaryParticipant',

--- a/src/recipe.ts
+++ b/src/recipe.ts
@@ -93,7 +93,10 @@ export interface RecipeStrategy {
   /** Adaptive-resolution fold planner. The host defaults this to 'kv-stable'
    *  (cache-stable compile plans; see buildFrameworkStrategy) — set explicitly
    *  only to opt into the legacy planners. */
-  foldingStrategy?: 'flat-profile' | 'oldest-first' | 'kv-stable';
+  foldingStrategy?: 'flat-profile' | 'oldest-first' | 'kv-stable' | 'kv-unified';
+  /** Complete fail-closed policy for the kv-unified solver. No live defaults
+   * are supplied: selecting kv-unified without every field is invalid. */
+  kvUnified?: RecipeKvUnifiedConfig;
   speculativeProduction?: boolean;
   /** L1 production holdback: keep the newest N closed chunks out of the
    *  speculative compression queue (default 1); demand still overrides. */
@@ -119,6 +122,32 @@ export interface RecipeStrategy {
    *  names the agent and directs attribution so pure-witness chunks don't
    *  flip the summarizer into another speaker's identity. */
   identityReminder?: string;
+}
+
+export interface RecipeKvUnifiedConfig {
+  policy: {
+    alpha: number;
+    budgetLowRatio: number;
+    budgetHighRatio: number;
+    budgetUnderLambda: number;
+    budgetOverLambda: number;
+    cacheLambda: number;
+    cacheScale: number;
+    cacheReadPrice: number;
+    cacheWritePrice: number;
+    continuityLambda: number;
+    continuityScale: number;
+    continuityRecencyHalfLifeTokens: number;
+    continuityRecencyFloor: number;
+    continuityStableHalfLife: number;
+    continuityStableFloor: number;
+  };
+  tokenBucketSize: number;
+  continuityBucketSize: number;
+  fidelityBucketSize: number;
+  labelCeiling: number;
+  adoptEpsilon: number;
+  treeifyNonContiguousSummaries: boolean;
 }
 
 export interface RecipeAgent {
@@ -1136,6 +1165,87 @@ async function resolveSystemPrompt(recipe: Recipe): Promise<Recipe> {
   return recipe;
 }
 
+function validateKvUnifiedConfig(strategy: Record<string, unknown>): void {
+  const selected = strategy.foldingStrategy === 'kv-unified';
+  const raw = strategy.kvUnified;
+  if (!selected) {
+    if (raw !== undefined) {
+      throw new Error('Recipe agent.strategy.kvUnified requires foldingStrategy "kv-unified".');
+    }
+    return;
+  }
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new Error(
+      'Recipe foldingStrategy "kv-unified" requires a complete agent.strategy.kvUnified object; defaults are forbidden.',
+    );
+  }
+  const config = raw as Record<string, unknown>;
+  if (!config.policy || typeof config.policy !== 'object' || Array.isArray(config.policy)) {
+    throw new Error('Recipe agent.strategy.kvUnified.policy must be a complete object.');
+  }
+  const policy = config.policy as Record<string, unknown>;
+  const policyNumbers = [
+    'alpha', 'budgetLowRatio', 'budgetHighRatio', 'budgetUnderLambda',
+    'budgetOverLambda', 'cacheLambda', 'cacheScale', 'cacheReadPrice',
+    'cacheWritePrice', 'continuityLambda', 'continuityScale',
+    'continuityRecencyHalfLifeTokens', 'continuityRecencyFloor',
+    'continuityStableHalfLife', 'continuityStableFloor',
+  ] as const;
+  for (const key of policyNumbers) {
+    if (typeof policy[key] !== 'number' || !Number.isFinite(policy[key])) {
+      throw new Error(`Recipe agent.strategy.kvUnified.policy.${key} must be a finite number.`);
+    }
+  }
+  const nonNegative = [
+    'alpha', 'budgetUnderLambda', 'budgetOverLambda', 'cacheLambda',
+    'cacheReadPrice', 'cacheWritePrice', 'continuityLambda',
+  ] as const;
+  for (const key of nonNegative) {
+    if ((policy[key] as number) < 0) {
+      throw new Error(`Recipe agent.strategy.kvUnified.policy.${key} must be non-negative.`);
+    }
+  }
+  for (const key of [
+    'cacheScale', 'continuityScale', 'continuityRecencyHalfLifeTokens',
+    'continuityStableHalfLife',
+  ] as const) {
+    if ((policy[key] as number) <= 0) {
+      throw new Error(`Recipe agent.strategy.kvUnified.policy.${key} must be positive.`);
+    }
+  }
+  const low = policy.budgetLowRatio as number;
+  const high = policy.budgetHighRatio as number;
+  if (low < 0 || high > 1 || low > high) {
+    throw new Error('Recipe kvUnified budget ratios must satisfy 0 <= low <= high <= 1.');
+  }
+  for (const key of ['continuityRecencyFloor', 'continuityStableFloor'] as const) {
+    const value = policy[key] as number;
+    if (value < 0 || value > 1) {
+      throw new Error(`Recipe agent.strategy.kvUnified.policy.${key} must be in [0, 1].`);
+    }
+  }
+  for (const key of [
+    'tokenBucketSize', 'continuityBucketSize', 'fidelityBucketSize', 'labelCeiling',
+  ] as const) {
+    const value = config[key];
+    if (typeof value !== 'number' || !Number.isSafeInteger(value) || value <= 0) {
+      throw new Error(`Recipe agent.strategy.kvUnified.${key} must be a positive safe integer.`);
+    }
+  }
+  if (
+    typeof config.adoptEpsilon !== 'number' ||
+    !Number.isFinite(config.adoptEpsilon) ||
+    config.adoptEpsilon < 0
+  ) {
+    throw new Error('Recipe agent.strategy.kvUnified.adoptEpsilon must be a finite non-negative number.');
+  }
+  if (typeof config.treeifyNonContiguousSummaries !== 'boolean') {
+    throw new Error(
+      'Recipe agent.strategy.kvUnified.treeifyNonContiguousSummaries must be an explicit boolean.',
+    );
+  }
+}
+
 /**
  * Validate raw JSON and fill defaults.
  */
@@ -1405,6 +1515,21 @@ export function validateRecipe(raw: unknown): Recipe {
         `recipe's "extensions" block (none is declared).`,
       );
     }
+    if (
+      strategy.foldingStrategy !== undefined &&
+      strategy.foldingStrategy !== 'flat-profile' &&
+      strategy.foldingStrategy !== 'oldest-first' &&
+      strategy.foldingStrategy !== 'kv-stable' &&
+      strategy.foldingStrategy !== 'kv-unified'
+    ) {
+      throw new Error(
+        `Recipe agent.strategy.foldingStrategy is invalid: ${JSON.stringify(strategy.foldingStrategy)}.`,
+      );
+    }
+    if (strategy.foldingStrategy === 'kv-unified' && strategy.type === 'passthrough') {
+      throw new Error('Recipe foldingStrategy "kv-unified" requires an autobiographical or frontdesk strategy.');
+    }
+    validateKvUnifiedConfig(strategy);
     if (
       strategy.compressionRefusalCurveFallbacks !== undefined
       && (

--- a/test/recipe-kv-unified.test.ts
+++ b/test/recipe-kv-unified.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from 'bun:test';
+import { buildFrameworkStrategy } from '../src/framework-strategy.js';
+import { validateRecipe, type RecipeKvUnifiedConfig } from '../src/recipe.js';
+
+function config(): RecipeKvUnifiedConfig {
+  return {
+    policy: {
+      alpha: 0.7,
+      budgetLowRatio: 0.7,
+      budgetHighRatio: 0.935,
+      budgetUnderLambda: 1_000,
+      budgetOverLambda: 4_000,
+      cacheLambda: 1,
+      cacheScale: 100_000,
+      cacheReadPrice: 0.1,
+      cacheWritePrice: 1.25,
+      continuityLambda: 1,
+      continuityScale: 100_000,
+      continuityRecencyHalfLifeTokens: 100_000,
+      continuityRecencyFloor: 0.2,
+      continuityStableHalfLife: 16,
+      continuityStableFloor: 0.25,
+    },
+    tokenBucketSize: 10_000,
+    continuityBucketSize: 50_000,
+    fidelityBucketSize: 100_000,
+    labelCeiling: 100_000,
+    adoptEpsilon: 2_000,
+    treeifyNonContiguousSummaries: false,
+  };
+}
+
+function recipe(kvUnified: unknown = config()) {
+  return {
+    name: 'kv-unified-test',
+    agent: {
+      name: 'fable',
+      systemPrompt: 'system',
+      strategy: {
+        type: 'autobiographical',
+        foldingStrategy: 'kv-unified',
+        kvUnified,
+      },
+    },
+  };
+}
+
+describe('kv-unified recipe plumbing', () => {
+  test('forwards the complete fail-closed policy unchanged', () => {
+    const validated = validateRecipe(recipe());
+    const strategy = buildFrameworkStrategy(validated, 'model', 'UTC') as unknown as {
+      config: { foldingStrategy?: string; kvUnified?: RecipeKvUnifiedConfig };
+    };
+    expect(strategy.config.foldingStrategy).toBe('kv-unified');
+    expect(strategy.config.kvUnified).toEqual(config());
+  });
+
+  test('rejects selecting kv-unified without a complete policy', () => {
+    const missing = recipe() as ReturnType<typeof recipe>;
+    delete (missing.agent.strategy as { kvUnified?: unknown }).kvUnified;
+    expect(() => validateRecipe(missing)).toThrow(/complete.*kvUnified/i);
+    const incomplete = config() as unknown as Record<string, unknown>;
+    incomplete.policy = { ...(incomplete.policy as object) };
+    delete (incomplete.policy as Record<string, unknown>).cacheLambda;
+    expect(() => validateRecipe(recipe(incomplete))).toThrow(/cacheLambda/);
+  });
+
+  test('rejects invalid bands, grids, and implicit treeification', () => {
+    const badBand = config();
+    badBand.policy.budgetLowRatio = 0.95;
+    expect(() => validateRecipe(recipe(badBand))).toThrow(/budget ratios/);
+
+    const badGrid = config();
+    badGrid.tokenBucketSize = 0;
+    expect(() => validateRecipe(recipe(badGrid))).toThrow(/tokenBucketSize/);
+
+    const missingTreeification = config() as unknown as Record<string, unknown>;
+    delete missingTreeification.treeifyNonContiguousSummaries;
+    expect(() => validateRecipe(recipe(missingTreeification))).toThrow(/explicit boolean/);
+  });
+
+  test('rejects a kvUnified object when another solver is selected', () => {
+    const raw = recipe() as ReturnType<typeof recipe>;
+    raw.agent.strategy.foldingStrategy = 'kv-stable';
+    expect(() => validateRecipe(raw)).toThrow(/requires foldingStrategy/);
+  });
+});


### PR DESCRIPTION
## Summary

- admit foldingStrategy kv-unified in autobiographical and frontdesk recipes
- forward the complete nested policy through the existing strategy passthrough
- fail at recipe load when any policy field is missing or malformed
- validate occupancy-band ordering, nonnegative welfare prices, positive scales, approximation grids, adoption epsilon, and explicit treeification
- reject a kvUnified object when another folding solver is selected

Dependencies:

- https://github.com/anima-research/context-manager/pull/83
- https://github.com/anima-research/agent-framework/pull/139
- https://github.com/antra-tess/membrane/pull/66

## Validation

- bun test
- 84 files, 747 tests passed

## Rollout

This adds configuration plumbing only. No existing recipe is changed, and Fable remains on kv-stable until the policy and replay gates are approved.