### PR TITLE
feat: wire tool wrapper prose guard recipe setting

### DIFF
--- a/changelog.d/tool-wrapper-prose-guard.added.md
+++ b/changelog.d/tool-wrapper-prose-guard.added.md
@@ -1,0 +1,1 @@
+- Add validated recipe plumbing for Agent Framework's default-off `agent.toolWrapperProseGuard` containment boundary.

--- a/src/framework-agent-config.ts
+++ b/src/framework-agent-config.ts
@@ -113,5 +113,8 @@ export function buildFrameworkAgentConfig(
     ...(recipe.agent.proseRouting !== undefined
       ? { proseRouting: recipe.agent.proseRouting }
       : {}),
+    ...(recipe.agent.toolWrapperProseGuard !== undefined
+      ? { toolWrapperProseGuard: recipe.agent.toolWrapperProseGuard }
+      : {}),
   };
 }

--- a/src/recipe.ts
+++ b/src/recipe.ts
@@ -239,6 +239,8 @@ export interface RecipeAgent {
    * Default 'locus'.
    */
   proseRouting?: 'locus' | 'explicit' | 'hybrid' | 'disabled';
+  /** Default-off containment of whole-response prose wrappers for known tools. */
+  toolWrapperProseGuard?: boolean;
   /**
    * Extra Anthropic beta flags sent as the `anthropic-beta` header on every
    * request (e.g. `["context-1m-2025-08-07"]` for the 1M context window on
@@ -1292,6 +1294,10 @@ export function validateRecipe(raw: unknown): Recipe {
     agent.proseRouting !== 'disabled'
   ) {
     throw new Error(`Recipe agent.proseRouting must be 'locus', 'explicit', 'hybrid', or 'disabled', got ${JSON.stringify(agent.proseRouting)}.`);
+  }
+
+  if (agent.toolWrapperProseGuard !== undefined && typeof agent.toolWrapperProseGuard !== 'boolean') {
+    throw new Error(`Recipe agent.toolWrapperProseGuard must be a boolean, got ${JSON.stringify(agent.toolWrapperProseGuard)}.`);
   }
 
   if (agent.timezone !== undefined) {

--- a/test/tool-wrapper-prose-guard-recipe.test.ts
+++ b/test/tool-wrapper-prose-guard-recipe.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from 'bun:test';
+import { buildFrameworkAgentConfig } from '../src/framework-agent-config.js';
+import { validateRecipe } from '../src/recipe.js';
+
+const base = (value?: unknown) => ({
+  name: 'tool-wrapper-prose-guard',
+  agent: {
+    systemPrompt: 'sys',
+    ...(value === undefined ? {} : { toolWrapperProseGuard: value }),
+  },
+});
+
+describe('toolWrapperProseGuard recipe wiring', () => {
+  test('is default-off by omission and composes true into AgentConfig', () => {
+    const absent = validateRecipe(base());
+    expect(absent.agent.toolWrapperProseGuard).toBeUndefined();
+    expect(buildFrameworkAgentConfig(absent, 'a', 'm', { kind: 's' } as never).toolWrapperProseGuard).toBeUndefined();
+
+    const enabled = validateRecipe(base(true));
+    expect(enabled.agent.toolWrapperProseGuard).toBe(true);
+    expect(buildFrameworkAgentConfig(enabled, 'a', 'm', { kind: 's' } as never).toolWrapperProseGuard).toBe(true);
+
+    const disabled = validateRecipe(base(false));
+    expect(disabled.agent.toolWrapperProseGuard).toBe(false);
+    expect(buildFrameworkAgentConfig(disabled, 'b', 'm', { kind: 's' } as never).toolWrapperProseGuard).toBe(false);
+
+    const reloaded = validateRecipe(JSON.parse(JSON.stringify(enabled)));
+    expect(buildFrameworkAgentConfig(reloaded, 'c', 'm', { kind: 's' } as never).toolWrapperProseGuard).toBe(true);
+    expect(buildFrameworkAgentConfig(absent, 'd', 'm', { kind: 's' } as never).toolWrapperProseGuard).toBeUndefined();
+  });
+
+  test('rejects non-boolean values instead of silently disabling the guard', () => {
+    for (const value of ['true', 1, null, {}]) {
+      expect(() => validateRecipe(base(value))).toThrow(/toolWrapperProseGuard/);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds validated recipe plumbing for Agent Framework's default-off `agent.toolWrapperProseGuard` setting.

- optional boolean in recipe schema
- explicit `false` preserved through validation/serialization
- forwarded directly into AgentConfig
- cross-agent non-bleed covered
- changelog entry included

Exact head: `73c30d5b0eae8c032b1549d45af8058328b340c2`

Focused recipe tests pass. Full-suite failures/errors match exact current-main baseline while the candidate adds two passing tests.

Depends on anima-research/agent-framework#142. No deployment, resident enablement, surgery, or restart authority is implied.
