### PR TITLE
fix(recipe): plumb mergeMaxSourceSpanMessages through to the strategy

### DIFF
--- a/changelog.d/116-plumb-merge-span-and-split-keys.fixed.md
+++ b/changelog.d/116-plumb-merge-span-and-split-keys.fixed.md
@@ -1,0 +1,6 @@
+- Recipes' `agent.strategy.mergeMaxSourceSpanMessages` now reaches the Context
+  Manager (it was accepted but never passed through, so the CM default applied
+  regardless of the recipe). Also plumbs and validates the Context Manager's
+  `compressionSplitFallback`, `compressionSplitPlaceholder`,
+  `compressionSplitMaxCallsPerChunk` and `compressionSplitMaxCallsPer10Min`
+  keys (all default off / CM defaults).

--- a/src/framework-strategy.ts
+++ b/src/framework-strategy.ts
@@ -17,6 +17,8 @@ const PASSTHROUGH_KEYS: ReadonlyArray<keyof RecipeStrategy> = [
   'compressionSourceOnlyFallback',
   'compressionMergeSourceOnly',
   'compressionMergeSourceOnlyFallback',
+  'compressionSplitFallback',
+  'compressionSplitPlaceholder',
   'compressionRecallBudgetTokens',
   'positionedRecallPairs',
   'recallHeaderTemplate',

--- a/src/framework-strategy.ts
+++ b/src/framework-strategy.ts
@@ -19,6 +19,8 @@ const PASSTHROUGH_KEYS: ReadonlyArray<keyof RecipeStrategy> = [
   'compressionMergeSourceOnlyFallback',
   'compressionSplitFallback',
   'compressionSplitPlaceholder',
+  'compressionSplitMaxCallsPerChunk',
+  'compressionSplitMaxCallsPer10Min',
   'compressionRecallBudgetTokens',
   'positionedRecallPairs',
   'recallHeaderTemplate',

--- a/src/framework-strategy.ts
+++ b/src/framework-strategy.ts
@@ -22,6 +22,7 @@ const PASSTHROUGH_KEYS: ReadonlyArray<keyof RecipeStrategy> = [
   'recallHeaderTemplate',
   'targetChunkTokens',
   'mergeThreshold',
+  'mergeMaxSourceSpanMessages',
   'summaryTargetTokens',
   'productionBudgetTokens',
   'l1BudgetTokens',

--- a/src/recipe.ts
+++ b/src/recipe.ts
@@ -66,6 +66,10 @@ export interface RecipeStrategy {
   compressionSplitFallback?: boolean;
   /** Allow a single-message placeholder inside a split-stitched L1 (default off). */
   compressionSplitPlaceholder?: boolean;
+  /** Split-stitch: max sub-calls per chunk (default 40). */
+  compressionSplitMaxCallsPerChunk?: number;
+  /** Split-stitch: max sub-calls per strategy instance per 10-minute in-memory window (default 80). */
+  compressionSplitMaxCallsPer10Min?: number;
   /** Token budget for prior recall-pair context in compression/merge
    * requests (Context Manager `compressionRecallBudgetTokens`). */
   compressionRecallBudgetTokens?: number;
@@ -1565,6 +1569,12 @@ export function validateRecipe(raw: unknown): Recipe {
     ] as const) {
       if (strategy[key] !== undefined && typeof strategy[key] !== 'boolean') {
         throw new Error(`Recipe agent.strategy.${key} must be a boolean.`);
+      }
+    }
+    for (const key of ['compressionSplitMaxCallsPerChunk', 'compressionSplitMaxCallsPer10Min'] as const) {
+      const value = strategy[key];
+      if (value !== undefined && (typeof value !== 'number' || !Number.isSafeInteger(value) || value <= 0)) {
+        throw new Error(`Recipe agent.strategy.${key} must be a positive safe integer.`);
       }
     }
     if (

--- a/src/recipe.ts
+++ b/src/recipe.ts
@@ -62,6 +62,10 @@ export interface RecipeStrategy {
   compressionMergeSourceOnly?: boolean;
   /** Preserve ordinary merge retries, then use target-only on the final attempt. */
   compressionMergeSourceOnlyFallback?: boolean;
+  /** Context Manager split-stitch L1 fallback rung (default off). */
+  compressionSplitFallback?: boolean;
+  /** Allow a single-message placeholder inside a split-stitched L1 (default off). */
+  compressionSplitPlaceholder?: boolean;
   /** Token budget for prior recall-pair context in compression/merge
    * requests (Context Manager `compressionRecallBudgetTokens`). */
   compressionRecallBudgetTokens?: number;
@@ -1556,6 +1560,8 @@ export function validateRecipe(raw: unknown): Recipe {
       'compressionSourceOnlyFallback',
       'compressionMergeSourceOnly',
       'compressionMergeSourceOnlyFallback',
+      'compressionSplitFallback',
+      'compressionSplitPlaceholder',
     ] as const) {
       if (strategy[key] !== undefined && typeof strategy[key] !== 'boolean') {
         throw new Error(`Recipe agent.strategy.${key} must be a boolean.`);

--- a/src/recipe.ts
+++ b/src/recipe.ts
@@ -69,6 +69,7 @@ export interface RecipeStrategy {
   recallHeaderTemplate?: string;
   targetChunkTokens?: number;
   mergeThreshold?: number;
+  mergeMaxSourceSpanMessages?: number;
   summaryTargetTokens?: number;
   /** Standing production target: keep the summary forest deep enough to fit
    *  this budget, enabling a later live-budget descent with no fold-storm and

--- a/test/framework-strategy-defaults.test.ts
+++ b/test/framework-strategy-defaults.test.ts
@@ -61,6 +61,21 @@ describe('standard-recipe memory defaults', () => {
     expect(config.foldingStrategy).toBeUndefined();
   });
 
+  test('mergeMaxSourceSpanMessages is passed through exactly and omission stays omitted (princess 2026-09-05: silently dropped, span guard stuck at the CM default)', () => {
+    const configured = buildFrameworkStrategy(
+      recipe({
+        name: 'Mira',
+        strategy: { type: 'autobiographical', mergeMaxSourceSpanMessages: 3000, mergeThreshold: 3 },
+      }),
+      'some-model',
+      'America/Los_Angeles',
+    );
+    expect(configView(configured).mergeMaxSourceSpanMessages).toBe(3000);
+    expect(configView(configured).mergeThreshold).toBe(3);
+    const omitted = buildFrameworkStrategy(recipe({ name: 'Mira' }), 'some-model', 'America/Los_Angeles');
+    expect(configView(omitted).mergeMaxSourceSpanMessages).toBeUndefined();
+  });
+
   test('productionBudgetTokens is passed through exactly and omission stays omitted', () => {
     const configured = buildFrameworkStrategy(
       recipe({

--- a/test/framework-strategy-defaults.test.ts
+++ b/test/framework-strategy-defaults.test.ts
@@ -75,6 +75,18 @@ describe('standard-recipe memory defaults', () => {
     expect(() => recipe({ name: 'Mira', strategy: { type: 'autobiographical', compressionSplitFallback: 'yes' } })).toThrow();
   });
 
+  test('split-stitch cap knobs pass through and are validated as positive integers', () => {
+    const on = buildFrameworkStrategy(
+      recipe({ name: 'Mira', strategy: { type: 'autobiographical', compressionSplitFallback: true, compressionSplitMaxCallsPerChunk: 12, compressionSplitMaxCallsPer10Min: 30 } }),
+      'some-model',
+      'America/Los_Angeles',
+    );
+    expect(configView(on).compressionSplitMaxCallsPerChunk).toBe(12);
+    expect(configView(on).compressionSplitMaxCallsPer10Min).toBe(30);
+    expect(() => recipe({ name: 'Mira', strategy: { type: 'autobiographical', compressionSplitMaxCallsPerChunk: 0 } })).toThrow();
+    expect(() => recipe({ name: 'Mira', strategy: { type: 'autobiographical', compressionSplitMaxCallsPer10Min: 1.5 } })).toThrow();
+  });
+
   test('mergeMaxSourceSpanMessages is passed through exactly and omission stays omitted (princess 2026-09-05: silently dropped, span guard stuck at the CM default)', () => {
     const configured = buildFrameworkStrategy(
       recipe({

--- a/test/framework-strategy-defaults.test.ts
+++ b/test/framework-strategy-defaults.test.ts
@@ -61,6 +61,20 @@ describe('standard-recipe memory defaults', () => {
     expect(config.foldingStrategy).toBeUndefined();
   });
 
+  test('compressionSplitFallback / compressionSplitPlaceholder pass through and stay omitted when omitted', () => {
+    const on = buildFrameworkStrategy(
+      recipe({ name: 'Mira', strategy: { type: 'autobiographical', compressionSplitFallback: true, compressionSplitPlaceholder: true } }),
+      'some-model',
+      'America/Los_Angeles',
+    );
+    expect(configView(on).compressionSplitFallback).toBe(true);
+    expect(configView(on).compressionSplitPlaceholder).toBe(true);
+    const omitted = buildFrameworkStrategy(recipe({ name: 'Mira' }), 'some-model', 'America/Los_Angeles');
+    expect(configView(omitted).compressionSplitFallback).toBeUndefined();
+    expect(configView(omitted).compressionSplitPlaceholder).toBeUndefined();
+    expect(() => recipe({ name: 'Mira', strategy: { type: 'autobiographical', compressionSplitFallback: 'yes' } })).toThrow();
+  });
+
   test('mergeMaxSourceSpanMessages is passed through exactly and omission stays omitted (princess 2026-09-05: silently dropped, span guard stuck at the CM default)', () => {
     const configured = buildFrameworkStrategy(
       recipe({


### PR DESCRIPTION
## Summary
- `agent.strategy.mergeMaxSourceSpanMessages` was accepted by the recipe loader but never reached the Context Manager: it is missing from `PASSTHROUGH_KEYS` in `src/framework-strategy.ts`, so the CM ran its default (1500) regardless of the recipe.
- Adds the key to `PASSTHROUGH_KEYS` and to `RecipeStrategy`, plus a test that the value passes through exactly and omission stays omitted.

## Evidence
Princess, 2026-09-05: recipe declared `mergeMaxSourceSpanMessages: 3000` since 09-02; boot log printed `merge-candidate excluded: L3 L3-345 — span 2181 msgs > limit 1500 (base 1500 × 3^0)` for six L3s and two L4s. The 09-02 offline drains worked only because their harness built the strategy directly. Declared-vs-effective class, same family as the Evander runtime-override finding of 09-04.

## Test plan
- [x] `bun test test/framework-strategy-defaults.test.ts test/recipe-source-only.test.ts test/recipe-kv-unified.test.ts`
- [x] Verified on princess's runtime copy: `buildFrameworkStrategy(recipe)` now yields `mergeMaxSourceSpanMessages: 3000` (restart pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VZZGeU7SiMU782wxRoXTUq