### PR TITLE
Telemetry deps: agent-framework ^0.12.0, membrane ^0.5.82; drop casts; adapter-level test

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,10 +5,10 @@
     "": {
       "name": "@animalabs/connectome-host",
       "dependencies": {
-        "@animalabs/agent-framework": "^0.11.0",
+        "@animalabs/agent-framework": "^0.12.0",
         "@animalabs/chronicle": "^0.3.0",
         "@animalabs/context-manager": "^0.6.3",
-        "@animalabs/membrane": "^0.5.80",
+        "@animalabs/membrane": "^0.5.82",
         "@opentui/core": "^0.1.82",
       },
       "devDependencies": {
@@ -19,13 +19,13 @@
     },
   },
   "packages": {
-    "@animalabs/agent-framework": ["@animalabs/agent-framework@0.11.0", "", { "dependencies": { "@animalabs/chronicle": "^0.3.0", "@animalabs/context-manager": "^0.6.0", "@animalabs/membrane": "^0.5.78", "chokidar": "^4.0.3", "discord.js": "^14.25.1", "ws": "^8.18.0" }, "bin": { "agent-framework-mcp": "dist/src/api/mcp-server.js", "agent-framework-recover": "dist/src/recovery/recover-cli.js" } }, "sha512-k3aZCTOYurNu4MyosU4nIiCJupXVnMHgHjWyfLeM84Z5hg9ICjuI5I5/1cuz8ZOvar1vyUnujBemAFbLzv2PjQ=="],
+    "@animalabs/agent-framework": ["@animalabs/agent-framework@0.12.0", "", { "dependencies": { "@animalabs/chronicle": "^0.3.0", "@animalabs/context-manager": "^0.6.0", "@animalabs/membrane": "^0.5.78", "chokidar": "^4.0.3", "discord.js": "^14.25.1", "ws": "^8.18.0" }, "bin": { "agent-framework-mcp": "dist/src/api/mcp-server.js", "agent-framework-recover": "dist/src/recovery/recover-cli.js" } }, "sha512-Yj0E4vA+kqMxp8LzVT1DBBppwBtPaaweOCloO47pAbJemLzLsJoCD1O9GOYjZ75LLfvGenzLgg1fWo0wXkMJ1w=="],
 
     "@animalabs/chronicle": ["@animalabs/chronicle@0.3.0", "", {}, "sha512-6BBJ9pWb8AnuHTNJTU07Y6Wut3IvdgWFxsy05IdlWcEnR5W23dlaBlaeJq7gDc7TwX05HfsDC+QZFEc69G+s4Q=="],
 
     "@animalabs/context-manager": ["@animalabs/context-manager@0.6.3", "", { "dependencies": { "@animalabs/chronicle": "^0.3.0", "@animalabs/membrane": "^0.5.69" } }, "sha512-zh60LgZxXzBbGrLpDHBAfGSPSL/H8mxz8nSWLOSh4pjiTOYbD0o0BjAM8CFz4LiaOIXnuSCbRoiv5UKsnrKwDw=="],
 
-    "@animalabs/membrane": ["@animalabs/membrane@0.5.80", "", { "dependencies": { "@anthropic-ai/sdk": "^0.52.0" } }, "sha512-D4xEij+J/3sJo2ZKFyjAeb0VuJl3QmygzEmi44J0nDNtmJSpUPYMJMaSid/ABj3dIs5EyXds/Ltr4qqyQ2DRTw=="],
+    "@animalabs/membrane": ["@animalabs/membrane@0.5.82", "", { "dependencies": { "@anthropic-ai/sdk": "^0.52.0" } }, "sha512-kCI3s/HXnXBPVcYCXIZfsdJBLRj77j5QyA9Hor1mC/nyD35D7e7N/VgR9awxqdGGWgIvgpjs6owXbGMk5t1pQA=="],
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.52.0", "", { "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-d4c+fg+xy9e46c8+YnrrgIQR45CZlAi7PwdzIfDXDM6ACxEZli1/fxhURsq30ZpMZy6LvSkr41jGq5aF5TD7rQ=="],
 
@@ -274,6 +274,8 @@
     "yoga-layout": ["yoga-layout@3.2.1", "", {}, "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="],
 
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@animalabs/context-manager/@animalabs/membrane": ["@animalabs/membrane@0.5.80", "", { "dependencies": { "@anthropic-ai/sdk": "^0.52.0" } }, "sha512-D4xEij+J/3sJo2ZKFyjAeb0VuJl3QmygzEmi44J0nDNtmJSpUPYMJMaSid/ABj3dIs5EyXds/Ltr4qqyQ2DRTw=="],
 
     "@discordjs/rest/@discordjs/collection": ["@discordjs/collection@2.1.1", "", {}, "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg=="],
 

--- a/changelog.d/telemetry-deps-0.12.changed.md
+++ b/changelog.d/telemetry-deps-0.12.changed.md
@@ -1,0 +1,6 @@
+- Depend on `@animalabs/agent-framework` ^0.12.0 and `@animalabs/membrane` ^0.5.82 —
+  the published versions that implement the active-turn trigger and the
+  lane-aware `dynamicHeaders` the wake-cause stamp (#113) relies on; the
+  compatibility cast and optional lookup are gone, and an adapter-level test
+  proves a stream call carries the origin trio while a complete call carries
+  debt only.

--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
     "postinstall": "test -d web && npm --prefix web install && npm --prefix web run build || true"
   },
   "dependencies": {
-    "@animalabs/agent-framework": "^0.11.0",
+    "@animalabs/agent-framework": "^0.12.0",
     "@animalabs/chronicle": "^0.3.0",
     "@animalabs/context-manager": "^0.6.3",
-    "@animalabs/membrane": "^0.5.80",
+    "@animalabs/membrane": "^0.5.82",
     "@opentui/core": "^0.1.82"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -963,17 +963,14 @@ async function main() {
 
   // Why the turn in progress fired (heartbeat / a channel message by whom /
   // operator), read from the framework's active-turn trigger. Same guards as
-  // the debt getter: no framework, several agents, or an older framework
-  // without the getter -> null -> the origin trio is simply not sent.
+  // the debt getter: no framework or several agents
+  // -> null -> the origin trio is simply not sent.
   const activeTurnTrigger = (): TurnTrigger | null => {
     try {
       const agents = appRefForDebt?.framework.getAllAgents() ?? [];
       if (agents.length !== 1) return null;
-      const fw = appRefForDebt?.framework as unknown as {
-        getActiveTurnTrigger?: (name: string) => TurnTrigger | undefined;
-      };
-      const t = fw?.getActiveTurnTrigger?.(agents[0]!.name);
-      return t && typeof t.reason === 'string' && typeof t.source === 'string' ? t : null;
+      const t = appRefForDebt?.framework.getActiveTurnTrigger(agents[0]!.name);
+      return t ? { reason: t.reason, source: t.source, channelId: t.channelId, counterparty: t.counterparty } : null;
     } catch {
       return null;
     }
@@ -1023,11 +1020,7 @@ async function main() {
           // configured base URL, so the stamp can only ever go to a
           // gateway the operator has declared — never to the vendor's
           // default endpoint (review finding on the first wiring).
-          // Cast note: @animalabs/membrane on npm (0.5.80) predates the
-          // dynamicHeaders field (antra-tess/membrane#65); drop the cast when
-          // the release lands. Harmless either way — an older membrane
-          // ignores unknown config keys.
-          ...(gateTelemetryDynamicHeaders ? ({ dynamicHeaders: gateTelemetryDynamicHeaders } as object) : {}),
+          ...(gateTelemetryDynamicHeaders ? { dynamicHeaders: gateTelemetryDynamicHeaders } : {}),
           // Hold this agent's cached prefix warm across idle gaps. Only fires
           // when the entry is actually near expiry, so a busy agent costs
           // nothing; only the 1h-TTL primary lane is eligible (the module

--- a/test/gate-telemetry-adapter.test.ts
+++ b/test/gate-telemetry-adapter.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Adapter-level proof (review finding on #113): with the PUBLISHED membrane,
+ * a stream call consults the active-turn trigger and carries the origin trio,
+ * while a complete call (compression / side-calls / keepalive) carries the
+ * debt stamp only. Runs the real AnthropicAdapter with a mocked SDK client.
+ */
+import { describe, expect, it } from 'bun:test';
+import { AnthropicAdapter } from '@animalabs/membrane';
+import { gateTelemetryHeaders } from '../src/gate-telemetry.js';
+
+const env = { GATE_TELEMETRY: '1', ANTHROPIC_BASE_URL: 'https://gateway.example/anthropic' };
+const wake = { reason: 'mcpl:channel-incoming', source: 'discord', channelId: 'discord:1:2', counterparty: 'discord:user:42' };
+
+const REQUEST = {
+  model: 'claude-test',
+  messages: [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }],
+} as any;
+
+const RESPONSE = {
+  id: 'msg_test', model: 'claude-test', role: 'assistant',
+  content: [{ type: 'text', text: 'ok' }], stop_reason: 'end_turn',
+  usage: { input_tokens: 1, output_tokens: 1 },
+};
+
+/** Minimal SDK stream: an async iterable of the events the adapter reads. */
+function mockStream() {
+  const events = [
+    { type: 'message_start', message: { id: 'msg_s', model: 'claude-test', role: 'assistant', content: [], usage: { input_tokens: 1, output_tokens: 0 } } },
+    { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } },
+    { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'ok' } },
+    { type: 'content_block_stop', index: 0 },
+    { type: 'message_delta', delta: { stop_reason: 'end_turn', stop_sequence: null }, usage: { output_tokens: 1 } },
+    { type: 'message_stop' },
+  ];
+  return {
+    async *[Symbol.asyncIterator]() { for (const e of events) yield e; },
+  };
+}
+
+function adapterWithTrigger(trigger: () => typeof wake | null) {
+  let asked = 0;
+  const dyn = gateTelemetryHeaders(env, () => 3, () => { asked++; return trigger(); })!;
+  const adapter = new AnthropicAdapter({ apiKey: 'sk-test', cacheKeepalive: { enabled: false }, dynamicHeaders: dyn } as any);
+  const calls: Array<{ kind: string; headers: Record<string, string> | undefined }> = [];
+  (adapter as any).client = {
+    messages: {
+      create: async (_req: unknown, opts: { headers?: Record<string, string> }) => { calls.push({ kind: 'complete', headers: opts?.headers }); return RESPONSE; },
+      stream: async (_req: unknown, opts: { headers?: Record<string, string> }) => { calls.push({ kind: 'stream', headers: opts?.headers }); return mockStream(); },
+    },
+  };
+  return { adapter, calls, asked: () => asked };
+}
+
+describe('gate telemetry through the published AnthropicAdapter', () => {
+  it('complete lane: debt only — the active trigger is not consulted', async () => {
+    const { adapter, calls, asked } = adapterWithTrigger(() => wake);
+    await adapter.complete(REQUEST);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.kind).toBe('complete');
+    expect(calls[0]!.headers).toEqual({ 'x-gate-debt-chunks': '3' });
+    expect(asked()).toBe(0);
+  });
+
+  it('stream lane: the trigger is consulted and the origin trio rides the request', async () => {
+    const { adapter, calls, asked } = adapterWithTrigger(() => wake);
+    const chunks: string[] = [];
+    await adapter.stream(REQUEST, { onChunk: (c: string) => { chunks.push(c); } } as any);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.kind).toBe('stream');
+    expect(calls[0]!.headers).toEqual({
+      'x-gate-debt-chunks': '3',
+      'x-gate-origin': 'event',
+      'x-gate-channel': 'discord:1:2',
+      'x-gate-counterparty': 'discord:user:42',
+    });
+    expect(asked()).toBe(1);
+  });
+
+  it('stream lane with no turn in progress: debt only, nothing guessed', async () => {
+    const { adapter, calls } = adapterWithTrigger(() => null);
+    await adapter.stream(REQUEST, { onChunk: () => {} } as any);
+    expect(calls[0]!.headers).toEqual({ 'x-gate-debt-chunks': '3' });
+  });
+});


### PR DESCRIPTION
Follow-up to #113, closing the second review finding there (dependency ranges did not implement the stamp's contracts).

- `@animalabs/agent-framework` ^0.11.0 → **^0.12.0** (published today: `getActiveTurnTrigger`, `InferenceRequest.counterparty`)
- `@animalabs/membrane` ^0.5.80 → **^0.5.82** (published today: `dynamicHeaders(ctx?: { lane })`, `DynamicHeadersContext`)
- `bun.lock` refreshed against the registry tarballs
- `index.ts`: the optional `getActiveTurnTrigger?.()` lookup and the `as object` cast are gone — the contracts are typed now
- `test/gate-telemetry-adapter.test.ts`: the real `AnthropicAdapter` from the published membrane with a mocked SDK client — stream call consults the trigger and carries `x-gate-origin/channel/counterparty`; complete call carries `x-gate-debt-chunks` only; stream with no turn in progress carries debt only (3 tests)
- `tsc --noEmit` clean against the published packages (the earlier pre-existing type error came from a linked-dist mismatch and is gone with the real install); telemetry tests 11/11 + 3/3

No behavior change beyond what #113 already described; this makes the changelog claim true for the install. Host release (`npm version`) intended after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)