### PR TITLE
Gate telemetry: stamp why the turn fired (x-gate-origin / channel / counterparty)

### DIFF
--- a/changelog.d/113-gate-origin-stamp.added.md
+++ b/changelog.d/113-gate-origin-stamp.added.md
@@ -1,0 +1,6 @@
+- Gate telemetry stamps why the turn fired: `x-gate-origin` (heartbeat |
+  event | mail | operator | raw reason), `x-gate-channel` and
+  `x-gate-counterparty` (adapter-namespaced ids, never content or display
+  names) ride the stream lane under the same `GATE_TELEMETRY=1` + base-URL
+  gate as the debt stamp; background calls on the complete lane carry debt
+  only (#113).

--- a/src/gate-telemetry.ts
+++ b/src/gate-telemetry.ts
@@ -61,7 +61,9 @@ export function originClass(trigger: TurnTrigger): string {
   if (r.includes('heartbeat') || s.includes('heartbeat')) return 'heartbeat';
   if (r.includes('mail') || s.includes('mail')) return 'mail';
   if (r === 'mcpl:channel-incoming' || r === 'mcpl:push-event' || r.startsWith('discord')) return 'event';
-  if (r.includes('admin') || r.includes('nudge') || r.includes('unstick') || r.includes('operator') || s === 'api' || s === 'tui') return 'operator';
+  // a person typing at the host itself: headless IPC, CLI, TUI, web UI, API
+  if (r === 'external-message' || ['headless', 'cli', 'tui', 'webui', 'api'].includes(s)) return 'operator';
+  if (r.includes('admin') || r.includes('nudge') || r.includes('unstick') || r.includes('operator')) return 'operator';
   return r.replace(/[^a-z0-9:_-]/g, '').slice(0, 40) || 'event';
 }
 

--- a/src/gate-telemetry.ts
+++ b/src/gate-telemetry.ts
@@ -14,6 +14,22 @@
  * Fail-closed on both (review finding on the first wiring: the stamp was
  * attached unconditionally, so with no base URL configured the value went
  * straight to the vendor).
+ *
+ * Two stamps ride the same hook:
+ *
+ *   x-gate-debt-chunks   compression debt at request build (every lane — the
+ *                        aux lane is where the debt series is most telling)
+ *   x-gate-origin        WHY the turn fired: heartbeat | event | mail |
+ *                        operator | <raw reason>  — stream lane ONLY
+ *   x-gate-channel       where (adapter-namespaced id)     — stream lane ONLY
+ *   x-gate-counterparty  who woke the agent (namespaced id) — stream lane ONLY
+ *
+ * The origin trio describes the agent's turn; a compression call running in
+ * the background is not the turn, so on the 'complete' lane those three are
+ * withheld (an older membrane that passes no lane gets them on every call —
+ * documented, and the ledger's `streamed` flag lets a reader tell the lanes
+ * apart regardless). Values are ids and short class words: never content,
+ * never display names.
  */
 
 /** Truthy env-flag parse: unset/''/'0'/'false' (any case) are off. */
@@ -21,11 +37,61 @@ function envFlag(value: string | undefined): boolean {
   return value !== undefined && value !== '' && value !== '0' && value.toLowerCase() !== 'false';
 }
 
+/** What the framework knows about the turn in progress (agent-framework InferenceRequest). */
+export interface TurnTrigger {
+  reason: string;
+  source: string;
+  channelId?: string;
+  counterparty?: string;
+}
+
+export interface DynamicHeadersContext {
+  lane?: 'stream' | 'complete';
+}
+
+/**
+ * Collapse the framework's free-form reason/source pair into the ledger's
+ * origin classes. The raw reason survives when no class fits, clipped and
+ * sanitized (ids and words only), so a new event kind shows up as itself
+ * instead of vanishing into 'event'.
+ */
+export function originClass(trigger: TurnTrigger): string {
+  const r = trigger.reason.toLowerCase();
+  const s = trigger.source.toLowerCase();
+  if (r.includes('heartbeat') || s.includes('heartbeat')) return 'heartbeat';
+  if (r.includes('mail') || s.includes('mail')) return 'mail';
+  if (r === 'mcpl:channel-incoming' || r === 'mcpl:push-event' || r.startsWith('discord')) return 'event';
+  if (r.includes('admin') || r.includes('nudge') || r.includes('unstick') || r.includes('operator') || s === 'api' || s === 'tui') return 'operator';
+  return r.replace(/[^a-z0-9:_-]/g, '').slice(0, 40) || 'event';
+}
+
+/** Header-safe attribute: printable characters only, clipped; empty → null (not sent). */
+function attr(v: string | undefined): string | null {
+  if (typeof v !== 'string') return null;
+  let clean = '';
+  for (const ch of v) {
+    const code = ch.charCodeAt(0);
+    if (code >= 0x20 && code !== 0x7f) clean += ch;
+  }
+  clean = clean.trim();
+  return clean ? clean.slice(0, 120) : null;
+}
+
 export function gateTelemetryHeaders(
   env: Record<string, string | undefined>,
   pendingDebtChunks: () => number | null,
-): (() => Record<string, number | null>) | undefined {
+  activeTrigger: () => TurnTrigger | null = () => null,
+): ((ctx?: DynamicHeadersContext) => Record<string, string | number | null>) | undefined {
   if (!envFlag(env.GATE_TELEMETRY)) return undefined;
   if (!env.ANTHROPIC_BASE_URL) return undefined;
-  return () => ({ 'x-gate-debt-chunks': pendingDebtChunks() });
+  return (ctx?: DynamicHeadersContext) => {
+    const out: Record<string, string | number | null> = { 'x-gate-debt-chunks': pendingDebtChunks() };
+    if (ctx?.lane === 'complete') return out;
+    const t = activeTrigger();
+    if (!t) return out;
+    out['x-gate-origin'] = originClass(t);
+    out['x-gate-channel'] = attr(t.channelId);
+    out['x-gate-counterparty'] = attr(t.counterparty);
+    return out;
+  };
 }

--- a/src/gate-telemetry.ts
+++ b/src/gate-telemetry.ts
@@ -67,16 +67,23 @@ export function originClass(trigger: TurnTrigger): string {
   return r.replace(/[^a-z0-9:_-]/g, '').slice(0, 40) || 'event';
 }
 
-/** Header-safe attribute: printable characters only, clipped; empty → null (not sent). */
+/**
+ * Header-safe attribute. HTTP header values are ByteStrings: a single
+ * non-ASCII code point (an emoji in a channel name, say) makes Fetch throw
+ * and would turn telemetry into a failed model request. So the rule is
+ * fail-closed on the WHOLE value — visible ASCII (0x20..0x7e) only, clipped
+ * to 120 — never character-stripping, which would mint a different id and
+ * collide provenance. An unsendable id is simply not sent (null → dropped).
+ */
 function attr(v: string | undefined): string | null {
   if (typeof v !== 'string') return null;
-  let clean = '';
-  for (const ch of v) {
-    const code = ch.charCodeAt(0);
-    if (code >= 0x20 && code !== 0x7f) clean += ch;
+  const t = v.trim();
+  if (!t) return null;
+  for (let i = 0; i < t.length; i++) {
+    const code = t.charCodeAt(i);
+    if (code < 0x20 || code > 0x7e) return null;
   }
-  clean = clean.trim();
-  return clean ? clean.slice(0, 120) : null;
+  return t.slice(0, 120);
 }
 
 export function gateTelemetryHeaders(

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ import {
 } from '@animalabs/membrane';
 import { LoggingAnthropicAdapter } from './logging-adapter.js';
 import { LoggingProviderAdapter } from './logging-provider-wrapper.js';
-import { gateTelemetryHeaders } from './gate-telemetry.js';
+import { gateTelemetryHeaders, type TurnTrigger } from './gate-telemetry.js';
 import { LoggingBedrockAdapter } from './logging-bedrock-adapter.js';
 import { CodexSubscriptionAdapter } from './codex-subscription-adapter.js';
 import { CallLedger } from './call-ledger.js';
@@ -946,7 +946,25 @@ async function main() {
     }
   };
 
-  const gateTelemetryDynamicHeaders = gateTelemetryHeaders(process.env, pendingDebtChunks);
+  // Why the turn in progress fired (heartbeat / a channel message by whom /
+  // operator), read from the framework's active-turn trigger. Same guards as
+  // the debt getter: no framework, several agents, or an older framework
+  // without the getter -> null -> the origin trio is simply not sent.
+  const activeTurnTrigger = (): TurnTrigger | null => {
+    try {
+      const agents = appRefForDebt?.framework.getAllAgents() ?? [];
+      if (agents.length !== 1) return null;
+      const fw = appRefForDebt?.framework as unknown as {
+        getActiveTurnTrigger?: (name: string) => TurnTrigger | undefined;
+      };
+      const t = fw?.getActiveTurnTrigger?.(agents[0]!.name);
+      return t && typeof t.reason === 'string' && typeof t.source === 'string' ? t : null;
+    } catch {
+      return null;
+    }
+  };
+
+  const gateTelemetryDynamicHeaders = gateTelemetryHeaders(process.env, pendingDebtChunks, activeTurnTrigger);
 
   const adapter = provider === 'openai-responses'
     ? new LoggingProviderAdapter(

--- a/test/gate-telemetry.test.ts
+++ b/test/gate-telemetry.test.ts
@@ -66,6 +66,8 @@ describe('gateTelemetryHeaders', () => {
     expect(originClass({ reason: 'mail:incoming', source: 'fenmail' })).toBe('mail');
     expect(originClass({ reason: 'mcpl:push-event', source: 'discord' })).toBe('event');
     expect(originClass({ reason: 'admin-nudge (someone)', source: 'framework' })).toBe('operator');
+    expect(originClass({ reason: 'external-message', source: 'headless' })).toBe('operator');
+    expect(originClass({ reason: 'external-message', source: 'tui' })).toBe('operator');
     expect(originClass({ reason: 'provider-acceleration-retry', source: 'framework' })).toBe('provider-acceleration-retry');
     expect(originClass({ reason: 'weird reason!!'.repeat(6), source: 'x' })).toHaveLength(40);
   });

--- a/test/gate-telemetry.test.ts
+++ b/test/gate-telemetry.test.ts
@@ -72,10 +72,20 @@ describe('gateTelemetryHeaders', () => {
     expect(originClass({ reason: 'weird reason!!'.repeat(6), source: 'x' })).toHaveLength(40);
   });
 
-  it('attributes are header-safe: control characters stripped, clipped to 120', () => {
-    const fn = gateTelemetryHeaders(env, debt, () => ({ reason: 'mcpl:channel-incoming', source: 'discord', channelId: 'a\r\nb', counterparty: 'x'.repeat(200) }));
+  it('attributes are header-safe: a value with any non-ASCII or control character is withheld whole, never rewritten', () => {
+    const fn = gateTelemetryHeaders(env, debt, () => ({ reason: 'mcpl:channel-incoming', source: 'discord', channelId: 'discord:\u{1F600}', counterparty: 'discord:user:4\r\n2' }));
     const h = fn!({ lane: 'stream' });
-    expect(h['x-gate-channel']).toBe('ab');
-    expect((h['x-gate-counterparty'] as string).length).toBe(120);
+    expect(h['x-gate-channel']).toBeNull();
+    expect(h['x-gate-counterparty']).toBeNull();
+    // and what IS sent can always be put in real Headers (Fetch ByteString rule)
+    const ok = gateTelemetryHeaders(env, debt, () => wake)!({ lane: 'stream' });
+    const sendable = Object.fromEntries(Object.entries(ok).filter(([, v]) => v !== null).map(([k, v]) => [k, String(v)]));
+    expect(() => new Headers(sendable)).not.toThrow();
+    expect(new Headers(sendable).get('x-gate-counterparty')).toBe('discord:user:42');
+  });
+
+  it('attributes are clipped to 120 visible-ASCII characters', () => {
+    const fn = gateTelemetryHeaders(env, debt, () => ({ reason: 'mcpl:channel-incoming', source: 'discord', counterparty: 'x'.repeat(200) }));
+    expect((fn!({ lane: 'stream' })['x-gate-counterparty'] as string).length).toBe(120);
   });
 });

--- a/test/gate-telemetry.test.ts
+++ b/test/gate-telemetry.test.ts
@@ -6,7 +6,7 @@
  * value went to the vendor's default endpoint.
  */
 import { describe, expect, it } from 'bun:test';
-import { gateTelemetryHeaders } from '../src/gate-telemetry.js';
+import { gateTelemetryHeaders, originClass } from '../src/gate-telemetry.js';
 
 const debt = () => 7;
 
@@ -30,5 +30,50 @@ describe('gateTelemetryHeaders', () => {
   it('unreadable debt stays null (membrane drops null values — unstamped, never guessed)', () => {
     const fn = gateTelemetryHeaders({ GATE_TELEMETRY: '1', ANTHROPIC_BASE_URL: 'https://gateway.example/anthropic' }, () => null);
     expect(fn!()).toEqual({ 'x-gate-debt-chunks': null });
+  });
+
+  const env = { GATE_TELEMETRY: '1', ANTHROPIC_BASE_URL: 'https://gateway.example/anthropic' };
+  const wake = { reason: 'mcpl:channel-incoming', source: 'discord', channelId: 'discord:1:2', counterparty: 'discord:user:42' };
+
+  it('origin trio rides the stream lane: why, where, by whom — ids only', () => {
+    const fn = gateTelemetryHeaders(env, debt, () => wake);
+    expect(fn!({ lane: 'stream' })).toEqual({
+      'x-gate-debt-chunks': 7,
+      'x-gate-origin': 'event',
+      'x-gate-channel': 'discord:1:2',
+      'x-gate-counterparty': 'discord:user:42',
+    });
+  });
+
+  it('complete lane (compression, side-calls, keepalive) carries debt only — a background call is not the turn', () => {
+    const fn = gateTelemetryHeaders(env, debt, () => wake);
+    expect(fn!({ lane: 'complete' })).toEqual({ 'x-gate-debt-chunks': 7 });
+  });
+
+  it('no lane told (older membrane) or no trigger known: honest — debt only, or trio without guessing', () => {
+    expect(gateTelemetryHeaders(env, debt, () => null)!({ lane: 'stream' })).toEqual({ 'x-gate-debt-chunks': 7 });
+    expect(gateTelemetryHeaders(env, debt, () => wake)!()).toMatchObject({ 'x-gate-origin': 'event' });
+    expect(gateTelemetryHeaders(env, debt)!({ lane: 'stream' })).toEqual({ 'x-gate-debt-chunks': 7 });
+  });
+
+  it('heartbeat wakes carry no channel or counterparty (null → dropped by membrane)', () => {
+    const fn = gateTelemetryHeaders(env, debt, () => ({ reason: 'heartbeat:tick', source: 'heartbeat' }));
+    expect(fn!({ lane: 'stream' })).toEqual({ 'x-gate-debt-chunks': 7, 'x-gate-origin': 'heartbeat', 'x-gate-channel': null, 'x-gate-counterparty': null });
+  });
+
+  it('originClass: heartbeat / mail / event / operator, raw reason otherwise (sanitized, clipped)', () => {
+    expect(originClass({ reason: 'heartbeat', source: 'heartbeat' })).toBe('heartbeat');
+    expect(originClass({ reason: 'mail:incoming', source: 'fenmail' })).toBe('mail');
+    expect(originClass({ reason: 'mcpl:push-event', source: 'discord' })).toBe('event');
+    expect(originClass({ reason: 'admin-nudge (someone)', source: 'framework' })).toBe('operator');
+    expect(originClass({ reason: 'provider-acceleration-retry', source: 'framework' })).toBe('provider-acceleration-retry');
+    expect(originClass({ reason: 'weird reason!!'.repeat(6), source: 'x' })).toHaveLength(40);
+  });
+
+  it('attributes are header-safe: control characters stripped, clipped to 120', () => {
+    const fn = gateTelemetryHeaders(env, debt, () => ({ reason: 'mcpl:channel-incoming', source: 'discord', channelId: 'a\r\nb', counterparty: 'x'.repeat(200) }));
+    const h = fn!({ lane: 'stream' });
+    expect(h['x-gate-channel']).toBe('ab');
+    expect((h['x-gate-counterparty'] as string).length).toBe(120);
   });
 });


### PR DESCRIPTION
Follow-up to #109 (x-gate-debt-chunks). The household gateway has had receivers for `x-gate-origin`, `x-gate-channel`, `x-gate-counterparty` since 2026-08-28 (ledger columns, stripped before the vendor); nothing sent them. This is the sender.

**What**
- `gate-telemetry.ts`: the hook now also emits the origin trio when the framework exposes the turn in progress: `x-gate-origin` = `heartbeat | event | mail | operator | <raw reason, sanitized ≤40>`, `x-gate-channel` = the trigger's adapter-namespaced channel id, `x-gate-counterparty` = namespaced author id of the triggering message. Ids and class words only — never content, never display names.
- Stream lane only. Compression, side-calls and keepalive touches run on the `complete` lane and are not the turn; stamping them with the turn's cause would mislead the ledger. Membrane passes the lane in antra-tess/membrane#67; an older membrane passes none and gets the trio on every call — the ledger's `streamed` flag still tells lanes apart.
- Same double gate as before (`GATE_TELEMETRY=1` AND `ANTHROPIC_BASE_URL`), same fail-honest rule: no framework / several agents / no trigger / older framework without the getter → the trio is simply not sent.
- `index.ts`: `activeTurnTrigger()` reads `framework.getActiveTurnTrigger(agent.name)` (anima-research/agent-framework PR alongside), guarded for its absence.

**Why**
The occupancy meters can already say whose words sit in each window (from the gateway's request capture). Who *woke* the agent cannot be read from a body — ambient digests enter context without requesting inference, so "newest message" was tried and dropped. Only the host knows the cause; this hands it to the ledger as three columns.

**Tests**: `test/gate-telemetry.test.ts` 10/10 (lane gating, null trigger, heartbeat → no channel/counterparty, originClass table, header-safe sanitizing). `tsc --noEmit`: one pre-existing error unrelated to this change (membrane type mismatch between a linked dist and the nested copy, present on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)